### PR TITLE
fix(dev): use runtime ports for develop start

### DIFF
--- a/docs/SOP.md
+++ b/docs/SOP.md
@@ -71,15 +71,17 @@ Phase N merge → 碰头（不是"要不要继续"，是"方向对不对"）→ 
 
 ## Develop 狗粮通道
 
-`../cat-cafe-develop` 是基于最新 `origin/develop` 的日常狗粮环境，用于体验已通过 fork 内部 PR 合入 develop 的集成态，不干扰 runtime / alpha。
+`../cat-cafe-develop` 是基于最新 `origin/develop` 的日常狗粮环境，用于体验已通过 fork 内部 PR 合入 develop 的集成态。
 
 | 命令 | 作用 |
 |------|------|
-| `pnpm develop:start` | 自动同步 origin/develop + 拉起独立 develop stack |
+| `pnpm develop:start` | 自动同步 origin/develop + 用 runtime 默认端口拉起 develop stack |
 | `pnpm develop:sync` | 只同步不启动 |
 | `pnpm develop:status` | 查看环境状态 |
 
-端口默认由 `WORKTREE_PORT_OFFSET=-20` 派生：API 3122、Web 5122、Redis 6378。不得复用 runtime 的 3003/3004/6399，也不得复用 alpha 的 3011/3012/6398。
+端口默认与 `pnpm start` 一致：Web 3003、API 3004、Redis 使用 runtime 默认配置。`pnpm start` 与 `pnpm develop:start` 是同一套本地单例端口，不能同时运行；切换前先 `pnpm stop`。
+
+需要临时隔离端口时，可显式设置 `CAT_CAFE_DEVELOP_WORKTREE_PORT_OFFSET`，但这不是日常狗粮默认路径。
 
 **注意**：`pnpm start` 永远是 runtime 主线入口，仍同步 `origin/main`。不要为了体验 develop 改写 `pnpm start` 语义。
 

--- a/scripts/develop-worktree.sh
+++ b/scripts/develop-worktree.sh
@@ -13,9 +13,14 @@ export CAT_CAFE_RUNTIME_REMOTE="${CAT_CAFE_DEVELOP_REMOTE:-origin}"
 export CAT_CAFE_RUNTIME_SOURCE_BRANCH="${CAT_CAFE_DEVELOP_SOURCE_BRANCH:-develop}"
 export CAT_CAFE_RUNTIME_SYNC_COMMAND="${CAT_CAFE_DEVELOP_SYNC_COMMAND:-pnpm develop:sync}"
 
-# Keep develop dogfood away from runtime (3003/3004/6399) and alpha
-# (3011/3012/6398). Offset -20 derives Redis 6378, API 3122, Web 5122.
-export WORKTREE_PORT_OFFSET="${CAT_CAFE_DEVELOP_WORKTREE_PORT_OFFSET:--20}"
+# Develop intentionally shares the same singleton ports as `pnpm start`.
+# Set CAT_CAFE_DEVELOP_WORKTREE_PORT_OFFSET only for explicit isolated
+# experiments.
+if [ -n "${CAT_CAFE_DEVELOP_WORKTREE_PORT_OFFSET:-}" ]; then
+  export WORKTREE_PORT_OFFSET="$CAT_CAFE_DEVELOP_WORKTREE_PORT_OFFSET"
+else
+  unset WORKTREE_PORT_OFFSET
+fi
 
 [[ "${1:-}" == "--source-only" ]] && { return 0 2>/dev/null; exit 0; }
 

--- a/scripts/runtime-worktree.test.sh
+++ b/scripts/runtime-worktree.test.sh
@@ -29,6 +29,9 @@ test_usage_includes_source_branch() {
 
 test_develop_wrapper_exports_runtime_defaults() {
   (
+    WORKTREE_PORT_OFFSET="-20"
+    unset CAT_CAFE_DEVELOP_WORKTREE_PORT_OFFSET
+
     # shellcheck source=./develop-worktree.sh
     source "$SCRIPT_DIR/develop-worktree.sh" --source-only
 
@@ -48,13 +51,30 @@ test_develop_wrapper_exports_runtime_defaults() {
       echo "FAIL: develop wrapper should show develop sync hint"
       exit 1
     }
-    [ "$WORKTREE_PORT_OFFSET" = "-20" ] || {
-      echo "FAIL: develop wrapper should reserve the -20 port offset"
+    [ "${WORKTREE_PORT_OFFSET+set}" != "set" ] || {
+      echo "FAIL: develop wrapper should share default runtime ports"
       exit 1
     }
   )
 
   echo "PASS: develop wrapper exports runtime defaults"
+}
+
+test_develop_wrapper_allows_explicit_port_offset() {
+  (
+    unset WORKTREE_PORT_OFFSET
+    CAT_CAFE_DEVELOP_WORKTREE_PORT_OFFSET="-20"
+
+    # shellcheck source=./develop-worktree.sh
+    source "$SCRIPT_DIR/develop-worktree.sh" --source-only
+
+    [ "$WORKTREE_PORT_OFFSET" = "-20" ] || {
+      echo "FAIL: develop wrapper should allow an explicit port offset"
+      exit 1
+    }
+  )
+
+  echo "PASS: develop wrapper allows explicit port offset"
 }
 
 test_is_api_running_uses_worktree_port_offset() {
@@ -149,5 +169,6 @@ test_init_and_sync_runtime_worktree_from_develop() {
 
 test_usage_includes_source_branch
 test_develop_wrapper_exports_runtime_defaults
+test_develop_wrapper_allows_explicit_port_offset
 test_is_api_running_uses_worktree_port_offset
 test_init_and_sync_runtime_worktree_from_develop


### PR DESCRIPTION
## Summary

- Make `pnpm develop:start` share the same runtime singleton ports/config as `pnpm start`.
- Clear inherited `WORKTREE_PORT_OFFSET` by default in the develop wrapper.
- Keep `CAT_CAFE_DEVELOP_WORKTREE_PORT_OFFSET` as an explicit opt-in escape hatch for isolated experiments.
- Update SOP and runtime wrapper tests.

## Why

Co-creator clarified that develop dogfood should differ only by synced source branch (`origin/develop` instead of `origin/main`). Redis, gateway, API/web ports, and runtime service surface should stay consistent with `pnpm start`.

## Validation

- `pnpm runtime:test`
- `git diff --check -- scripts/develop-worktree.sh scripts/runtime-worktree.test.sh docs/SOP.md`

## Operational note

`pnpm start` and `pnpm develop:start` now intentionally compete for the same local singleton ports. They cannot run at the same time; switching lanes must stop the active stack first.

[砚砚/gpt-5.5🐾]
