### PR TITLE
feat: display project directory in chat header

### DIFF
--- a/packages/web/src/components/ChatContainerHeader.tsx
+++ b/packages/web/src/components/ChatContainerHeader.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useChatStore } from '@/stores/chatStore';
 import { ExportButton } from './ExportButton';
 import { VoiceCompanionButton } from './VoiceCompanionButton';
@@ -85,17 +86,47 @@ export function ChatContainerHeader({
 function ThreadIndicator({ threadId }: { threadId: string }) {
   const threads = useChatStore((s) => s.threads);
   const currentThread = threads.find((t) => t.id === threadId);
+  const [copied, setCopied] = useState(false);
 
   if (threadId === 'default') {
     return <p className="text-base font-bold text-cafe truncate min-w-0">大厅</p>;
   }
 
   const title = currentThread?.title ?? '未命名对话';
+  const projectPath = currentThread?.projectPath;
+  const isRealProject = projectPath && projectPath !== 'default' && projectPath !== 'lobby';
+  const dirName = isRealProject ? projectPath.split('/').filter(Boolean).pop() : null;
+
+  const handleCopyPath = async () => {
+    if (!projectPath) return;
+    await navigator.clipboard.writeText(projectPath);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
 
   return (
-    <p className="text-base font-bold text-cafe truncate min-w-0" title={title}>
-      {title}
-    </p>
+    <div className="flex items-center gap-1.5 min-w-0">
+      {dirName && (
+        <>
+          <span
+            className="inline-flex items-center gap-1 text-xs text-cafe-muted shrink-0 cursor-pointer rounded px-1.5 py-0.5 hover:bg-[var(--console-hover-bg)] transition-colors"
+            title={copied ? '已复制!' : projectPath}
+            onClick={handleCopyPath}
+            role="button"
+            tabIndex={0}
+          >
+            <svg className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M2 6a2 2 0 012-2h5l2 2h5a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z" />
+            </svg>
+            {dirName}
+          </span>
+          <span className="text-cafe-muted text-xs shrink-0 select-none">·</span>
+        </>
+      )}
+      <p className="text-base font-bold text-cafe truncate min-w-0" title={title}>
+        {title}
+      </p>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- 在 `ThreadIndicator` 中显示当前对话的工作目录名称（最后一级目录 + 文件夹图标）
- Hover 显示完整绝对路径，点击复制全路径到剪贴板
- default / lobby thread 不显示路径 tag

Closes zts212653/clowder-ai#727

## Test plan

- [ ] 打开有 `projectPath` 的对话，确认标题左侧显示目录名
- [ ] Hover 目录 tag，确认 tooltip 显示完整绝对路径
- [ ] 点击目录 tag，确认剪贴板包含完整路径，tooltip 短暂变为"已复制!"
- [ ] 切换到大厅（default thread），确认不显示路径 tag
- [ ] 移动端视图下标题 truncate 正常，路径 tag 不被截断

[宪宪/Opus-46🐾]