### PR TITLE
fix(web): proxy remote develop API calls through web origin

### DIFF
--- a/packages/web/src/utils/__tests__/api-client-resolve.test.ts
+++ b/packages/web/src/utils/__tests__/api-client-resolve.test.ts
@@ -56,7 +56,7 @@ describe('resolveApiUrl', () => {
     expect(resolve()).toBe('https://api.example.com');
   });
 
-  // ── P1 fix: localhost env + remote access → skip env, auto-detect ──
+  // ── localhost env + remote access → same-origin proxy ──
 
   it('skips localhost env when accessed remotely (reverse proxy)', async () => {
     process.env.NEXT_PUBLIC_API_URL = 'http://localhost:3004';
@@ -65,11 +65,18 @@ describe('resolveApiUrl', () => {
     expect(resolve()).toBe('http://1.2.3.4');
   });
 
-  it('skips 127.0.0.1 env when accessed remotely', async () => {
+  it('uses same-origin proxy for 127.0.0.1 env when accessed remotely with an explicit web port', async () => {
     process.env.NEXT_PUBLIC_API_URL = 'http://127.0.0.1:3004';
     stubLocation({ hostname: '10.0.0.5', protocol: 'http:', port: '3003' });
     const resolve = await loadResolveApiUrl();
-    expect(resolve()).toBe('http://10.0.0.5:3004');
+    expect(resolve()).toBe('http://10.0.0.5:3003');
+  });
+
+  it('does not derive a nonexistent remote API port when runtime web/API ports are non-adjacent', async () => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost:3122';
+    stubLocation({ hostname: '100.64.1.23', protocol: 'http:', port: '5122' });
+    const resolve = await loadResolveApiUrl();
+    expect(resolve()).toBe('http://100.64.1.23:5122');
   });
 
   // ── localhost env + local access → use env (no skip) ──

--- a/packages/web/src/utils/api-client.ts
+++ b/packages/web/src/utils/api-client.ts
@@ -31,6 +31,11 @@ export function resolveApiUrl(): string {
     //   - localhost env + remote browser → reverse-proxy users would hit dev's loopback
     //   - cloud env + local browser → would force a Cloudflare Tunnel round-trip for nothing
     const mismatch = (isLocalhostDefault && isRemoteAccess) || (!isLocalhostDefault && isLocalAccess);
+    if (isLocalhostDefault && isRemoteAccess) {
+      const protocol = location.protocol ?? 'http:';
+      const port = location.port ? `:${location.port}` : '';
+      return `${protocol}//${location.hostname}${port}`;
+    }
     if (!mismatch) return envUrl;
   }
   if (typeof window === 'undefined') return 'http://localhost:3004';


### PR DESCRIPTION
## Summary

- When the frontend is opened from a remote host and `NEXT_PUBLIC_API_URL` points at `localhost`/`127.0.0.1`, resolve API calls to the current web origin instead of deriving `frontendPort + 1`.
- This lets `/api`, `/socket.io`, and `/uploads` go through the existing Next rewrites to the real API port.
- Add a regression for develop dogfood ports: web `5122`, API `3122`, no listener on `5123`.

## Why

`pnpm develop:start` runs `../cat-cafe-develop` with non-adjacent ports: frontend `5122`, API `3122`. Remote browser access to `http://<ip>:5122` previously inferred `http://<ip>:5123`, so message send failed with `Failed to fetch` even though the API health check on `3122` was OK.

## Validation

- `pnpm --filter @cat-cafe/web exec vitest run src/utils/__tests__/api-client-resolve.test.ts`
- `git diff --cached --check -- packages/web/src/utils/api-client.ts packages/web/src/utils/__tests__/api-client-resolve.test.ts`

## Known unrelated local state

- Full `pnpm --filter @cat-cafe/web test -- --run src/utils/__tests__/api-client-resolve.test.ts` was accidentally run and failed on existing unrelated tests: `CliDiagnosticsPanel.test.ts` and `chat-container-header-thread-indicator.test.ts`.
- Existing ACP edits and untracked docs/outputs remain unstaged and unrelated.

[砚砚/gpt-5.5🐾]
