### PR TITLE
feat(F153): Phase I implementation — Step Summary (counter + agent_loop marker + Hub panel)

### DIFF
--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -49,7 +49,11 @@ import {
 } from '../../../../../infrastructure/telemetry/instruments.js';
 import { normalizeModel } from '../../../../../infrastructure/telemetry/model-normalizer.js';
 import { emitOtelLog } from '../../../../../infrastructure/telemetry/otel-logger.js';
-import { recordLlmCallSpan, recordToolUseSpan } from '../../../../../infrastructure/telemetry/span-helpers.js';
+import {
+  recordAgentLoop,
+  recordLlmCallSpan,
+  recordToolUseSpan,
+} from '../../../../../infrastructure/telemetry/span-helpers.js';
 import { resolveActiveProjectRoot } from '../../../../../utils/active-project-root.js';
 import { resolveCliCommand } from '../../../../../utils/cli-resolve.js';
 import { DEFAULT_CLI_TIMEOUT_MS, resolveCliTimeoutMs } from '../../../../../utils/cli-timeout.js';
@@ -1630,6 +1634,12 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
 
         outputs.push({ ...msg, isFinal: isLastCat });
       } else {
+        // F153 Phase I: agent_loop is telemetry-only — record marker, never push to outputs
+        // (no user-visible signal, no transcript write, no downstream forwarding).
+        if (msg.type === 'agent_loop') {
+          if (invocationSpan) recordAgentLoop(invocationSpan);
+          continue;
+        }
         outputs.push(attachInvocationIdToTaskProgress(msg));
 
         // F153 Phase E: Record tool_use as child span (zero-duration; shows in trace tree with tool name + category)

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -1636,9 +1636,11 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       } else {
         // F153 Phase I: agent_loop is telemetry-only — record marker, never push to outputs
         // (no user-visible signal, no transcript write, no downstream forwarding).
+        // processMessage is an arrow function (not a loop), so `return outputs` (empty here)
+        // is the correct way to skip the remaining branches and transcript writer below.
         if (msg.type === 'agent_loop') {
           if (invocationSpan) recordAgentLoop(invocationSpan);
-          continue;
+          return outputs;
         }
         outputs.push(attachInvocationIdToTaskProgress(msg));
 

--- a/packages/api/src/domains/cats/services/agents/providers/claude-ndjson-parser.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/claude-ndjson-parser.ts
@@ -83,7 +83,9 @@ export function transformClaudeEvent(
 
     if (s.type === 'message_stop') {
       streamState.currentMessageId = undefined;
-      return null;
+      // F153 Phase I: emit telemetry-only agent_loop marker (provider-agnostic anchor at LLM call boundary,
+      // per KD-31/KD-33). invoke-single-cat consumes this to increment recordAgentLoop; never reaches outputs.
+      return { type: 'agent_loop' as const, catId, timestamp: Date.now() };
     }
 
     // F045: Reset thinking buffer when a thinking block starts

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -25,6 +25,7 @@ import {
   ROUTE_TOTAL_TOKENS,
 } from '../../../../../infrastructure/telemetry/genai-semconv.js';
 import {
+  a2aDispatchCount,
   inlineActionChecked,
   inlineActionDetected,
   inlineActionFeedbackWriteFailed,
@@ -1518,6 +1519,8 @@ export async function* routeSerial(
                   },
                   parentCtx,
                 );
+                // F153 Phase I: counter for Step Summary aggregate; only AGENT_ID attribute (mentioner cat).
+                a2aDispatchCount.add(1, { [AGENT_ID]: catId as string });
               }
             }
 

--- a/packages/api/src/domains/cats/services/types.ts
+++ b/packages/api/src/domains/cats/services/types.ts
@@ -106,7 +106,8 @@ export type AgentMessageType =
   | 'a2a_handoff'
   | 'system_info' // budget warnings, cancel feedback, extraction progress, thinking
   | 'provider_signal' // F149: upstream capacity/retry signals — skipped by invocation timeout & content flags
-  | 'liveness_signal'; // F149: stream idle watchdog — skipped by invocation timeout & content flags
+  | 'liveness_signal' // F149: stream idle watchdog — skipped by invocation timeout & content flags
+  | 'agent_loop'; // F153 Phase I: telemetry-only marker at LLM call boundary (provider stream parser emits; never user-visible)
 
 /**
  * A message yielded from an agent during invocation

--- a/packages/api/src/infrastructure/telemetry/dispatch-span.ts
+++ b/packages/api/src/infrastructure/telemetry/dispatch-span.ts
@@ -7,10 +7,16 @@
 
 import { context as ctxApi, trace } from '@opentelemetry/api';
 import type { CallerTraceContext } from './genai-semconv.js';
+import { AGENT_ID } from './genai-semconv.js';
+import { a2aDispatchCount } from './instruments.js';
 
 const tracer = trace.getTracer('cat-cafe-a2a');
 
-export function wrapWithDispatchSpan(callerCtx: CallerTraceContext, targetCount: number): CallerTraceContext {
+export function wrapWithDispatchSpan(
+  callerCtx: CallerTraceContext,
+  targetCount: number,
+  sourceCatId?: string,
+): CallerTraceContext {
   const remoteParent = trace.setSpanContext(ctxApi.active(), {
     traceId: callerCtx.traceId,
     spanId: callerCtx.spanId,
@@ -23,6 +29,9 @@ export function wrapWithDispatchSpan(callerCtx: CallerTraceContext, targetCount:
     { attributes: { 'dispatch.target_count': targetCount, 'dispatch.source': 'callback' } },
     remoteParent,
   );
+
+  // F153 Phase I: counter for Step Summary aggregate; only AGENT_ID attribute when known.
+  a2aDispatchCount.add(1, sourceCatId ? { [AGENT_ID]: sourceCatId } : {});
 
   const sc = dispatchSpan.spanContext();
   dispatchSpan.end();

--- a/packages/api/src/infrastructure/telemetry/instruments.ts
+++ b/packages/api/src/infrastructure/telemetry/instruments.ts
@@ -163,6 +163,21 @@ export const catResponseDuration = lazy(() =>
   }),
 );
 
+// --- F153 Phase I: Step Summary counters ---
+
+/**
+ * Counter: A2A mention_dispatch span occurrences.
+ * Increments at every `cat_cafe.mention_dispatch` span creation (in-process or callback path).
+ * Attributes (allowlist-filtered): only `agent.id` (mentioner cat) — never invocationId/threadId
+ * (metric-allowlist forbids high-cardinality). Omit `agent.id` when source cat is unknown
+ * (e.g. callback path without sourceCatId).
+ */
+export const a2aDispatchCount = lazy(() =>
+  meter().createCounter('cat_cafe.a2a.dispatch.count', {
+    description: 'A2A mention_dispatch span occurrences (F153 Phase I)',
+  }),
+);
+
 // --- F174 Phase D1: callback auth observability ---
 
 /**

--- a/packages/api/src/infrastructure/telemetry/span-helpers.ts
+++ b/packages/api/src/infrastructure/telemetry/span-helpers.ts
@@ -119,6 +119,33 @@ const toolCallCounts = new WeakMap<Span, number>();
 /** @deprecated Use recordToolUseSpan instead. Kept for backward compat during migration. */
 export const recordToolUseEvent = recordToolUseSpan;
 
+// --- F153 Phase I: cat_cafe.agent_loop marker ---
+
+const agentLoopCounts = new WeakMap<Span, number>();
+
+/**
+ * Record one completed agent loop (think → act → observe) on the invocation span.
+ *
+ * Provider stream parsers should call this at every LLM call boundary they can
+ * identify from their stream protocol. The cumulative count is stored as the
+ * `agent_loop.count` attribute on invocationSpan (same WeakMap + setAttribute
+ * pattern as `tool.basic_call_count`), so Step Summary can derive
+ * `agent_loop_count` per-route = sum across child invocation spans.
+ *
+ * Provider-agnostic: does NOT depend on `msg.metadata.usage.durationApiMs` or
+ * the `done` event (both are per-invocation, not per-loop — see F153 KD-33).
+ *
+ * Providers that cannot identify LLM call boundaries from their stream simply
+ * never call this helper; the invocation span has no `agent_loop.count`
+ * attribute, and Step Summary displays `—` (per AC-I2, AC-I7 — non-degradation
+ * to invocation count).
+ */
+export function recordAgentLoop(invocationSpan: Span): void {
+  const prev = (agentLoopCounts.get(invocationSpan) ?? 0) + 1;
+  agentLoopCounts.set(invocationSpan, prev);
+  invocationSpan.setAttribute('agent_loop.count', prev);
+}
+
 /**
  * Stamp routing decision attributes onto the invocation span.
  * Not a separate span — routing is instantaneous and should live

--- a/packages/api/src/infrastructure/telemetry/step-summary.ts
+++ b/packages/api/src/infrastructure/telemetry/step-summary.ts
@@ -1,0 +1,124 @@
+/**
+ * F153 Phase I: Step Summary aggregation.
+ *
+ * Computes per-route step metrics from a trace's stored spans. Descriptive
+ * only (no efficiency or quality scoring, per KD-16/KD-32).
+ *
+ * Null sub-counts (`agent_loop_count` / `tool_call_count` / `a2a_dispatch_count`)
+ * are returned when the trace is restored (flattened to
+ * `cat_cafe.invocation.restored`, hierarchy lost) OR when no provider emitted
+ * the `cat_cafe.agent_loop` marker. UI must render `—` for null, not `0`
+ * (AC-I4 / AC-I7 non-degradation).
+ */
+
+import type { TraceSpanDTO } from './local-trace-store.js';
+
+/** OTel SpanStatusCode.ERROR */
+const SPAN_STATUS_ERROR = 2;
+
+/** Step summary for one trace (one route). */
+export interface StepSummary {
+  traceId: string;
+  /** Length: total agent loops in this route. null when restored or no provider marker. */
+  agent_loop_count: number | null;
+  /** Total tool calls (MCP child spans + basic-tool counter). null when restored. */
+  tool_call_count: number | null;
+  /** A2A dispatch count = number of cat_cafe.mention_dispatch spans. null when restored. */
+  a2a_dispatch_count: number | null;
+  /** Route duration in ms. Always available (route span or trace time-range fallback). */
+  duration_ms: number;
+  /** Total tokens from cat_cafe.route span attribute route.total_tokens. */
+  token_total: number;
+  /** Number of spans with ERROR status code. */
+  error_count: number;
+  /** Whether all invocation spans are restored (hierarchy lost). */
+  is_restored: boolean;
+  /** Width: avg tools per agent loop. null when either length or tool count is null. */
+  width_avg_tools_per_loop: number | null;
+}
+
+/**
+ * Aggregate spans of a single trace into a StepSummary. Returns null when no spans.
+ *
+ * NOTE: descriptive only — never compute efficiency / quality / normative scores
+ * here. The UI must not synthesize such fields either (per AC-I5, KD-32).
+ */
+export function computeStepSummary(spans: TraceSpanDTO[], traceId: string): StepSummary | null {
+  if (spans.length === 0) return null;
+
+  const routeSpan = spans.find((s) => s.name === 'cat_cafe.route');
+  const liveInvocationSpans = spans.filter((s) => s.name === 'cat_cafe.invocation');
+  const restoredInvocationSpans = spans.filter((s) => s.name === 'cat_cafe.invocation.restored');
+
+  // Restored when there are no live invocation spans but restored ones exist.
+  const isRestored = liveInvocationSpans.length === 0 && restoredInvocationSpans.length > 0;
+
+  // agent_loop_count: sum the `agent_loop.count` attribute across live invocation spans.
+  // null when restored OR when no live invocation span exposed the attribute
+  // (provider did not emit cat_cafe.agent_loop marker — AC-I2 non-degradation).
+  let agentLoopCount: number | null = null;
+  if (!isRestored) {
+    const counts = liveInvocationSpans
+      .map((s) => s.attributes['agent_loop.count'])
+      .filter((v): v is number => typeof v === 'number');
+    if (counts.length > 0) {
+      agentLoopCount = counts.reduce((a, b) => a + b, 0);
+    }
+  }
+
+  // tool_call_count: MCP/business child spans + basic-tool counter attribute (dual-track per KD-35).
+  let toolCallCount: number | null = null;
+  if (!isRestored) {
+    const mcpToolUseSpans = spans.filter((s) => s.name.startsWith('cat_cafe.tool_use ')).length;
+    const basicCounts = liveInvocationSpans
+      .map((s) => s.attributes['tool.basic_call_count'])
+      .filter((v): v is number => typeof v === 'number')
+      .reduce((a, b) => a + b, 0);
+    toolCallCount = mcpToolUseSpans + basicCounts;
+  }
+
+  // a2a_dispatch_count: count of cat_cafe.mention_dispatch spans (KD-34: derive from span, not metric counter).
+  let a2aDispatchCount: number | null = null;
+  if (!isRestored) {
+    a2aDispatchCount = spans.filter((s) => s.name === 'cat_cafe.mention_dispatch').length;
+  }
+
+  // duration_ms: prefer route span duration; fallback to trace time range.
+  const durationMs = routeSpan?.durationMs ?? computeTraceDuration(spans);
+
+  // token_total: from route span (route.total_tokens), set in route-serial.ts finally block.
+  const tokenTotal =
+    routeSpan && typeof routeSpan.attributes['route.total_tokens'] === 'number'
+      ? (routeSpan.attributes['route.total_tokens'] as number)
+      : 0;
+
+  // error_count: spans with ERROR status code.
+  const errorCount = spans.filter((s) => s.status.code === SPAN_STATUS_ERROR).length;
+
+  // Width: avg tools per loop.
+  const width: number | null =
+    agentLoopCount != null && agentLoopCount > 0 && toolCallCount != null ? toolCallCount / agentLoopCount : null;
+
+  return {
+    traceId,
+    agent_loop_count: agentLoopCount,
+    tool_call_count: toolCallCount,
+    a2a_dispatch_count: a2aDispatchCount,
+    duration_ms: durationMs,
+    token_total: tokenTotal,
+    error_count: errorCount,
+    is_restored: isRestored,
+    width_avg_tools_per_loop: width,
+  };
+}
+
+function computeTraceDuration(spans: TraceSpanDTO[]): number {
+  if (spans.length === 0) return 0;
+  let start = Infinity;
+  let end = -Infinity;
+  for (const s of spans) {
+    if (s.startTimeMs < start) start = s.startTimeMs;
+    if (s.endTimeMs > end) end = s.endTimeMs;
+  }
+  return end - start;
+}

--- a/packages/api/src/routes/callback-a2a-trigger.ts
+++ b/packages/api/src/routes/callback-a2a-trigger.ts
@@ -232,6 +232,12 @@ export async function enqueueA2ATargets(
     });
     const enqueued = pushResult.added;
     if (enqueued.length > 0) {
+      // F153 Phase I (Maine Coon round-2 P2): legacy worklist callback dispatch must also
+      // mint the mention_dispatch span + a2a.dispatch.count counter. Use the lazy helper for
+      // its side-effects; the returned trace context is unused here because route-serial
+      // (which consumes the worklist) doesn't accept a callerTraceContext at worklist-push
+      // time. Empty added / blocked branches still skip this (lazy = idempotent on first call).
+      ensureDispatchTraceContext();
       if (deliveryCursorStore) {
         // F27 + #77: Best-effort auto-ack to prevent surprise backlog when cats later
         // call pending-mentions. This intentionally advances the mention-ack cursor

--- a/packages/api/src/routes/callback-a2a-trigger.ts
+++ b/packages/api/src/routes/callback-a2a-trigger.ts
@@ -86,8 +86,9 @@ export async function enqueueA2ATargets(
   const targetCats = opts.targetCats;
 
   // F153: wrap caller trace context with mention_dispatch span for callback A2A causality
+  // Phase I: pass fromCatId so a2a.dispatch.count counter carries AGENT_ID attribute.
   const dispatchTraceContext = opts.callerTraceContext
-    ? wrapWithDispatchSpan(opts.callerTraceContext, targetCats.length)
+    ? wrapWithDispatchSpan(opts.callerTraceContext, targetCats.length, fromCatId)
     : undefined;
 
   // F122B: If InvocationQueue is available, enqueue as agent entry (unified dispatch).

--- a/packages/api/src/routes/callback-a2a-trigger.ts
+++ b/packages/api/src/routes/callback-a2a-trigger.ts
@@ -85,11 +85,18 @@ export async function enqueueA2ATargets(
   const fromCatId = callerCatId ?? opts.triggerMessage.catId ?? getDefaultCatId();
   const targetCats = opts.targetCats;
 
-  // F153: wrap caller trace context with mention_dispatch span for callback A2A causality
-  // Phase I: pass fromCatId so a2a.dispatch.count counter carries AGENT_ID attribute.
-  const dispatchTraceContext = opts.callerTraceContext
-    ? wrapWithDispatchSpan(opts.callerTraceContext, targetCats.length, fromCatId)
-    : undefined;
+  // F153 Phase I (Maine Coon P1): Lazy-create mention_dispatch span + a2a.dispatch.count counter
+  // ONLY when a target is about to actually dispatch (passes all guards and reaches a real enqueue
+  // or fallback invocation). Pre-creating would mint span/counter even when ALL cats are blocked
+  // by depth limit / dedup / ping-pong streak / empty-conflict fallback — polluting Step Summary
+  // a2a_dispatch_count with phantom dispatches.
+  let dispatchTraceContext: CallerTraceContext | undefined;
+  const ensureDispatchTraceContext = (): CallerTraceContext | undefined => {
+    if (dispatchTraceContext === undefined && opts.callerTraceContext) {
+      dispatchTraceContext = wrapWithDispatchSpan(opts.callerTraceContext, targetCats.length, fromCatId);
+    }
+    return dispatchTraceContext;
+  };
 
   // F122B: If InvocationQueue is available, enqueue as agent entry (unified dispatch).
   // This replaces both the worklist path and the fallback standalone invocation.
@@ -168,7 +175,7 @@ export async function enqueueA2ATargets(
         intent: 'execute',
         autoExecute: true,
         callerCatId: callerCatId ?? undefined,
-        callerTraceContext: dispatchTraceContext,
+        callerTraceContext: ensureDispatchTraceContext(),
       });
       queueDiagnostics.push({
         catId,
@@ -330,7 +337,11 @@ export async function enqueueA2ATargets(
       );
     }
     // Proceed with non-conflicting targets only
-    await triggerA2AInvocation(deps, { ...opts, targetCats: nonConflicting, callerTraceContext: dispatchTraceContext });
+    await triggerA2AInvocation(deps, {
+      ...opts,
+      targetCats: nonConflicting,
+      callerTraceContext: ensureDispatchTraceContext(),
+    });
     return { enqueued: nonConflicting, fallback: true };
   }
 
@@ -346,7 +357,7 @@ export async function enqueueA2ATargets(
   // F167 PR1 history note: originally this path filtered role-gated targets before
   // fallback; Phase E retires L3, so targetCats == opts.targetCats now. Kept the
   // explicit spread for intent clarity and future filter hooks.
-  await triggerA2AInvocation(deps, { ...opts, targetCats, callerTraceContext: dispatchTraceContext });
+  await triggerA2AInvocation(deps, { ...opts, targetCats, callerTraceContext: ensureDispatchTraceContext() });
   return { enqueued: targetCats, fallback: true };
 }
 

--- a/packages/api/src/routes/telemetry.ts
+++ b/packages/api/src/routes/telemetry.ts
@@ -11,7 +11,6 @@
 import type { FastifyPluginAsync } from 'fastify';
 import { hmacId } from '../infrastructure/telemetry/hmac.js';
 import type { LocalTraceStore } from '../infrastructure/telemetry/local-trace-store.js';
-import { LOCAL_TRACE_STORE_DEFAULT_MAX_SPANS } from '../infrastructure/telemetry/local-trace-store.js';
 import type { MetricsSnapshotStore } from '../infrastructure/telemetry/metrics-snapshot-store.js';
 import { parsePrometheusText } from '../infrastructure/telemetry/metrics-snapshot-store.js';
 import { computeStepSummary } from '../infrastructure/telemetry/step-summary.js';
@@ -117,12 +116,14 @@ export const telemetryRoutes: FastifyPluginAsync<TelemetryRoutesOptions> = async
     if (!traceId) {
       return reply.status(400).send({ error: 'traceId is required' });
     }
-    // F153 Phase I (Maine Coon P1): limit = buffer capacity to ensure we read ALL spans for the
-    // trace, not just the newest 500. Long multi-cat tasks easily exceed 500 spans (route +
-    // many invocation + cli_session + llm_call + tool_use + mention_dispatch), and query() is
-    // newest-first; a 500-cap would silently undercount agent_loop_count / tool_call_count /
-    // error_count for exactly the long traces Step Summary is designed to surface.
-    const spans = opts.traceStore.query({ traceId, limit: LOCAL_TRACE_STORE_DEFAULT_MAX_SPANS });
+    // F153 Phase I (Maine Coon P1 + round-2 non-blocking): limit = actual store capacity to
+    // ensure we read ALL spans for the trace, not just the newest 500. Long multi-cat tasks
+    // easily exceed 500 spans (route + many invocation + cli_session + llm_call + tool_use +
+    // mention_dispatch), and query() is newest-first; a 500-cap would silently undercount
+    // agent_loop_count / tool_call_count / error_count for exactly the long traces Step
+    // Summary is designed to surface. Source from stats().maxSpans so tests / future
+    // configurations that use a non-default buffer capacity remain honored.
+    const spans = opts.traceStore.query({ traceId, limit: opts.traceStore.stats().maxSpans });
     const summary = computeStepSummary(spans, traceId);
     if (!summary) {
       return reply.status(404).send({ error: 'No spans found for traceId' });

--- a/packages/api/src/routes/telemetry.ts
+++ b/packages/api/src/routes/telemetry.ts
@@ -13,6 +13,7 @@ import { hmacId } from '../infrastructure/telemetry/hmac.js';
 import type { LocalTraceStore } from '../infrastructure/telemetry/local-trace-store.js';
 import type { MetricsSnapshotStore } from '../infrastructure/telemetry/metrics-snapshot-store.js';
 import { parsePrometheusText } from '../infrastructure/telemetry/metrics-snapshot-store.js';
+import { computeStepSummary } from '../infrastructure/telemetry/step-summary.js';
 
 export interface ReadinessResult {
   status: 'ready' | 'degraded';
@@ -94,6 +95,33 @@ export const telemetryRoutes: FastifyPluginAsync<TelemetryRoutesOptions> = async
     }
 
     return opts.traceStore.stats();
+  });
+
+  /**
+   * GET /api/telemetry/step-summary — aggregate Step Summary for a route (F153 Phase I).
+   *
+   * Query params:
+   *   traceId — OTel trace ID (required)
+   *
+   * Returns descriptive step metrics (per AC-I1/I6, KD-32 descriptive only — no
+   * efficiency or quality scoring). Null sub-counts indicate restored spans or
+   * no provider marker (AC-I4 — UI must render '—' for null, never '0').
+   */
+  app.get<{ Querystring: { traceId?: string } }>('/api/telemetry/step-summary', async (request, reply) => {
+    if (!requireSession(request, reply)) return;
+    if (!opts.traceStore) {
+      return reply.status(503).send({ error: 'Trace store not available (OTel may be disabled)' });
+    }
+    const traceId = request.query.traceId;
+    if (!traceId) {
+      return reply.status(400).send({ error: 'traceId is required' });
+    }
+    const spans = opts.traceStore.query({ traceId, limit: 500 });
+    const summary = computeStepSummary(spans, traceId);
+    if (!summary) {
+      return reply.status(404).send({ error: 'No spans found for traceId' });
+    }
+    return summary;
   });
 
   /**

--- a/packages/api/src/routes/telemetry.ts
+++ b/packages/api/src/routes/telemetry.ts
@@ -11,6 +11,7 @@
 import type { FastifyPluginAsync } from 'fastify';
 import { hmacId } from '../infrastructure/telemetry/hmac.js';
 import type { LocalTraceStore } from '../infrastructure/telemetry/local-trace-store.js';
+import { LOCAL_TRACE_STORE_DEFAULT_MAX_SPANS } from '../infrastructure/telemetry/local-trace-store.js';
 import type { MetricsSnapshotStore } from '../infrastructure/telemetry/metrics-snapshot-store.js';
 import { parsePrometheusText } from '../infrastructure/telemetry/metrics-snapshot-store.js';
 import { computeStepSummary } from '../infrastructure/telemetry/step-summary.js';
@@ -116,7 +117,12 @@ export const telemetryRoutes: FastifyPluginAsync<TelemetryRoutesOptions> = async
     if (!traceId) {
       return reply.status(400).send({ error: 'traceId is required' });
     }
-    const spans = opts.traceStore.query({ traceId, limit: 500 });
+    // F153 Phase I (Maine Coon P1): limit = buffer capacity to ensure we read ALL spans for the
+    // trace, not just the newest 500. Long multi-cat tasks easily exceed 500 spans (route +
+    // many invocation + cli_session + llm_call + tool_use + mention_dispatch), and query() is
+    // newest-first; a 500-cap would silently undercount agent_loop_count / tool_call_count /
+    // error_count for exactly the long traces Step Summary is designed to surface.
+    const spans = opts.traceStore.query({ traceId, limit: LOCAL_TRACE_STORE_DEFAULT_MAX_SPANS });
     const summary = computeStepSummary(spans, traceId);
     if (!summary) {
       return reply.status(404).send({ error: 'No spans found for traceId' });

--- a/packages/api/test/telemetry/step-summary.test.js
+++ b/packages/api/test/telemetry/step-summary.test.js
@@ -88,6 +88,66 @@ test('F153 Phase I: telemetry routes expose /api/telemetry/step-summary endpoint
   assert.ok(src.includes('computeStepSummary'), 'Should import computeStepSummary');
 });
 
+// ── Maine Coon review round 1 P1 fixes ─────────────────────────────
+
+test('F153 Phase I (P1-1): callback-a2a-trigger lazy-creates dispatch span only when actually dispatching', () => {
+  const src = readFileSync(resolve(__dirname, '../../src/routes/callback-a2a-trigger.ts'), 'utf8');
+  // Lazy helper must exist
+  assert.ok(src.includes('ensureDispatchTraceContext'), 'Should define ensureDispatchTraceContext lazy helper');
+  // wrapWithDispatchSpan must NOT be called at function top before guards
+  // (look for top-level early creation pattern)
+  assert.ok(
+    !/const dispatchTraceContext = opts\.callerTraceContext\s*\?\s*wrapWithDispatchSpan/.test(src),
+    'Must NOT pre-allocate dispatchTraceContext before depth/dedup/streak guards',
+  );
+  // All three downstream usage points must go through the lazy helper
+  assert.ok(src.includes('callerTraceContext: ensureDispatchTraceContext()'), 'enqueue path must use lazy helper');
+});
+
+test('F153 Phase I (P1-2): step-summary route reads full buffer, not capped at 500', () => {
+  const src = readFileSync(resolve(__dirname, '../../src/routes/telemetry.ts'), 'utf8');
+  // Must NOT use a hard 500 cap
+  assert.ok(
+    !/traceStore\.query\(\{\s*traceId\s*,\s*limit:\s*500\s*\}\)/.test(src),
+    'step-summary must not silently truncate long traces at 500 spans',
+  );
+  // Must use the buffer-capacity constant
+  assert.ok(
+    src.includes('LOCAL_TRACE_STORE_DEFAULT_MAX_SPANS'),
+    'step-summary should use LOCAL_TRACE_STORE_DEFAULT_MAX_SPANS for query limit',
+  );
+});
+
+test('AC-I1 (P1-2 regression): computeStepSummary aggregates correctly across > 500 spans', async () => {
+  const computeStepSummary = await importComputeStepSummary();
+  if (!computeStepSummary) return;
+
+  // Synthesize a long trace: 1 route + many invocations with agent_loop.count, plus tool spans.
+  const spans = [
+    span({
+      name: 'cat_cafe.route',
+      spanId: 'r',
+      durationMs: 50000,
+      attributes: { 'route.total_tokens': 12345 },
+    }),
+  ];
+  // 600 invocations, each contributing 1 to agent_loop_count
+  for (let i = 0; i < 600; i++) {
+    spans.push(
+      span({
+        name: 'cat_cafe.invocation',
+        spanId: `i${i}`,
+        parentSpanId: 'r',
+        attributes: { 'agent_loop.count': 1, 'tool.basic_call_count': 0 },
+      }),
+    );
+  }
+  const summary = computeStepSummary(spans, 'trace-long');
+  assert.equal(summary.agent_loop_count, 600, 'Should not silently truncate at 500');
+  assert.equal(summary.tool_call_count, 0);
+  assert.equal(summary.duration_ms, 50000);
+});
+
 // ── Behavioral: computeStepSummary (AC-I1, I2, I4, I5, I6) ─────────
 
 const COMPUTE_PATH = '../../dist/infrastructure/telemetry/step-summary.js';

--- a/packages/api/test/telemetry/step-summary.test.js
+++ b/packages/api/test/telemetry/step-summary.test.js
@@ -1,0 +1,244 @@
+/**
+ * F153 Phase I: Step Summary — AC-I1..AC-I7 coverage.
+ *
+ * - Behavioral: computeStepSummary on synthetic spans covers
+ *   live/restored, missing marker, dual-track tool counts, width derivation,
+ *   and the descriptive-only contract (no normative fields synthesized).
+ * - Source-level: counter wiring (instruments + dispatch-span + route-serial),
+ *   recordAgentLoop wiring (span-helpers + invoke-single-cat), Claude parser
+ *   emits agent_loop on message_stop, AgentMessageType extension.
+ */
+
+if (!process.env.NODE_ENV) process.env.NODE_ENV = 'test';
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Source-level wiring (AC-I3, AC-I2, AC-I7) ──────────────────────
+
+test('F153 Phase I: instruments.ts registers cat_cafe.a2a.dispatch.count counter', () => {
+  const src = readFileSync(resolve(__dirname, '../../src/infrastructure/telemetry/instruments.ts'), 'utf8');
+  assert.ok(src.includes('a2aDispatchCount'), 'Should export a2aDispatchCount');
+  assert.ok(src.includes('cat_cafe.a2a.dispatch.count'), 'Should register cat_cafe.a2a.dispatch.count instrument name');
+});
+
+test('F153 Phase I: dispatch-span.ts increments counter and accepts optional sourceCatId', () => {
+  const src = readFileSync(resolve(__dirname, '../../src/infrastructure/telemetry/dispatch-span.ts'), 'utf8');
+  assert.ok(src.includes('a2aDispatchCount.add(1'), 'Should increment a2aDispatchCount');
+  assert.ok(src.includes('sourceCatId'), 'wrapWithDispatchSpan should accept optional sourceCatId');
+  assert.ok(
+    !src.includes('invocationId'),
+    'dispatch-span counter must NOT carry invocationId (metric-allowlist.ts forbids high-cardinality)',
+  );
+});
+
+test('F153 Phase I: route-serial.ts increments a2aDispatchCount on in-process dispatch', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/routing/route-serial.ts'),
+    'utf8',
+  );
+  assert.ok(src.includes('a2aDispatchCount'), 'Should import a2aDispatchCount');
+  assert.ok(src.includes('a2aDispatchCount.add(1'), 'Should call a2aDispatchCount.add at dispatch span creation');
+});
+
+test('F153 Phase I: span-helpers.ts exports recordAgentLoop, sets agent_loop.count attribute', () => {
+  const src = readFileSync(resolve(__dirname, '../../src/infrastructure/telemetry/span-helpers.ts'), 'utf8');
+  assert.ok(src.includes('export function recordAgentLoop'), 'Should export recordAgentLoop');
+  assert.ok(src.includes("'agent_loop.count'"), 'Should set agent_loop.count attribute on invocationSpan');
+  assert.ok(src.includes('agentLoopCounts'), 'Should use WeakMap counter (same pattern as toolCallCounts)');
+});
+
+test('F153 Phase I: Claude parser emits agent_loop AgentMessage at message_stop', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/providers/claude-ndjson-parser.ts'),
+    'utf8',
+  );
+  assert.ok(src.includes("s.type === 'message_stop'"), 'Should detect message_stop event');
+  assert.ok(
+    src.includes("type: 'agent_loop' as const"),
+    'Should return { type: agent_loop } AgentMessage (not null) at message_stop',
+  );
+});
+
+test('F153 Phase I: AgentMessageType union extends with agent_loop', () => {
+  const src = readFileSync(resolve(__dirname, '../../src/domains/cats/services/types.ts'), 'utf8');
+  assert.ok(src.includes("'agent_loop'"), 'AgentMessageType should include agent_loop variant');
+});
+
+test('F153 Phase I: invoke-single-cat handles agent_loop telemetry-only (continue, no outputs)', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/invocation/invoke-single-cat.ts'),
+    'utf8',
+  );
+  assert.ok(src.includes('recordAgentLoop'), 'Should import recordAgentLoop');
+  assert.ok(
+    src.includes("msg.type === 'agent_loop'") && src.includes('recordAgentLoop(invocationSpan)'),
+    'Should branch on agent_loop and call recordAgentLoop',
+  );
+});
+
+test('F153 Phase I: telemetry routes expose /api/telemetry/step-summary endpoint', () => {
+  const src = readFileSync(resolve(__dirname, '../../src/routes/telemetry.ts'), 'utf8');
+  assert.ok(src.includes('/api/telemetry/step-summary'), 'Should register step-summary route');
+  assert.ok(src.includes('computeStepSummary'), 'Should import computeStepSummary');
+});
+
+// ── Behavioral: computeStepSummary (AC-I1, I2, I4, I5, I6) ─────────
+
+const COMPUTE_PATH = '../../dist/infrastructure/telemetry/step-summary.js';
+
+async function importComputeStepSummary() {
+  try {
+    return (await import(COMPUTE_PATH)).computeStepSummary;
+  } catch (err) {
+    // Build not run yet — skip behavioral tests cleanly.
+    return null;
+  }
+}
+
+function span(overrides) {
+  const base = {
+    traceId: 't',
+    spanId: 's',
+    parentSpanId: undefined,
+    name: 'cat_cafe.unknown',
+    kind: 0,
+    startTimeMs: 0,
+    endTimeMs: 100,
+    durationMs: 100,
+    status: { code: 0 },
+    attributes: {},
+    events: [],
+    storedAt: Date.now(),
+  };
+  return { ...base, ...overrides };
+}
+
+test('AC-I1+I6: computeStepSummary aggregates 6 metrics + Length × Width from live spans', async () => {
+  const computeStepSummary = await importComputeStepSummary();
+  if (!computeStepSummary) {
+    console.warn('  ↳ dist not built; behavioral suite skipped (source-level still validates wiring)');
+    return;
+  }
+
+  const summary = computeStepSummary(
+    [
+      span({
+        name: 'cat_cafe.route',
+        spanId: 'r',
+        durationMs: 1234,
+        attributes: { 'route.total_tokens': 5678 },
+      }),
+      span({
+        name: 'cat_cafe.invocation',
+        spanId: 'i1',
+        parentSpanId: 'r',
+        attributes: { 'agent_loop.count': 3, 'tool.basic_call_count': 2 },
+      }),
+      span({
+        name: 'cat_cafe.invocation',
+        spanId: 'i2',
+        parentSpanId: 'r',
+        attributes: { 'agent_loop.count': 4, 'tool.basic_call_count': 1 },
+      }),
+      span({ name: 'cat_cafe.tool_use Read', spanId: 't1', parentSpanId: 'i1' }),
+      span({ name: 'cat_cafe.tool_use Edit', spanId: 't2', parentSpanId: 'i1' }),
+      span({ name: 'cat_cafe.mention_dispatch', spanId: 'd1', parentSpanId: 'i1' }),
+    ],
+    'trace-x',
+  );
+  assert.equal(summary.agent_loop_count, 7);
+  assert.equal(summary.tool_call_count, 2 + 1 + 2); // basic + mcp
+  assert.equal(summary.a2a_dispatch_count, 1);
+  assert.equal(summary.duration_ms, 1234);
+  assert.equal(summary.token_total, 5678);
+  assert.equal(summary.is_restored, false);
+  // Width = tool_call_count / agent_loop_count
+  assert.ok(summary.width_avg_tools_per_loop != null);
+  assert.ok(Math.abs(summary.width_avg_tools_per_loop - 5 / 7) < 1e-9);
+});
+
+test('AC-I4: restored-only trace returns null sub-counts (UI shows —, never 0)', async () => {
+  const computeStepSummary = await importComputeStepSummary();
+  if (!computeStepSummary) return;
+
+  const summary = computeStepSummary(
+    [
+      span({ name: 'cat_cafe.invocation.restored', durationMs: 500 }),
+      span({ name: 'cat_cafe.invocation.restored', durationMs: 700 }),
+    ],
+    'trace-restored',
+  );
+  assert.equal(summary.is_restored, true);
+  assert.equal(summary.agent_loop_count, null);
+  assert.equal(summary.tool_call_count, null);
+  assert.equal(summary.a2a_dispatch_count, null);
+  assert.equal(summary.width_avg_tools_per_loop, null);
+});
+
+test('AC-I2/I7 non-degradation: live invocations without agent_loop.count attr → agent_loop_count is null', async () => {
+  const computeStepSummary = await importComputeStepSummary();
+  if (!computeStepSummary) return;
+
+  const summary = computeStepSummary(
+    [
+      span({ name: 'cat_cafe.route', spanId: 'r', durationMs: 200 }),
+      span({ name: 'cat_cafe.invocation', spanId: 'i', parentSpanId: 'r', attributes: {} }),
+    ],
+    'trace-no-marker',
+  );
+  assert.equal(summary.is_restored, false);
+  assert.equal(summary.agent_loop_count, null, 'No provider marker emitted → null, NOT 0');
+  // Critical non-degradation: must not silently fall back to invocation count.
+  assert.notEqual(summary.agent_loop_count, 1);
+  assert.equal(summary.width_avg_tools_per_loop, null);
+});
+
+test('AC-I5: StepSummary never includes efficiency/quality/score fields (descriptive only, KD-32)', async () => {
+  const computeStepSummary = await importComputeStepSummary();
+  if (!computeStepSummary) return;
+
+  const summary = computeStepSummary([span({ name: 'cat_cafe.route', durationMs: 1 })], 't');
+  const keys = Object.keys(summary).map((k) => k.toLowerCase());
+  for (const forbidden of ['efficiency', 'quality', 'score', 'rating', 'grade', 'goodness']) {
+    assert.ok(!keys.some((k) => k.includes(forbidden)), `StepSummary must not include ${forbidden} field`);
+  }
+});
+
+test('AC-I1: error_count counts only spans with ERROR status code', async () => {
+  const computeStepSummary = await importComputeStepSummary();
+  if (!computeStepSummary) return;
+
+  const summary = computeStepSummary(
+    [
+      span({ name: 'cat_cafe.route', durationMs: 1 }),
+      span({ name: 'cat_cafe.invocation', status: { code: 2 } }),
+      span({ name: 'cat_cafe.llm_call', status: { code: 2 } }),
+      span({ name: 'cat_cafe.llm_call', status: { code: 0 } }),
+    ],
+    't',
+  );
+  assert.equal(summary.error_count, 2);
+});
+
+test('AC-I7: empty spans returns null (no synthetic data)', async () => {
+  const computeStepSummary = await importComputeStepSummary();
+  if (!computeStepSummary) return;
+
+  assert.equal(computeStepSummary([], 't'), null);
+});
+
+// ── Frontend wiring (AC-I1, AC-I4) ─────────────────────────────────
+
+test('F153 Phase I: HubTraceTree renders StepSummaryPanel for each expanded trace', () => {
+  const src = readFileSync(resolve(__dirname, '../../../web/src/components/HubTraceTree.tsx'), 'utf8');
+  assert.ok(src.includes('StepSummaryPanel'), 'Should define StepSummaryPanel component');
+  assert.ok(src.includes('/api/telemetry/step-summary'), 'Should fetch step-summary endpoint');
+  assert.ok(src.includes("n === null ? '—'"), "Null sub-counts must render '—' (non-degradation, AC-I4)");
+  assert.ok(src.includes('Restored (history)'), 'Should badge restored traces');
+});

--- a/packages/api/test/telemetry/step-summary.test.js
+++ b/packages/api/test/telemetry/step-summary.test.js
@@ -111,10 +111,24 @@ test('F153 Phase I (P1-2): step-summary route reads full buffer, not capped at 5
     !/traceStore\.query\(\{\s*traceId\s*,\s*limit:\s*500\s*\}\)/.test(src),
     'step-summary must not silently truncate long traces at 500 spans',
   );
-  // Must use the buffer-capacity constant
+  // Maine Coon round-2 non-blocking: prefer stats().maxSpans over a hardcoded constant so
+  // tests / future configurations with non-default buffer capacity are honored.
   assert.ok(
-    src.includes('LOCAL_TRACE_STORE_DEFAULT_MAX_SPANS'),
-    'step-summary should use LOCAL_TRACE_STORE_DEFAULT_MAX_SPANS for query limit',
+    src.includes('traceStore.stats().maxSpans'),
+    'step-summary should use traceStore.stats().maxSpans for query limit',
+  );
+});
+
+test('F153 Phase I (round-2 P2): legacy worklist callback success also mints dispatch span/counter', () => {
+  const src = readFileSync(resolve(__dirname, '../../src/routes/callback-a2a-trigger.ts'), 'utf8');
+  // The lazy helper must be invoked in the worklist success branch (enqueued.length > 0)
+  // — otherwise callbacks routed via the legacy F27 worklist path will silently skip the
+  // mention_dispatch span and a2a.dispatch.count counter even when dispatch did happen.
+  const worklistBlock = src.split('if (hasWorklist(threadId))')[1] ?? '';
+  const successBranch = worklistBlock.split('if (enqueued.length > 0)')[1] ?? '';
+  assert.ok(
+    successBranch.includes('ensureDispatchTraceContext()'),
+    'worklist success branch must call ensureDispatchTraceContext() (lazy side-effects: span + counter)',
   );
 });
 

--- a/packages/web/src/components/HubTraceTree.tsx
+++ b/packages/web/src/components/HubTraceTree.tsx
@@ -190,6 +190,7 @@ function TraceCard({ trace, expanded, onToggle }: { trace: TraceGroup; expanded:
       {expanded && (
         <div className="border-t border-cafe-border px-3 pb-3 pt-2 space-y-2">
           <div className="text-[10px] text-cafe-muted font-mono">traceId: {trace.traceId}</div>
+          <StepSummaryPanel traceId={trace.traceId} />
           <TreeWaterfall trace={trace} selectedSpan={selectedSpan} onSelectSpan={setSelectedSpan} />
           {selectedSpan && <SpanDetail span={trace.spans.find((s) => s.spanId === selectedSpan)} />}
         </div>
@@ -577,6 +578,86 @@ function PromptMeta({ capture }: { capture: PromptCaptureData }) {
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+// ── F153 Phase I: Step Summary panel ──────────────────────────────
+
+interface StepSummaryData {
+  traceId: string;
+  agent_loop_count: number | null;
+  tool_call_count: number | null;
+  a2a_dispatch_count: number | null;
+  duration_ms: number;
+  token_total: number;
+  error_count: number;
+  is_restored: boolean;
+  width_avg_tools_per_loop: number | null;
+}
+
+function StepSummaryPanel({ traceId }: { traceId: string }) {
+  const [data, setData] = useState<StepSummaryData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiFetch(`/api/telemetry/step-summary?traceId=${encodeURIComponent(traceId)}`)
+      .then(async (res) => {
+        if (cancelled) return;
+        if (res.ok) {
+          const json = (await res.json()) as StepSummaryData;
+          setData(json);
+        }
+      })
+      .catch(() => {
+        /* ignore */
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [traceId]);
+
+  if (loading) {
+    return <div className="text-[10px] text-cafe-muted">Loading Step Summary…</div>;
+  }
+  if (!data) return null;
+
+  // '—' for null (AC-I4 / AC-I7 non-degradation — never render 0 for unknown).
+  const fmt = (n: number | null): string => (n === null ? '—' : n.toString());
+
+  return (
+    <div className="rounded-lg border border-cafe-border bg-cafe-surface-elevated p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-xs font-medium text-cafe">Step Summary</span>
+        {data.is_restored && (
+          <span className="rounded bg-cafe-surface px-1.5 py-0.5 text-[10px] text-cafe-muted">Restored (history)</span>
+        )}
+      </div>
+      <div className="grid grid-cols-3 gap-2">
+        <StepCell label="Agent loops" value={fmt(data.agent_loop_count)} primary />
+        <StepCell label="Tool calls" value={fmt(data.tool_call_count)} />
+        <StepCell label="A2A dispatch" value={fmt(data.a2a_dispatch_count)} />
+        <StepCell label="Duration" value={`${data.duration_ms.toFixed(0)} ms`} />
+        <StepCell label="Tokens" value={data.token_total.toLocaleString()} />
+        <StepCell label="Errors" value={data.error_count.toString()} />
+      </div>
+      <div className="mt-2 border-t border-cafe-border pt-2 text-[10px] text-cafe-muted">
+        Length × Width = {fmt(data.agent_loop_count)} loop ×{' '}
+        {data.width_avg_tools_per_loop != null ? `${data.width_avg_tools_per_loop.toFixed(1)} tools/loop` : '—'}
+      </div>
+    </div>
+  );
+}
+
+function StepCell({ label, value, primary }: { label: string; value: string; primary?: boolean }) {
+  return (
+    <div>
+      <div className="text-[10px] text-cafe-muted">{label}</div>
+      <div className={`font-mono text-xs ${primary ? 'font-semibold text-cafe' : 'text-cafe'}`}>{value}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Implementation of F153 Phase I per the spec landed in #2 (commit `b36540cf`). Closes `zts212653/clowder-ai#721` once merged.

- **Backend**: register `cat_cafe.a2a.dispatch.count` counter, add `recordAgentLoop(invocationSpan)` helper, emit `cat_cafe.agent_loop` marker from Claude provider at `message_stop`, expose `GET /api/telemetry/step-summary`.
- **Frontend**: `StepSummaryPanel` inside each expanded `TraceCard` showing 6 metrics + Length × Width + Live vs Restored distinction.
- **Tests**: `step-summary.test.js` covers wiring (source-level) + aggregation behavior + AC-I5 (no normative fields) + AC-I7 non-degradation.

## AC coverage

| AC | Where |
|----|-------|
| AC-I1 (Hub sub-view with 6 metrics) | `HubTraceTree.tsx` StepSummaryPanel + `/api/telemetry/step-summary` route |
| AC-I2 (`cat_cafe.agent_loop` marker, per-provider parser, `—` when absent) | `claude-ndjson-parser.ts` message_stop branch + `recordAgentLoop` + `computeStepSummary` non-degradation |
| AC-I3 (`cat_cafe.a2a.dispatch.count` counter, only AGENT_ID) | `instruments.ts` + `dispatch-span.ts` + `route-serial.ts` |
| AC-I4 (Restored `—` marker, never `0`) | `computeStepSummary` is_restored + StepSummaryPanel `fmt(n)` |
| AC-I5 (descriptive only, no efficiency/quality fields) | step-summary.ts contract + `step-summary.test.js` |
| AC-I6 (Length × Width) | `width_avg_tools_per_loop` derived + panel "Length × Width" line |
| AC-I7 (tests) | `step-summary.test.js` source + behavioral coverage |

## KD references

- KD-31 step = agent loop, anchor = `cat_cafe.agent_loop` stream marker
- KD-32 descriptive only, no efficiency/quality score
- KD-33 done event / llm_call span are per-invocation; marker required
- KD-34 metric counter only AGENT_ID; route dim via span count
- KD-35 tool double-track (MCP child span + basic counter attr); token via ROUTE_TOTAL_TOKENS

## Test plan

- [ ] Source-level wiring tests pass
- [ ] Behavioral tests pass once `dist` is built (`pnpm -r build`)
- [ ] Manual: open Hub Traces tab, expand a trace, verify Step Summary renders
- [ ] Manual: trigger restored hydrate path (restart API), verify "Restored (history)" badge + `—` markers for sub-counts
- [ ] biome `check` clean on new code (pre-existing HubTraceTree warnings out of scope)

## Out of scope

- Other providers (Codex/Gemini/Kimi/Antigravity/OpenCode/DARE/A2A) emitting agent_loop marker — Claude only in this PR; other providers stay `—` per AC-I2 first-pass.
- `pnpm lint` full pass — worktree NODE_ENV=production skips devDeps; main repo CI is authoritative.

[宪宪/Opus-47🐾]