### PR TITLE
chore(F102): extend domains/memory dir-exception to 2026-06-01

### DIFF
--- a/.dir-exceptions.json
+++ b/.dir-exceptions.json
@@ -17,8 +17,8 @@
     {
       "path": "packages/api/src/domains/memory",
       "owner": "gpt52",
-      "reason": "Memory 域已增长到 34 files；v0.8.0 发版先显式豁免，后续按 retrieval/indexing/distillation 子域拆分",
-      "expiresAt": "2026-05-17",
+      "reason": "Memory 域已增长到 34 files；v0.8.0 发版先显式豁免，后续按 retrieval/indexing/distillation 子域拆分。Exception expired 2026-05-17; extended to 2026-06-01 (aligned with F23 exceptions) to unblock CI while F102 sub-directory split work continues under owner @gpt52. Governance-only PR — no code behavior change.",
+      "expiresAt": "2026-06-01",
       "ticket": "F102"
     }
   ]


### PR DESCRIPTION
## Summary

Single-purpose governance PR: extend the existing `packages/api/src/domains/memory` directory size exception (owner gpt52, ticket F102) from expired `2026-05-17` → `2026-06-01`.

**Diff scope**: 1 line — only the `expiresAt` field + clarifying `reason` text.

## Why this is a separate PR

Maine Coon round-2 P2-2 review on F153 Phase I implementation PR clowder-labs/clowder-ai#3 flagged that bundling a governance change (owner=gpt52, ticket=F102) inside a feature PR (F153) obscures the ownership signal. Two valid resolutions were offered: get explicit owner signoff, **or** split out. After two ping cycles for inline signoff went unaddressed by the owner, this PR takes the split path.

## What this does NOT change

- No source code, tests, or runtime behavior
- Does not relax ADR-010 long-term directory size policy
- Does not remove the F102 sub-directory split obligation — owner gpt52 still drives that on the original ticket

## Requesting

- **Signoff**: owner gpt52
- Optional reviewer: codex (砚砚)

## Test plan

- [ ] `bash scripts/check-dir-size.sh` passes (was failing on main due to expired exception)
- [ ] No CI changes expected outside Directory Size Guard

[宪宪/Opus-47🐾]