### PR TITLE
[codex] add F159 Phase F write/exec tools

### DIFF
--- a/docs/decisions/001-agent-invocation-approach.md
+++ b/docs/decisions/001-agent-invocation-approach.md
@@ -8,10 +8,10 @@ created: 2026-02-26
 # ADR-001: Agent 调用方式选择
 
 ## 状态
-已更新（2026-04-11 修订）
+已更新（2026-06-16 修订）
 
 ## 日期
-2026-02-04（初始）/ 2026-02-06（修订）/ 2026-04-11（F159 修订）
+2026-02-04（初始）/ 2026-02-06（修订）/ 2026-04-11（F159 修订）/ 2026-06-16（F159 Phase F 修订）
 
 ## 背景
 
@@ -54,7 +54,12 @@ Cat Café 需要程序化调用三只 AI 猫猫（Claude/Codex/Gemini），并�
 - ❌ 不绕过现有安全基线（account-binding / workspace-security）
 - ❌ 不绕过 governance preflight（F070 fail-closed 治理门禁）
 - ❌ 不覆写 home 目录配置文件（ADR-017 铁律：`~/.codex/AGENTS.md` 等）
-- ❌ F159 scope 内不开放 write/edit/delete、shell/command execution、outbound network side-effect 工具（仅 read-only 工具集）
+- ❌ Phase A-E 不开放 write/edit/delete、shell/command execution、outbound network side-effect 工具（仅 read-only 工具集）
+- ✅ Phase F 可在显式 `nativeToolLevel` 分级授权下开放受控 side-effect 工具：
+  - `L0`：read-only（默认）
+  - `L1`：`write_file` / `patch_file`，必须通过 create-safe path resolver、CAS hash、结构化审计
+  - `L2`：`run_command`，必须使用结构化 `{ binary, args }`、allowlist-first `commandPolicy`、`execFile`、受限 env、timeout/buffer cap、结构化审计
+- ❌ Phase F 仍不开放任意 shell、任意网络、任意 `HOME` 透传、raw callback 写口、cross-thread/A2A 路由副作用
 
 **成本模型：**
 - Native provider 使用 API key 付费，不消耗订阅额度
@@ -68,6 +73,7 @@ Cat Café 需要程序化调用三只 AI 猫猫（Claude/Codex/Gemini），并�
 4. **F050 Safety Contract**：满足 External Agent Contract v1 的 Section D（Capability）和 Section F（Safety）
 5. **F149 Failure taxonomy**：按三层分类（process-poison / session-poison / turn-transient）处理故障
 6. **Governance fail-closed**：调用前必须通过 governance preflight（F070），不可跳过或降级
+7. **Phase F side-effect audit**：write/patch/exec/callback side-effect 必须写入独立结构化审计，不能依赖 transcript 的 `tool_result` 截断摘要
 
 **与相关 Feature 的边界：**
 - **F143**：native provider 实现 F143 的 provider 契约，不绕过宿主抽象
@@ -146,3 +152,4 @@ Cat Café 需要程序化调用三只 AI 猫猫（Claude/Codex/Gemini），并�
 | 2026-02-04 | 初始决策：选择方案 C (SDK) | 完整 agent 能力 + 低延迟 |
 | 2026-02-06 | 修订为方案 B (CLI 子进程) | SDK 只能用 API key，无法用订阅额度；Gemini API 模式无文件操作能力 |
 | 2026-04-11 | F159：新增方案 E (Opt-in Native Provider) | 轻量任务 CLI 启动开销不划算；RFC #434 + maintainer review 确认方向；安全硬 gate 作为准入门槛 |
+| 2026-06-16 | F159 Phase F：在分级授权下有条件开放 write/exec | 将 CatAgent 从 read-only 扩展为轻量内置可工作 provider，同时保留 CLI 默认主路径和 fail-closed 安全边界 |

--- a/docs/features/F159-catagent-native-provider.md
+++ b/docs/features/F159-catagent-native-provider.md
@@ -1,6 +1,6 @@
 ---
 feature_ids: [F159]
-related_features: [F143, F149, F153]
+related_features: [F143, F149, F153, F050, F070]
 topics: [provider, agent-runtime, api-path, architecture, security, community]
 doc_kind: spec
 created: 2026-04-11
@@ -9,7 +9,7 @@ community_issue: "zts212653/clowder-ai#434"
 
 # F159: CatAgent Native Provider — Opt-in API Path
 
-> **Status**: in-progress | **Owner**: 社区 (bouillipx) + Ragdoll + Maine Coon | **Priority**: P1
+> **Status**: in-review（Phase A-E 已合入；Phase F F1/F2/F3-min 已实现，等待跨 family review + dogfood） | **Owner**: 社区 (bouillipx) + Ragdoll + Maine Coon | **Priority**: P1
 
 ## Why
 
@@ -66,29 +66,107 @@ community_issue: "zts212653/clowder-ai#434"
 4. stream EOF / missing `message_stop` / unclosed content block / orphan `tool_use` 全部走 **strict streaming fail-closed**
 5. 不引入 `@anthropic-ai/sdk`，继续保持 raw `fetch` + 本地 parser 的 provider-owned 实现边界
 
+### Phase F: Write/Exec Tool Surface
+
+在 Phase A-E 的只读基座之上，把 CatAgent 扩展为 **轻量、内置、可干活的 native provider**，但仍保持：
+
+1. **不替代 CLI 默认主路径**：CLI 仍负责重度编码、完整 agent 能力和订阅额度利用
+2. **不引入新的北向 API**：继续复用现有 `AgentService.invoke()` 门面
+3. **不下沉宿主安全边界**：account-binding / workspace-security / governance preflight 仍由宿主层兜底
+
+Phase F 采用分级工具面和分 slice 推进，而不是一次性开放所有副作用能力：
+
+#### Slice F1: Tiered Tool Surface + Write Tools
+
+1. **CatConfig 扩展**：新增 `nativeToolLevel?: 'L0' | 'L1' | 'L2'`
+2. **分级工具面**：
+   - `L0`：`read_file` / `list_files` / `search_content`（F159 已有）
+   - `L1`：`write_file` / `patch_file`
+   - `L2`：`run_command`
+   - 未声明时默认 `L0`，保持向下兼容
+3. **create-safe path resolver**：
+   - 现有 `resolveSecurePath()` 对 `ENOENT` 放过，不能直接用于新建文件
+   - 新增 `resolveCreatePath(root, userPath)`：找到最近存在的祖先目录 → `realpath()` 校验 → 重跑 denylist → 阻止 symlink 父目录逃逸
+4. **write_file**：
+   - 参数：`path`、`content`
+   - 路径：走 `resolveCreatePath()`
+   - 写入：tmp + rename 原子写
+   - 限额：单次 256 KiB
+5. **patch_file**：
+   - 参数：`path`、`old_text`、`new_text`、`expected_hash`
+   - 语义：compare-and-swap 精确替换
+   - 守卫：`expected_hash` 校验文件未被并发修改；`old_text` 必须唯一匹配
+6. **结构化审计**：
+   - 写操作独立记录 `tool/path/bytes/hashBefore/hashAfter/timestamp`
+   - 不依赖 transcript 中 500 字符 `tool_result` 截断
+
+#### Slice F2: run_command + Command Policy Matrix
+
+1. **commandPolicy**（替代 `argv[0]` 粗粒度白名单）：
+   - `commandPolicy?: CommandPolicyEntry[]`
+   - 每条 entry 必须是 allowlist-first：`binary` + `allowedSubcommands` + `allowedFlags` / `allowedArgPatterns`
+   - `deniedFlags` 只能作为 defense-in-depth，不能作为授权依据
+   - 无 entry = 不可执行（fail-closed）
+2. **run_command**：
+   - 输入为结构化 `{ binary: string, args: string[] }`
+   - 不接受字符串命令，避免 shell 解析歧义
+3. **校验顺序**：
+   - `binary` 命中策略项
+   - `args[0]` 若作为 subcommand，必须在 `allowedSubcommands` 内
+   - flags / args 必须匹配该命令的 allowlist policy；未声明即拒绝
+   - `node`、`pnpm install/publish`、`git push/fetch/config` 等高风险形态默认不进入 MVP policy
+4. **执行约束**：
+   - `execFile`，不经 shell
+   - `cwd` 锁定 workspace
+   - `timeout = 30s`
+   - `maxBuffer = 512 KiB`
+   - env 仅透传 `PATH` + `NODE_ENV`，不透传 `HOME`
+5. **失败策略**：
+   - 非零退出码：作为 `tool_result` 返回，按 `turn-transient` 处理
+   - 超时：`SIGTERM` + 3s grace + `SIGKILL`
+   - 有副作用命令禁止盲重试
+6. **结构化审计**：
+   - 记录 `binary/args/exitCode/duration/stdoutBytes/stderrBytes/policyEntry`
+   - 拒绝执行同样产出 `rejectReason`
+
+#### Slice F3-min: Host-Native Scoped Callback Tool
+
+1. **mandatory core 只交付 `update_current_task_status`**：
+   - 这是 host-native scoped callback tool，不是 `update_task` 的 alias
+   - 只在宿主能绑定 current invocation / current task 时注册；无 current task 时不注册或拒绝
+   - 只允许更新 `status` / `progress` / `summary`
+   - 明确禁止传入或修改 `owner` / `assignee` / `kind` / `targetCats` / `threadId` / `taskId`
+   - 审计记录必须包含 `invocationId` / `currentTaskId` / `changedFields`
+2. **optional / non-blocker: `post_current_thread_status`**：
+   - 若本轮实现，必须是 no-route / no-mention / no-targetCats / no-cross-thread
+   - host 负责拒绝或转义行首 `@`，避免触发 A2A 路由
+3. **deferred callback surface**：
+   - `create_task` / raw `post_message` / `cross_post_message` / 任意 A2A routing 全部后置
+   - 不走 MCP bridge；未来若 F143 `toolBridge` / `permission policy` seam 落地，再评估是否抽象上提
+
 ## Acceptance Criteria
 
 ### Phase A（RFC 收敛 + ADR 边界）
-- [ ] AC-A1: `clowder-ai#434` 标题/正文完成定位修正，统一使用 “native provider / opt-in API path” 口径
-- [ ] AC-A2: ADR-001 修订草案落盘，明确 CLI 仍是默认主路径，API path 仅为 opt-in
-- [ ] AC-A3: F143 / F149 / F050 边界写入 spec/RFC，不再混成“另一套 runtime”
-- [ ] AC-A4: 正式 feature 编号分配完成，cat-cafe 真相源与社区 issue 双向链接
+- [x] AC-A1: `clowder-ai#434` 标题/正文完成定位修正，统一使用 “native provider / opt-in API path” 口径
+- [x] AC-A2: ADR-001 修订草案落盘，明确 CLI 仍是默认主路径，API path 仅为 opt-in
+- [x] AC-A3: F143 / F149 / F050 边界写入 spec/RFC，不再混成“另一套 runtime”
+- [x] AC-A4: 正式 feature 编号分配完成，cat-cafe 真相源与社区 issue 双向链接
 
 ### Phase B（Host Integration + Security Baseline）
-- [ ] AC-B1: CatAgent 凭据解析复用现有 account-binding 链路（`resolveBoundAccountRefForCat -> resolveForClient`），不存在任意 key 扫描 fallback
-- [ ] AC-B2: workspace 边界复用共享安全 helper，symlink 场景有回归测试
-- [ ] AC-B3: 工具参数注入防护在 host/provider integration layer 落地，有针对性测试
-- [ ] AC-B4: provider 的 `done/error/usage` 终态审计在现有链路中可验证
+- [x] AC-B1: CatAgent 凭据解析复用现有 account-binding 链路（`resolveBoundAccountRefForCat -> resolveForClient`），不存在任意 key 扫描 fallback
+- [x] AC-B2: workspace 边界复用共享安全 helper，symlink 场景有回归测试
+- [x] AC-B3: 工具参数注入防护在 host/provider integration layer 落地，有针对性测试
+- [x] AC-B4: provider 的 `done/error/usage` 终态审计在现有链路中可验证
 
 ### Phase C（Minimal Native Provider）
-- [ ] AC-C1: provider 以 opt-in 方式注册，不改变现有默认 provider 选择语义
-- [ ] AC-C2: 单轮文本任务可端到端执行，并正确产出 `session_init/text/error/done`
-- [ ] AC-C3: abort / timeout / error 情况下无悬挂 session 或缺失终态
-- [ ] AC-C4: v1 不开放 write/exec/跨线程副作用工具
+- [x] AC-C1: provider 以 opt-in 方式注册，不改变现有默认 provider 选择语义
+- [x] AC-C2: 单轮文本任务可端到端执行，并正确产出 `session_init/text/error/done`
+- [x] AC-C3: abort / timeout / error 情况下无悬挂 session 或缺失终态
+- [x] AC-C4: v1 不开放 write/exec/跨线程副作用工具
 
 ### Phase D（Read-Only Tools + Compaction Follow-up）
-- [ ] AC-D1: read-only tools 只有在宿主层权限边界复用完成后才开放
-- [ ] AC-D2: compact/microcompact 若保留，必须证明不会破坏身份约束和审计链
+- [x] AC-D1: read-only tools 只有在宿主层权限边界复用完成后才开放
+- [x] AC-D2: compact/microcompact 未进入已交付路径；provider path 不依赖 compact，未破坏身份约束和审计链
 
 ### Phase E（SSE Streaming + Fail-Closed Turn Handling）
 - [x] AC-E1: text tokens 按 chunk 产出到上游（每个 `text_delta` → 一个 `type: 'text'` AgentMessage）
@@ -97,15 +175,39 @@ community_issue: "zts212653/clowder-ai#434"
 - [x] AC-E4: stream error / disconnect / missing `message_stop` / unclosed block → `error + done`；第一轮错误保留 zero-usage 契约；orphan `tool_use` 发 failed `tool_result`
 - [x] AC-E5: strict streaming fail-closed —— 不做 non-streaming fallback；任意 stream error 直接终止并产出终态
 
+### Phase F（Write/Exec Tool Surface）
+- [x] AC-F1: `CatConfig` 支持 `nativeToolLevel`，默认 `L0`
+- [x] AC-F2: `buildToolRegistry` 根据 `nativeToolLevel` 注册 `L0/L1/L2` 工具面
+- [x] AC-F3: `resolveCreatePath()` 实现：最近存在祖先 `realpath` 校验 + denylist 重跑，阻止 symlink 父目录逃逸
+- [x] AC-F4: `write_file` 实现原子写（tmp + rename），写入上限 256 KiB
+- [x] AC-F5: `patch_file` 实现 compare-and-swap：`expected_hash` 校验 + `old_text` 唯一匹配
+- [x] AC-F6: write/patch 产出独立结构化审计，不依赖 transcript 截断
+- [x] AC-F7: `CatConfig` 支持 `commandPolicy`，默认空（fail-closed）
+- [x] AC-F8: `run_command` 只接受结构化 `{ binary, args }` 输入，不接受字符串命令
+- [x] AC-F9: 命令策略矩阵按 allowlist-first 的 `binary -> subcommand -> flags/arg patterns` 校验，任一未声明立即拒绝
+- [x] AC-F10: `run_command` 通过 `execFile` 执行，`cwd` 锁定 workspace，超时 30s，`maxBuffer` 512 KiB
+- [x] AC-F11: env 仅透传 `PATH` + `NODE_ENV`，不透传 `HOME`
+- [x] AC-F12: run_command 的执行/拒绝均产出结构化审计，并遵循 F149 failure taxonomy
+- [x] AC-F13a: mandatory host-native scoped callback tool 仅为 `update_current_task_status`，且只能作用于 current invocation / current task
+- [x] AC-F13b: `update_current_task_status` 无 current task 时不注册或拒绝；只允许 `status` / `progress` / `summary`，禁止 `owner` / `assignee` / `kind` / `targetCats` / `threadId` / `taskId`
+- [x] AC-F13c: optional `post_current_thread_status` 若实现，必须 no-route / no-mention / no-targetCats / no-cross-thread；`create_task` / raw `post_message` / `cross_post_message` / 任意 A2A routing 明确 deferred
+- [x] AC-F13d: callback tools 产出独立结构化审计，并遵循 F149 failure taxonomy
+- [x] AC-F14: 行为测试覆盖写入越权、symlink 祖先逃逸、大小超限、hash 不匹配、策略矩阵拒绝、超时杀进程、env 不泄露、callback scoping 拒绝
+- [x] AC-F15: ADR-001 修订完成，明确 F159 Phase F 在分级授权下有条件开放 write/exec；这是 Phase F merge gate
+
+> Implementation note (2026-06-16): `update_current_task_status` 只从 thread metadata 中显式选中的 current task 注入；callback 执行时会重新校验 `threadId` 和 `ownerCatId`。未选中 task、跨 thread、跨 owner 时不注册该工具。`post_current_thread_status` / raw `post_message` / `create_task` / cross-thread / A2A routing 仍未进入 Phase F 工具面。
+
 ## 需求点 Checklist
 
 | ID | 需求点（社区原话/转述） | AC 编号 | 验证方式 | 状态 |
 |----|-------------------------|---------|----------|------|
-| R1 | “继续探索 CatAgent，但不要回到 #397 的实现形态” | AC-A1, AC-A3 | RFC/Spec 对照检查 | [ ] |
-| R2 | “给这个方向一个正式 feature 编号” | AC-A4 | spec + BACKLOG + issue 链接 | [ ] |
-| R3 | “API path 只作为 opt-in，不改变默认主路径” | AC-A2, AC-C1 | ADR + 配置验证 | [ ] |
-| R4 | “安全三项是硬 gate，不是 backlog” | AC-B1, AC-B2, AC-B3 | 测试 + review 记录 | [ ] |
-| R5 | “如果要做，就按 provider 能力逐步推进” | AC-C2, AC-C4, AC-D1, AC-E1, AC-E4 | phased implementation review | [ ] |
+| R1 | “继续探索 CatAgent，但不要回到 #397 的实现形态” | AC-A1, AC-A3 | RFC/Spec 对照检查 | [x] |
+| R2 | “给这个方向一个正式 feature 编号” | AC-A4 | spec + BACKLOG + issue 链接 | [x] |
+| R3 | “API path 只作为 opt-in，不改变默认主路径” | AC-A2, AC-C1 | ADR + 配置验证 | [x] |
+| R4 | “安全三项是硬 gate，不是 backlog” | AC-B1, AC-B2, AC-B3 | 测试 + review 记录 | [x] |
+| R5 | “如果要做，就按 provider 能力逐步推进” | AC-C2, AC-C4, AC-D1, AC-E1, AC-E4 | phased implementation review | [x] |
+| R6 | “轻量级、与 Cat Cafe 强耦合、内置可干活的 agent” | AC-F1, AC-F4, AC-F8, AC-F13a | spec + design review | [x] |
+| R7 | “权限模型走分级工具，不默认全开” | AC-F1, AC-F2, AC-F7, AC-F9 | spec + tests | [x] |
 
 ### 覆盖检查
 - [x] 每个需求点都能映射到至少一个 AC
@@ -117,15 +219,22 @@ community_issue: "zts212653/clowder-ai#434"
 - **Evolved from**: F143（native provider 的宿主契约来自 F143）
 - **Related**: F149（runtime ops 经验输入，但 CatAgent 不复用 ACP carrier 模型）
 - **Related**: F153（provider usage / audit / observability 能力复用）
+- **Related**: F050（External Agent Contract——Phase F 的 capability / safety 边界输入）
+- **Related**: F070（Portable Governance——Phase F 仍需 governance fail-closed）
 
 ## Risk
 
 | 风险 | 缓解 |
 |------|------|
-| 再次把 provider 做成“平台内第二套 runtime” | Phase A 先收敛定位，title/body/spec 全部统一口径 |
-| provider 自己重写安全边界，导致宿主层失血 | 安全三项全部上提到 host/provider integration layer |
-| API path 模糊化后冲击 CLI 默认路线 | ADR-001 明确 opt-in only，默认路径不变 |
-| 一次性把 loop/tools/compact 全塞进首版实现 | 强制分 Phase，先最小 provider，再扩 read-only tools |
+| 再次把 provider 做成“平台内第二套 runtime” | Phase A 先收敛定位，title/body/spec 全部统一口径；Phase F 继续复用宿主 façade |
+| provider 自己重写安全边界，导致宿主层失血 | 安全三项全部上提到 host/provider integration layer；新增 `resolveCreatePath` 也走共享边界 |
+| API path 模糊化后冲击 CLI 默认路线 | ADR-001 明确 opt-in only，默认路径不变；Phase F 仍不替代 CLI |
+| 一次性把 loop/tools/compact 全塞进首版实现 | 强制分 Phase，先最小 provider，再扩 read-only tools，再做 write/exec |
+| 新建文件穿过 symlink 父目录逃逸 workspace | `resolveCreatePath` 找最近存在祖先 `realpath` 校验，拒绝 symlink 父目录创建 |
+| `run_command` 的粗粒度白名单退化为任意执行 | 用 `commandPolicy` 策略矩阵替代 `argv[0]` 级白名单；不接受字符串命令 |
+| side-effect 审计依赖 transcript 截断导致证据不足 | write/exec 工具独立产出结构化审计记录 |
+| callback tool 触发 A2A / cross-thread / task lifecycle 连锁副作用 | Phase F Core 只交付 `update_current_task_status`；raw message/task/cross-thread/A2A routing deferred |
+| F159 原 ADR 边界与 Phase F write/exec 冲突 | ADR-001 修订作为 Phase F merge gate，不把契约修订后置到 launch gate |
 
 ## Key Decisions
 
@@ -137,8 +246,28 @@ community_issue: "zts212653/clowder-ai#434"
 | KD-4 | `feat/catagent` 分支只作为 spike 参考，不作为可直接 merge 的实现分支 | #397 已被定性为 architecture-blocked spike | 2026-04-11 |
 | KD-5 | 为该方向分配正式 feature 编号 F159 | 这是独立、用户可感知的新 provider 能力，不是 F143/F149/F050 的纯子任务 | 2026-04-11 |
 | KD-6 | Phase E 采用 strict streaming fail-closed，不保留 conditional non-streaming fallback | 当前 provider path 更需要清晰审计边界与确定性终态，而不是条件重试复杂度 | 2026-04-24 |
+| KD-7 | Write/Exec 继续作为 F159 Phase F 推进，不再使用本地误开的 F188 作为独立 feature 真相源 | Feature 编号一号一真相源；不碰现有 canonical F188（Library Stewardship） | 2026-06-16 |
+| KD-8 | Phase F 采用分级工具面（`L0/L1/L2`） | 平衡能力与安全，默认 `L0` 向下兼容 F159 已交付行为 | 2026-06-16 |
+| KD-9 | 新增 `resolveCreatePath`，不直接复用 `resolveSecurePath` 处理新建文件 | `resolveSecurePath` 对 `ENOENT` 放过，无法覆盖 symlink 父目录逃逸 | 2026-06-16 |
+| KD-10 | `patch_file` 采用 compare-and-swap（`expected_hash` + 精确文本替换） | 防止基于陈旧读取的盲替换 | 2026-06-16 |
+| KD-11 | `run_command` 采用结构化 `{ binary, args }` + `commandPolicy`，不接受字符串命令 | 消除 shell 解析歧义，并把命令授权粒度收紧到 `binary/subcommand/flag` | 2026-06-16 |
+| KD-12 | Cat Cafe 深度集成先收 `F3-min`：mandatory 仅 `update_current_task_status`，raw message/task/cross-thread/A2A routing 后置 | 保留“强耦合”产品目标，同时避免 callback surface 触发 A2A / task lifecycle 级联副作用 | 2026-06-16 |
+| KD-13 | write/exec side-effect 工具必须独立产出结构化审计 | 现有 transcript 中 500 字符 `tool_result` 截断不足以承担 side-effect audit | 2026-06-16 |
 
 ## Review Gate
 
 - Phase A: Ragdoll + Maine Coon架构 review → team lead拍板
 - Phase B-E: 跨 family review
+- Phase F-F1/F2: 安全敏感，必须跨 family review
+- Phase F-F3: 产品方向 + 宿主边界联合 review
+- Phase F merge gate: AC-F15（ADR-001 边界修订）必须先完成
+- Phase F exit / launch gate: 默认权限策略、dogfood、审计可见性、fail-closed 验证
+
+## Revision History
+
+| 日期 | 变更 | 原因 |
+|------|------|------|
+| 2026-04-11 | F159 立项：Opt-in Native Provider 路径 | 把 #397 spike 收敛为 F143 下的 native provider 方向 |
+| 2026-04-24 | Phase E：strict streaming fail-closed 定稿 | 明确 streaming 终态和审计边界 |
+| 2026-06-16 | Phase F：Write/Exec Tool Surface 规划并回归 F159 真相源 | 本地误开的 F188 草案并回 F159；保持 feature 编号单一真相源 |
+| 2026-06-16 | Phase F F1/F2/F3-min 实现完成，进入 review | 分级工具面、write/patch、run_command policy、current-task scoped callback 已落地 |

--- a/packages/api/src/config/cat-config-loader.ts
+++ b/packages/api/src/config/cat-config-loader.ts
@@ -23,7 +23,7 @@ import type {
 import { type ClientId, catRegistry, createCatId, normalizeCliEffortForProvider } from '@cat-cafe/shared';
 import { z } from 'zod';
 import { createModuleLogger } from '../infrastructure/logger.js';
-import { bootstrapCatCatalog, readCatCatalogRaw, resolveCatCatalogPath } from './cat-catalog-store.js';
+import { bootstrapCatCatalog, readCatCatalogRaw } from './cat-catalog-store.js';
 import { isValidTimeZone } from './time-zone.js';
 
 const log = createModuleLogger('cat-config');
@@ -51,6 +51,14 @@ const contextBudgetSchema = z.object({
   maxContextTokens: z.number().positive(),
   maxMessages: z.number().positive().int(),
   maxContentLengthPerMsg: z.number().positive(),
+});
+
+const commandPolicyEntrySchema = z.object({
+  binary: z.string().min(1),
+  allowedSubcommands: z.array(z.string().min(1)).optional(),
+  allowedFlags: z.array(z.string().min(1)).optional(),
+  allowedArgPatterns: z.array(z.string().min(1)).optional(),
+  deniedFlags: z.array(z.string().min(1)).optional(),
 });
 
 const agyProfileSchema = z
@@ -105,6 +113,8 @@ const catVariantSchema = z.object({
   avatar: z.string().min(1).optional(), // F32-b P4c: override breed avatar
   color: colorSchema.optional(), // F32-b P4c: override breed color
   contextBudget: contextBudgetSchema.optional(),
+  nativeToolLevel: z.enum(['L0', 'L1', 'L2']).optional(), // F159 Phase F
+  commandPolicy: z.array(commandPolicyEntrySchema).optional(), // F159 Phase F
   voiceConfig: z // F103: per-cat TTS voice configuration
     .object({
       voice: z.string().min(1),
@@ -386,7 +396,6 @@ function mergeTemplateWithCatalog(templatePath: string): string | null {
  */
 export function loadCatConfig(filePath?: string): CatCafeConfig {
   let raw: string;
-  let resolvedPath = filePath;
   if (filePath) {
     try {
       raw = readFileSync(filePath, 'utf-8');
@@ -399,10 +408,8 @@ export function loadCatConfig(filePath?: string): CatCafeConfig {
     const merged = mergeTemplateWithCatalog(templatePath);
     if (merged !== null) {
       raw = merged;
-      resolvedPath = resolveCatCatalogPath(dirname(templatePath));
     } else {
       raw = readTemplate(templatePath);
-      resolvedPath = templatePath;
     }
   }
 
@@ -517,6 +524,8 @@ export function toAllCatConfigs(config: CatCafeConfig): Record<string, CatConfig
         ...(variant.cli != null ? { cli: variant.cli } : {}),
         ...(variant.provider != null ? { provider: variant.provider } : {}),
         ...(variant.contextBudget != null ? { contextBudget: variant.contextBudget } : {}),
+        ...(variant.nativeToolLevel != null ? { nativeToolLevel: variant.nativeToolLevel } : {}),
+        ...(variant.commandPolicy != null ? { commandPolicy: variant.commandPolicy } : {}),
         ...(variant.voiceConfig != null ? { voiceConfig: variant.voiceConfig } : {}),
         roleDescription: variant.roleDescription ?? breed.roleDescription,
         personality: variant.personality ?? defaultVariant?.personality ?? '',

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -13,7 +13,15 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
-import { type CatId, type ContextHealth, catRegistry, type MessageContent, type SessionRecord } from '@cat-cafe/shared';
+import {
+  type CatId,
+  type ContextHealth,
+  catRegistry,
+  type MessageContent,
+  type SessionRecord,
+  type TaskItem,
+  type TaskStatus,
+} from '@cat-cafe/shared';
 import { context, SpanStatusCode, trace } from '@opentelemetry/api';
 import {
   resolveBuiltinClientForProvider,
@@ -138,7 +146,7 @@ import type { SessionManager } from '../../session/SessionManager.js';
 import type { ISessionSealer } from '../../session/SessionSealer.js';
 import type { TranscriptSessionInfo, TranscriptWriter } from '../../session/TranscriptWriter.js';
 import type { ISessionChainStore } from '../../stores/ports/SessionChainStore.js';
-import type { IThreadStore } from '../../stores/ports/ThreadStore.js';
+import type { IThreadStore, Thread } from '../../stores/ports/ThreadStore.js';
 import type { AgentMessage, AgentService, AgentServiceOptions } from '../../types.js';
 import { hasL0CompilerSeam } from '../../types.js';
 import type { InvocationRegistry } from '../invocation/InvocationRegistry.js';
@@ -559,6 +567,137 @@ export interface InvocationParams {
   readonly continuityCapsule?: RouteStateContinuityCapsule;
 }
 
+function getSelectedTaskId(thread: Thread | null | undefined): string | undefined {
+  return thread?.bootcampState?.selectedTaskId ?? thread?.firstRunQuestState?.selectedTaskId;
+}
+
+function toTaskProgressStatus(status: TaskStatus): string {
+  if (status === 'done') return 'completed';
+  if (status === 'todo') return 'pending';
+  return 'in_progress';
+}
+
+function describeCurrentTaskActivity(patch: { progress?: number; summary?: string }): string | undefined {
+  if (patch.summary) return patch.summary;
+  if (patch.progress !== undefined) return `progress ${Math.round(patch.progress)}%`;
+  return undefined;
+}
+
+function upsertTaskProgressItem(items: TaskProgressItem[], item: TaskProgressItem): TaskProgressItem[] {
+  const next = items.filter((existing) => existing.id !== item.id);
+  next.push(item);
+  return next;
+}
+
+type CurrentTaskStatusPatch = {
+  status?: TaskStatus;
+  progress?: number;
+  summary?: string;
+};
+
+type ScopedTaskStore = NonNullable<InvocationDeps['taskStore']>;
+
+async function getScopedCurrentTask(input: {
+  readonly taskStore: ScopedTaskStore;
+  readonly currentTaskId: string;
+  readonly threadId: string;
+  readonly catId: CatId;
+}): Promise<TaskItem> {
+  const currentTask = await input.taskStore.get(input.currentTaskId);
+  if (!currentTask) throw new Error('Current task is no longer available');
+  if (currentTask.threadId !== input.threadId) throw new Error('Current task belongs to a different thread');
+  if (currentTask.ownerCatId && currentTask.ownerCatId !== input.catId) {
+    throw new Error('Current task is owned by another cat');
+  }
+  return currentTask;
+}
+
+function buildCurrentTaskUpdateData(patch: CurrentTaskStatusPatch): { status?: TaskStatus; why?: string } {
+  const updateData: { status?: TaskStatus; why?: string } = {};
+  if (patch.status !== undefined) updateData.status = patch.status;
+  if (patch.summary !== undefined) updateData.why = patch.summary;
+  return updateData;
+}
+
+async function persistCurrentTaskProgress(input: {
+  readonly taskProgressStore?: TaskProgressStore;
+  readonly threadId: string;
+  readonly catId: CatId;
+  readonly invocationId: string;
+  readonly task: TaskItem;
+  readonly patch: CurrentTaskStatusPatch;
+}): Promise<void> {
+  if (!input.taskProgressStore) return;
+  const activeForm = describeCurrentTaskActivity(input.patch);
+  const progressItem: TaskProgressItem = {
+    id: input.task.id,
+    subject: input.task.title,
+    status: toTaskProgressStatus(input.task.status),
+    ...(activeForm ? { activeForm } : {}),
+  };
+  const existingSnapshot = await input.taskProgressStore.getSnapshot(input.threadId, input.catId);
+  await input.taskProgressStore.setSnapshot({
+    threadId: input.threadId,
+    catId: input.catId,
+    tasks: upsertTaskProgressItem(existingSnapshot?.tasks ?? [], progressItem),
+    status: input.task.status === 'done' ? 'completed' : 'running',
+    updatedAt: Date.now(),
+    lastInvocationId: input.invocationId,
+  });
+}
+
+async function updateScopedCurrentTaskStatus(input: {
+  readonly taskStore: ScopedTaskStore;
+  readonly taskProgressStore?: TaskProgressStore;
+  readonly currentTaskId: string;
+  readonly threadId: string;
+  readonly catId: CatId;
+  readonly invocationId: string;
+  readonly patch: CurrentTaskStatusPatch;
+}): Promise<void> {
+  const currentTask = await getScopedCurrentTask(input);
+  const updateData = buildCurrentTaskUpdateData(input.patch);
+  const updatedTask =
+    Object.keys(updateData).length > 0 ? await input.taskStore.update(currentTask.id, updateData) : currentTask;
+  if (!updatedTask) throw new Error('Current task update failed');
+  await persistCurrentTaskProgress({ ...input, task: updatedTask });
+}
+
+async function resolveCatAgentScopedCallbacks(input: {
+  readonly taskStore?: InvocationDeps['taskStore'];
+  readonly taskProgressStore?: TaskProgressStore;
+  readonly thread: Thread | null;
+  readonly threadId: string;
+  readonly catId: CatId;
+  readonly invocationId: string;
+}): Promise<AgentServiceOptions['catAgentScopedCallbacks'] | undefined> {
+  const selectedTaskId = getSelectedTaskId(input.thread);
+  const taskStore = input.taskStore;
+  if (!selectedTaskId || !taskStore) return undefined;
+
+  const selectedTask = await taskStore.get(selectedTaskId);
+  if (!selectedTask) return undefined;
+  if (selectedTask.threadId !== input.threadId) return undefined;
+  if (selectedTask.ownerCatId && selectedTask.ownerCatId !== input.catId) return undefined;
+
+  return {
+    currentTask: {
+      invocationId: input.invocationId,
+      currentTaskId: selectedTask.id,
+      updateCurrentTaskStatus: (patch) =>
+        updateScopedCurrentTaskStatus({
+          taskStore,
+          taskProgressStore: input.taskProgressStore,
+          currentTaskId: selectedTask.id,
+          threadId: input.threadId,
+          catId: input.catId,
+          invocationId: input.invocationId,
+          patch,
+        }),
+    },
+  };
+}
+
 /**
  * Invoke a single cat agent and yield messages.
  *
@@ -951,11 +1090,13 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
     }
 
     // Resolve workingDirectory from thread's projectPath
+    let invocationThread: Thread | null = null;
     let workingDirectory: string | undefined;
     let bootcampWorkspaceError: Error | undefined;
     if (threadStore) {
       try {
         const thread = await preflightRace(Promise.resolve(threadStore.get(threadId)), 'threadStore.get', signal);
+        invocationThread = thread ?? null;
         if (thread?.createdAt) threadCreatedAt = thread.createdAt;
         // #836: Reborn session strategy — force new session every invocation.
         // Uses store lookup (isRebornSession) instead of thread field because
@@ -1608,6 +1749,20 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       }
     }
 
+    let catAgentScopedCallbacks: AgentServiceOptions['catAgentScopedCallbacks'] | undefined;
+    try {
+      catAgentScopedCallbacks = await resolveCatAgentScopedCallbacks({
+        taskStore: deps.taskStore,
+        taskProgressStore: deps.taskProgressStore,
+        thread: invocationThread,
+        threadId,
+        catId,
+        invocationId,
+      });
+    } catch (err) {
+      log.warn({ threadId, catId, invocationId, err }, 'CatAgent scoped callback resolution failed');
+    }
+
     const baseOptions: AgentServiceOptions = {
       callbackEnv,
       ...(accountEnv ? { accountEnv } : {}),
@@ -1622,6 +1777,7 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       ...(params.uploadDir ? { uploadDir: params.uploadDir } : {}),
       ...(signal ? { signal } : {}),
       ...(spawnCliOverride ? { spawnCliOverride } : {}),
+      ...(catAgentScopedCallbacks ? { catAgentScopedCallbacks } : {}),
       invocationId,
       ...(sessionId ? { cliSessionId: sessionId } : {}),
       // F118 Phase B: Enable liveness probe for all CLI providers.

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/CatAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/CatAgentService.ts
@@ -9,6 +9,7 @@
 import type { CatConfig, CatId } from '@cat-cafe/shared';
 import { getCatModel } from '../../../../../../config/cat-models.js';
 import { createModuleLogger } from '../../../../../../infrastructure/logger.js';
+import { AuditEventTypes, getEventAuditLog } from '../../../orchestration/EventAuditLog.js';
 import type { AgentMessage, AgentService, AgentServiceOptions, MessageMetadata, TokenUsage } from '../../../types.js';
 import { mergeTokenUsage } from '../../../types.js';
 import { resolveApiCredentials } from './catagent-credentials.js';
@@ -18,7 +19,12 @@ import { buildToolRegistry, findTool, getToolSchemas } from './catagent-read-too
 import type { CatAgentStreamEvent } from './catagent-stream-parser.js';
 import { parseAnthropicSSE } from './catagent-stream-parser.js';
 import { validateToolInput } from './catagent-tool-guard.js';
-import type { CatAgentTool } from './catagent-tools.js';
+import type {
+  CatAgentTool,
+  CatAgentToolAuditEvent,
+  CatAgentToolAuditSink,
+  CatAgentToolRegistryOptions,
+} from './catagent-tools.js';
 
 const log = createModuleLogger('catagent');
 
@@ -140,7 +146,7 @@ export class CatAgentService implements AgentService {
     options?: AgentServiceOptions,
   ): AsyncIterable<AgentMessage> {
     const workDir = options?.workingDirectory;
-    const tools = workDir ? await buildToolRegistry(workDir) : [];
+    const tools = await buildToolRegistry(workDir, this.createToolRegistryOptions(options));
     const toolSchemas = getToolSchemas(tools);
     const messages: Array<{ role: string; content: unknown }> = [{ role: 'user', content: prompt }];
     let totalUsage: TokenUsage | undefined;
@@ -265,7 +271,10 @@ export class CatAgentService implements AgentService {
 
     // Rebuild content blocks sorted by index (P1: preserve full assistant content)
     const sortedIndices = [...blocksByIndex.keys()].sort((a, b) => a - b);
-    for (const idx of sortedIndices) contentBlocks.push(blocksByIndex.get(idx)!);
+    for (const idx of sortedIndices) {
+      const block = blocksByIndex.get(idx);
+      if (block) contentBlocks.push(block);
+    }
 
     const turnUsage: TokenUsage = { ...inputUsage, outputTokens };
     return { contentBlocks, stopReason, turnUsage, hadStreamError };
@@ -334,6 +343,34 @@ export class CatAgentService implements AgentService {
     _metadata: MessageMetadata,
   ): Promise<CatAgentToolExecResult[]> {
     return executeCatAgentTools(blocks, tools);
+  }
+
+  private createToolRegistryOptions(options?: AgentServiceOptions): CatAgentToolRegistryOptions {
+    return {
+      nativeToolLevel: this.catConfig?.nativeToolLevel,
+      commandPolicy: this.catConfig?.commandPolicy,
+      audit: this.createToolAuditSink(options),
+      scopedCallbacks: options?.catAgentScopedCallbacks,
+    };
+  }
+
+  private createToolAuditSink(options?: AgentServiceOptions): CatAgentToolAuditSink | undefined {
+    const ctx = options?.auditContext;
+    if (!ctx) return undefined;
+    return async (event: CatAgentToolAuditEvent) => {
+      await getEventAuditLog().append({
+        type: AuditEventTypes.CATAGENT_SIDE_EFFECT,
+        threadId: ctx.threadId,
+        data: {
+          invocationId: ctx.invocationId,
+          threadId: ctx.threadId,
+          userId: ctx.userId,
+          catId: ctx.catId,
+          provider: 'catagent',
+          ...event,
+        },
+      });
+    };
   }
 
   private *handleFetchError(

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-read-tools.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-read-tools.ts
@@ -6,18 +6,28 @@
  * - list_files:     list directory contents (resolveSecurePath + isDenylisted filter)
  * - search_content: ripgrep search (buildSafeCommand + denylist exclude + result filter)
  *
- * ADR-001 boundary: no write/edit/delete, no shell/exec, no network tools.
+ * Phase F adds gated side-effect tools:
+ * - L1: write_file / patch_file
+ * - L2: run_command with allowlist-first commandPolicy
+ * - F3-min: update_current_task_status host-native scoped callback
  */
 
 import { execFile } from 'node:child_process';
-import { open, readdir } from 'node:fs/promises';
-import { join } from 'node:path';
+import { createHash, randomUUID } from 'node:crypto';
+import { lstat, mkdir, open, readdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+import { dirname, join, relative } from 'node:path';
 import { promisify } from 'node:util';
 
+import type { CommandPolicyEntry, TaskStatus } from '@cat-cafe/shared';
 import { isDenylisted } from '../../../../../../domains/workspace/workspace-security.js';
 import { buildSafeCommand } from './catagent-tool-guard.js';
-import type { CatAgentTool, ToolSchema } from './catagent-tools.js';
-import { resolveSecurePath } from './catagent-tools.js';
+import type {
+  CatAgentTool,
+  CatAgentToolAuditEvent,
+  CatAgentToolRegistryOptions,
+  ToolSchema,
+} from './catagent-tools.js';
+import { resolveCreatePath, resolveSecurePath } from './catagent-tools.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -27,6 +37,11 @@ const HARD_MAX_BYTES = 32_768;
 /** Max bytes buffered per read_file call — enforced BEFORE line splitting to prevent OOM. */
 const READ_BUDGET_BYTES = 1_048_576; // 1 MiB
 const MAX_SEARCH_RESULTS = 50;
+const MAX_WRITE_BYTES = 256 * 1024;
+const DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
+const COMMAND_MAX_BUFFER = 512 * 1024;
+const LEVEL_RANK = { L0: 0, L1: 1, L2: 2 } as const;
+const TASK_STATUSES = new Set<TaskStatus>(['todo', 'doing', 'blocked', 'done']);
 
 /** Denylist globs for rg pre-filtering (isDenylisted is the authoritative filter) */
 const RG_DENYLIST_GLOBS = ['!.env*', '!*.pem', '!*.key', '!id_rsa*', '!.git', '!secrets'];
@@ -201,15 +216,426 @@ function filterAndTruncate(stdout: string): string {
   return `${lines.slice(0, MAX_SEARCH_RESULTS).join('\n')}\n\n[Truncated: ${MAX_SEARCH_RESULTS}/${lines.length} matches shown.]`;
 }
 
+// ── write_file / patch_file ──
+
+const writeFileSchema: ToolSchema = {
+  name: 'write_file',
+  description: 'Write a UTF-8 file within the workspace using an atomic tmp+rename operation. Max 256 KiB.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string', description: 'Relative path to write' },
+      content: { type: 'string', description: 'Full file content' },
+    },
+    required: ['path', 'content'] as const,
+  },
+};
+
+const patchFileSchema: ToolSchema = {
+  name: 'patch_file',
+  description:
+    'Patch a workspace file by replacing one unique old_text occurrence after expected_hash compare-and-swap.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string', description: 'Relative path to patch' },
+      old_text: { type: 'string', description: 'Text that must match exactly once' },
+      new_text: { type: 'string', description: 'Replacement text' },
+      expected_hash: { type: 'string', description: 'SHA-256 hash or prefix of the current file content' },
+    },
+    required: ['path', 'old_text', 'new_text', 'expected_hash'] as const,
+  },
+};
+
+function hashContent(content: Buffer | string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+function normalizedRel(workDir: string, resolvedPath: string): string {
+  return relative(workDir, resolvedPath).replace(/\\/g, '/');
+}
+
+async function emitAudit(options: CatAgentToolRegistryOptions, event: CatAgentToolAuditEvent): Promise<void> {
+  await options.audit?.(event);
+}
+
+async function rejectWithAudit(
+  options: CatAgentToolRegistryOptions,
+  event: Omit<CatAgentToolAuditEvent, 'outcome' | 'timestamp'>,
+  message: string,
+): Promise<never> {
+  await emitAudit(options, { ...event, outcome: 'rejected', rejectReason: message, timestamp: Date.now() });
+  throw new Error(message);
+}
+
+async function existingFileHash(resolvedPath: string): Promise<string | null> {
+  try {
+    const st = await lstat(resolvedPath);
+    if (st.isSymbolicLink()) throw new Error('Refusing to overwrite symlink path');
+    if (st.isDirectory()) throw new Error('Refusing to overwrite directory path');
+    return hashContent(await readFile(resolvedPath));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+async function writeAtomicUtf8(resolvedPath: string, content: string): Promise<void> {
+  const parent = dirname(resolvedPath);
+  await mkdir(parent, { recursive: true });
+  const tmpPath = join(parent, `.catagent-${process.pid}-${randomUUID()}.tmp`);
+  try {
+    await writeFile(tmpPath, content, { encoding: 'utf-8', flag: 'wx' });
+    await rename(tmpPath, resolvedPath);
+  } catch (err) {
+    await unlink(tmpPath).catch(() => undefined);
+    throw err;
+  }
+}
+
+async function executeWriteFile(
+  input: Record<string, unknown>,
+  workDir: string,
+  options: CatAgentToolRegistryOptions,
+): Promise<string> {
+  const content = input.content as string;
+  const bytes = Buffer.byteLength(content, 'utf-8');
+  if (bytes > MAX_WRITE_BYTES) {
+    await rejectWithAudit(
+      options,
+      { tool: 'write_file', path: input.path as string, bytes },
+      'write_file exceeds 256 KiB',
+    );
+  }
+
+  const resolved = await resolveCreatePath(workDir, input.path as string);
+  const relPath = normalizedRel(workDir, resolved);
+  const hashBefore = await existingFileHash(resolved);
+  await writeAtomicUtf8(resolved, content);
+  const hashAfter = hashContent(content);
+  await emitAudit(options, {
+    tool: 'write_file',
+    outcome: 'ok',
+    timestamp: Date.now(),
+    path: relPath,
+    bytes,
+    hashBefore,
+    hashAfter,
+  });
+  return `Wrote ${bytes} bytes to ${relPath} (sha256:${hashAfter.slice(0, 12)})`;
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle.length === 0) return 0;
+  let count = 0;
+  let idx = haystack.indexOf(needle);
+  while (idx !== -1) {
+    count++;
+    idx = haystack.indexOf(needle, idx + needle.length);
+  }
+  return count;
+}
+
+async function executePatchFile(
+  input: Record<string, unknown>,
+  workDir: string,
+  options: CatAgentToolRegistryOptions,
+): Promise<string> {
+  const resolved = await resolveSecurePath(workDir, input.path as string);
+  const relPath = normalizedRel(workDir, resolved);
+  const oldText = input.old_text as string;
+  const newText = input.new_text as string;
+  const expectedHash = input.expected_hash as string;
+  if (expectedHash.length < 8) {
+    await rejectWithAudit(options, { tool: 'patch_file', path: relPath }, 'expected_hash must be at least 8 hex chars');
+  }
+
+  const before = await readFile(resolved, 'utf-8');
+  const hashBefore = hashContent(before);
+  if (!hashBefore.startsWith(expectedHash)) {
+    await rejectWithAudit(options, { tool: 'patch_file', path: relPath, hashBefore }, 'expected_hash mismatch');
+  }
+  const matches = countOccurrences(before, oldText);
+  if (matches !== 1) {
+    await rejectWithAudit(
+      options,
+      { tool: 'patch_file', path: relPath, hashBefore },
+      `old_text must match exactly once (found ${matches})`,
+    );
+  }
+
+  const after = before.replace(oldText, newText);
+  const hashAfter = hashContent(after);
+  await writeAtomicUtf8(resolved, after);
+  await emitAudit(options, {
+    tool: 'patch_file',
+    outcome: 'ok',
+    timestamp: Date.now(),
+    path: relPath,
+    bytes: Buffer.byteLength(after, 'utf-8'),
+    hashBefore,
+    hashAfter,
+  });
+  return `Patched ${relPath} (sha256:${hashBefore.slice(0, 12)} -> ${hashAfter.slice(0, 12)})`;
+}
+
+// ── run_command ──
+
+const runCommandSchema: ToolSchema = {
+  name: 'run_command',
+  description: 'Run one allowlisted command with structured argv. No shell, cwd locked to workspace.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      binary: { type: 'string', description: 'Command binary exactly matching commandPolicy.binary' },
+      args: { type: 'array', description: 'Argument vector. String command lines are not accepted.' },
+    },
+    required: ['binary', 'args'] as const,
+  },
+};
+
+function compilePolicyPattern(pattern: string): RegExp {
+  try {
+    return new RegExp(pattern);
+  } catch {
+    throw new Error(`Invalid commandPolicy allowedArgPattern: ${pattern}`);
+  }
+}
+
+function isAllowedByPatterns(value: string, patterns: readonly string[] | undefined): boolean {
+  return (patterns ?? []).some((pattern) => compilePolicyPattern(pattern).test(value));
+}
+
+function findCommandPolicyEntry(binary: string, policy: readonly CommandPolicyEntry[] | undefined): CommandPolicyEntry {
+  if (!policy || policy.length === 0) throw new Error('No command policy configured');
+  const entry = policy.find((p) => p.binary === binary);
+  if (!entry) throw new Error(`Command binary "${binary}" is not allowed by command policy`);
+  return entry;
+}
+
+function assertCommandArgsSafe(args: readonly string[], entry: CommandPolicyEntry): void {
+  const denied = new Set(entry.deniedFlags ?? []);
+  for (const arg of args) {
+    if (arg.includes('\0')) throw new Error('Command args must not contain NUL bytes');
+    if (denied.has(arg)) throw new Error(`Command flag "${arg}" is denied by command policy`);
+  }
+}
+
+function assertAllowedSubcommand(args: readonly string[], entry: CommandPolicyEntry): void {
+  const allowedSubcommands = entry.allowedSubcommands ?? [];
+  if (allowedSubcommands.length === 0) return;
+  const subcommand = args[0];
+  if (!subcommand || subcommand.startsWith('-') || !allowedSubcommands.includes(subcommand)) {
+    throw new Error(`Command subcommand "${subcommand ?? '<missing>'}" is not allowed by command policy`);
+  }
+}
+
+function assertAllowedCommandArg(arg: string, index: number, entry: CommandPolicyEntry): void {
+  if (index === 0 && (entry.allowedSubcommands ?? []).includes(arg)) return;
+  if (arg.startsWith('-')) {
+    if (!(entry.allowedFlags ?? []).includes(arg)) {
+      throw new Error(`Command flag "${arg}" is not allowed by command policy`);
+    }
+    return;
+  }
+  if (!isAllowedByPatterns(arg, entry.allowedArgPatterns)) {
+    throw new Error(`Command arg "${arg}" is not allowed by command policy`);
+  }
+}
+
+function validateCommandPolicy(
+  binary: string,
+  args: readonly string[],
+  policy: readonly CommandPolicyEntry[] | undefined,
+): CommandPolicyEntry {
+  const entry = findCommandPolicyEntry(binary, policy);
+  assertCommandArgsSafe(args, entry);
+  assertAllowedSubcommand(args, entry);
+  for (const [index, arg] of args.entries()) {
+    assertAllowedCommandArg(arg, index, entry);
+  }
+  return entry;
+}
+
+function constrainedCommandEnv(): NodeJS.ProcessEnv {
+  return {
+    ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+    ...(process.env.NODE_ENV ? { NODE_ENV: process.env.NODE_ENV } : {}),
+  };
+}
+
+function formatCommandOutput(exitCode: number | null, stdout: string, stderr: string): string {
+  const parts = [`exitCode: ${exitCode ?? 'signal'}`];
+  if (stdout) parts.push('', 'stdout:', stdout.trimEnd());
+  if (stderr) parts.push('', 'stderr:', stderr.trimEnd());
+  return parts.join('\n');
+}
+
+async function resolvePolicyEntry(
+  binary: string,
+  args: readonly string[],
+  options: CatAgentToolRegistryOptions,
+): Promise<CommandPolicyEntry> {
+  try {
+    return validateCommandPolicy(binary, args, options.commandPolicy);
+  } catch (err) {
+    await rejectWithAudit(options, { tool: 'run_command', binary, args }, (err as Error).message);
+    throw err;
+  }
+}
+
+async function executeRunCommand(
+  input: Record<string, unknown>,
+  workDir: string,
+  options: CatAgentToolRegistryOptions,
+): Promise<string> {
+  const binary = input.binary as string;
+  const rawArgs = input.args as unknown[];
+  if (!Array.isArray(rawArgs) || rawArgs.some((arg) => typeof arg !== 'string')) {
+    await rejectWithAudit(options, { tool: 'run_command', binary }, 'run_command args must be an array of strings');
+  }
+  const args = rawArgs as string[];
+  const policyEntry = await resolvePolicyEntry(binary, args, options);
+
+  const startedAt = Date.now();
+  const timeout = options.commandTimeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS;
+  try {
+    const { stdout, stderr } = await execFileAsync(binary, args, {
+      cwd: workDir,
+      timeout,
+      maxBuffer: COMMAND_MAX_BUFFER,
+      env: constrainedCommandEnv(),
+    });
+    await emitAudit(options, {
+      tool: 'run_command',
+      outcome: 'ok',
+      timestamp: Date.now(),
+      binary,
+      args,
+      exitCode: 0,
+      durationMs: Date.now() - startedAt,
+      stdoutBytes: Buffer.byteLength(stdout),
+      stderrBytes: Buffer.byteLength(stderr),
+      policyEntry: policyEntry.binary,
+    });
+    return formatCommandOutput(0, stdout, stderr);
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { stdout?: string; stderr?: string; killed?: boolean; signal?: string };
+    const stdout = e.stdout ?? '';
+    const stderr = e.stderr ?? '';
+    const timedOut = e.killed || e.signal === 'SIGTERM';
+    await emitAudit(options, {
+      tool: 'run_command',
+      outcome: 'error',
+      timestamp: Date.now(),
+      binary,
+      args,
+      exitCode: typeof e.code === 'number' ? e.code : null,
+      durationMs: Date.now() - startedAt,
+      stdoutBytes: Buffer.byteLength(stdout),
+      stderrBytes: Buffer.byteLength(stderr),
+      policyEntry: policyEntry.binary,
+      rejectReason: timedOut ? `timed out after ${timeout}ms` : e.message,
+    });
+    if (timedOut) throw new Error(`Command timed out after ${timeout}ms`);
+    throw new Error(formatCommandOutput(typeof e.code === 'number' ? e.code : null, stdout, stderr));
+  }
+}
+
+// ── update_current_task_status ──
+
+const updateCurrentTaskStatusSchema: ToolSchema = {
+  name: 'update_current_task_status',
+  description: 'Update the current task status/progress/summary. Scoped to the current invocation and current task.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      status: { type: 'string', description: 'Task status: todo, doing, blocked, or done' },
+      progress: { type: 'number', description: 'Progress percentage, 0-100' },
+      summary: { type: 'string', description: 'Short task progress summary' },
+    },
+    required: [] as const,
+  },
+};
+
+async function executeUpdateCurrentTaskStatus(
+  input: Record<string, unknown>,
+  options: CatAgentToolRegistryOptions,
+): Promise<string> {
+  const currentTask = options.scopedCallbacks?.currentTask;
+  if (!currentTask) throw new Error('No current task is bound for this invocation');
+
+  const patch: { status?: TaskStatus; progress?: number; summary?: string } = {};
+  if (input.status !== undefined) {
+    if (!TASK_STATUSES.has(input.status as TaskStatus)) throw new Error(`Unsupported task status "${input.status}"`);
+    patch.status = input.status as TaskStatus;
+  }
+  if (input.progress !== undefined) {
+    const progress = input.progress as number;
+    if (!Number.isFinite(progress) || progress < 0 || progress > 100) {
+      throw new Error('progress must be a finite number between 0 and 100');
+    }
+    patch.progress = progress;
+  }
+  if (input.summary !== undefined) {
+    const summary = (input.summary as string).trim();
+    if (!summary || summary.length > 500) throw new Error('summary must be 1-500 characters');
+    patch.summary = summary;
+  }
+  const changedFields = Object.keys(patch);
+  if (changedFields.length === 0) throw new Error('At least one of status, progress, or summary is required');
+
+  await currentTask.updateCurrentTaskStatus(patch);
+  await emitAudit(options, {
+    tool: 'update_current_task_status',
+    outcome: 'ok',
+    timestamp: Date.now(),
+    invocationId: currentTask.invocationId,
+    currentTaskId: currentTask.currentTaskId,
+    changedFields,
+  });
+  return `Updated current task ${currentTask.currentTaskId}: ${changedFields.join(', ')}`;
+}
+
 // ── Registry ──
 
-export async function buildToolRegistry(workDir: string): Promise<CatAgentTool[]> {
-  const tools: CatAgentTool[] = [
-    { schema: readFileSchema, execute: (i) => executeReadFile(i, workDir), permission: 'allow' },
-    { schema: listFilesSchema, execute: (i) => executeListFiles(i, workDir), permission: 'allow' },
-  ];
-  if (await checkRgAvailable()) {
+function levelAtLeast(level: CatAgentToolRegistryOptions['nativeToolLevel'], required: 'L1' | 'L2'): boolean {
+  return LEVEL_RANK[level ?? 'L0'] >= LEVEL_RANK[required];
+}
+
+export async function buildToolRegistry(
+  workDir?: string,
+  options: CatAgentToolRegistryOptions = {},
+): Promise<CatAgentTool[]> {
+  const tools: CatAgentTool[] = [];
+  if (workDir) {
+    tools.push(
+      { schema: readFileSchema, execute: (i) => executeReadFile(i, workDir), permission: 'allow' },
+      { schema: listFilesSchema, execute: (i) => executeListFiles(i, workDir), permission: 'allow' },
+    );
+  }
+  if (workDir && (await checkRgAvailable())) {
     tools.push({ schema: searchContentSchema, execute: (i) => executeSearchContent(i, workDir), permission: 'allow' });
+  }
+  if (workDir && levelAtLeast(options.nativeToolLevel, 'L1')) {
+    tools.push(
+      { schema: writeFileSchema, execute: (i) => executeWriteFile(i, workDir, options), permission: 'allow' },
+      { schema: patchFileSchema, execute: (i) => executePatchFile(i, workDir, options), permission: 'allow' },
+    );
+  }
+  if (workDir && levelAtLeast(options.nativeToolLevel, 'L2')) {
+    tools.push({
+      schema: runCommandSchema,
+      execute: (i) => executeRunCommand(i, workDir, options),
+      permission: 'allow',
+    });
+  }
+  if (options.scopedCallbacks?.currentTask) {
+    tools.push({
+      schema: updateCurrentTaskStatusSchema,
+      execute: (i) => executeUpdateCurrentTaskStatus(i, options),
+      permission: 'allow',
+    });
   }
   return tools;
 }

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-read-tools.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-read-tools.ts
@@ -39,6 +39,7 @@ const READ_BUDGET_BYTES = 1_048_576; // 1 MiB
 const MAX_SEARCH_RESULTS = 50;
 const MAX_WRITE_BYTES = 256 * 1024;
 const DEFAULT_COMMAND_TIMEOUT_MS = 30_000;
+const DEFAULT_COMMAND_KILL_GRACE_MS = 3_000;
 const COMMAND_MAX_BUFFER = 512 * 1024;
 const LEVEL_RANK = { L0: 0, L1: 1, L2: 2 } as const;
 const TASK_STATUSES = new Set<TaskStatus>(['todo', 'doing', 'blocked', 'done']);
@@ -325,15 +326,28 @@ async function executeWriteFile(
   return `Wrote ${bytes} bytes to ${relPath} (sha256:${hashAfter.slice(0, 12)})`;
 }
 
-function countOccurrences(haystack: string, needle: string): number {
-  if (needle.length === 0) return 0;
+interface TextSpanMatch {
+  start: number;
+  end: number;
+  matches: number;
+}
+
+function findUniqueTextSpan(haystack: string, needle: string): TextSpanMatch {
+  if (needle.length === 0) return { start: -1, end: -1, matches: 0 };
   let count = 0;
+  let first = -1;
   let idx = haystack.indexOf(needle);
   while (idx !== -1) {
     count++;
-    idx = haystack.indexOf(needle, idx + needle.length);
+    if (first === -1) first = idx;
+    if (count > 1) break;
+    idx = haystack.indexOf(needle, idx + 1);
   }
-  return count;
+  return { start: first, end: first + needle.length, matches: count };
+}
+
+function replaceTextSpan(haystack: string, span: TextSpanMatch, replacement: string): string {
+  return `${haystack.slice(0, span.start)}${replacement}${haystack.slice(span.end)}`;
 }
 
 async function executePatchFile(
@@ -355,16 +369,16 @@ async function executePatchFile(
   if (!hashBefore.startsWith(expectedHash)) {
     await rejectWithAudit(options, { tool: 'patch_file', path: relPath, hashBefore }, 'expected_hash mismatch');
   }
-  const matches = countOccurrences(before, oldText);
-  if (matches !== 1) {
+  const span = findUniqueTextSpan(before, oldText);
+  if (span.matches !== 1) {
     await rejectWithAudit(
       options,
       { tool: 'patch_file', path: relPath, hashBefore },
-      `old_text must match exactly once (found ${matches})`,
+      `old_text must match exactly once (found ${span.matches})`,
     );
   }
 
-  const after = before.replace(oldText, newText);
+  const after = replaceTextSpan(before, span, newText);
   const hashAfter = hashContent(after);
   await writeAtomicUtf8(resolved, after);
   await emitAudit(options, {
@@ -471,6 +485,77 @@ function formatCommandOutput(exitCode: number | null, stdout: string, stderr: st
   return parts.join('\n');
 }
 
+interface ExecFileStrictResult {
+  stdout: string;
+  stderr: string;
+}
+
+interface ExecFileStrictError extends Error {
+  code?: number | string | null;
+  signal?: NodeJS.Signals | null;
+  stdout?: string;
+  stderr?: string;
+  timedOut?: boolean;
+}
+
+function execFileWithStrictTimeout(
+  binary: string,
+  args: readonly string[],
+  options: {
+    cwd: string;
+    timeoutMs: number;
+    killGraceMs: number;
+    maxBuffer: number;
+    env: NodeJS.ProcessEnv;
+  },
+): Promise<ExecFileStrictResult> {
+  return new Promise((resolve, reject) => {
+    let timedOut = false;
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    let killHandle: NodeJS.Timeout | undefined;
+    const child = execFile(
+      binary,
+      [...args],
+      {
+        cwd: options.cwd,
+        maxBuffer: options.maxBuffer,
+        env: options.env,
+      },
+      (err, stdout, stderr) => {
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+        if (killHandle) clearTimeout(killHandle);
+        if (err) {
+          const error = err as ExecFileStrictError;
+          error.stdout = String(stdout ?? '');
+          error.stderr = String(stderr ?? '');
+          if (timedOut) error.timedOut = true;
+          reject(error);
+          return;
+        }
+        if (timedOut) {
+          const error = new Error(`Command timed out after ${options.timeoutMs}ms`) as ExecFileStrictError;
+          error.stdout = String(stdout ?? '');
+          error.stderr = String(stderr ?? '');
+          error.timedOut = true;
+          reject(error);
+          return;
+        }
+        resolve({ stdout: String(stdout ?? ''), stderr: String(stderr ?? '') });
+      },
+    );
+
+    timeoutHandle = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+      killHandle = setTimeout(() => {
+        child.kill('SIGKILL');
+      }, options.killGraceMs);
+      killHandle.unref?.();
+    }, options.timeoutMs);
+    timeoutHandle.unref?.();
+  });
+}
+
 async function resolvePolicyEntry(
   binary: string,
   args: readonly string[],
@@ -499,10 +584,12 @@ async function executeRunCommand(
 
   const startedAt = Date.now();
   const timeout = options.commandTimeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS;
+  const killGrace = options.commandKillGraceMs ?? DEFAULT_COMMAND_KILL_GRACE_MS;
   try {
-    const { stdout, stderr } = await execFileAsync(binary, args, {
+    const { stdout, stderr } = await execFileWithStrictTimeout(binary, args, {
       cwd: workDir,
-      timeout,
+      timeoutMs: timeout,
+      killGraceMs: killGrace,
       maxBuffer: COMMAND_MAX_BUFFER,
       env: constrainedCommandEnv(),
     });
@@ -520,10 +607,10 @@ async function executeRunCommand(
     });
     return formatCommandOutput(0, stdout, stderr);
   } catch (err) {
-    const e = err as NodeJS.ErrnoException & { stdout?: string; stderr?: string; killed?: boolean; signal?: string };
+    const e = err as ExecFileStrictError;
     const stdout = e.stdout ?? '';
     const stderr = e.stderr ?? '';
-    const timedOut = e.killed || e.signal === 'SIGTERM';
+    const timedOut = e.timedOut === true;
     await emitAudit(options, {
       tool: 'run_command',
       outcome: 'error',
@@ -535,7 +622,7 @@ async function executeRunCommand(
       stdoutBytes: Buffer.byteLength(stdout),
       stderrBytes: Buffer.byteLength(stderr),
       policyEntry: policyEntry.binary,
-      rejectReason: timedOut ? `timed out after ${timeout}ms` : e.message,
+      rejectReason: timedOut ? `timed out after ${timeout}ms; sent SIGTERM then SIGKILL` : e.message,
     });
     if (timedOut) throw new Error(`Command timed out after ${timeout}ms`);
     throw new Error(formatCommandOutput(typeof e.code === 'number' ? e.code : null, stdout, stderr));

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-tools.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-tools.ts
@@ -4,11 +4,15 @@
  * Thin delegation to shared resolveWorkspacePath (workspace-security.ts).
  * Ensures a single path-validation implementation across all providers.
  *
- * Tool registry (read_file / list_files / search_content) ships in Phase D.
- * ADR-001 F159 boundary: no write/edit/delete, no shell/exec, no network tools.
+ * Tool registry (read_file / list_files / search_content) shipped in Phase D.
+ * Phase F adds gated write/exec tools under nativeToolLevel and commandPolicy.
  */
 
-import { resolveWorkspacePath } from '../../../../../../domains/workspace/workspace-security.js';
+import type { CommandPolicyEntry, NativeToolLevel, TaskStatus } from '@cat-cafe/shared';
+import {
+  resolveWorkspaceCreatePath,
+  resolveWorkspacePath,
+} from '../../../../../../domains/workspace/workspace-security.js';
 
 /** Anthropic tool schema shape (inline to avoid SDK dependency in this slice) */
 export interface ToolSchema {
@@ -27,6 +31,51 @@ export interface CatAgentTool {
   permission: ToolPermission;
 }
 
+export interface CatAgentToolAuditEvent {
+  tool: string;
+  outcome: 'ok' | 'error' | 'rejected';
+  timestamp: number;
+  path?: string;
+  bytes?: number;
+  hashBefore?: string | null;
+  hashAfter?: string;
+  binary?: string;
+  args?: readonly string[];
+  exitCode?: number | null;
+  durationMs?: number;
+  stdoutBytes?: number;
+  stderrBytes?: number;
+  policyEntry?: string;
+  rejectReason?: string;
+  invocationId?: string;
+  currentTaskId?: string;
+  changedFields?: readonly string[];
+}
+
+export type CatAgentToolAuditSink = (event: CatAgentToolAuditEvent) => void | Promise<void>;
+
+export interface CatAgentCurrentTaskCallback {
+  invocationId: string;
+  currentTaskId: string;
+  updateCurrentTaskStatus: (patch: {
+    status?: TaskStatus;
+    progress?: number;
+    summary?: string;
+  }) => void | Promise<void>;
+}
+
+export interface CatAgentScopedCallbacks {
+  currentTask?: CatAgentCurrentTaskCallback;
+}
+
+export interface CatAgentToolRegistryOptions {
+  nativeToolLevel?: NativeToolLevel;
+  commandPolicy?: readonly CommandPolicyEntry[];
+  commandTimeoutMs?: number;
+  audit?: CatAgentToolAuditSink;
+  scopedCallbacks?: CatAgentScopedCallbacks;
+}
+
 /**
  * Resolve and validate a path within the working directory.
  * Pure delegation to resolveWorkspacePath — no error translation,
@@ -34,4 +83,13 @@ export interface CatAgentTool {
  */
 export async function resolveSecurePath(workingDirectory: string, filePath: string): Promise<string> {
   return resolveWorkspacePath(workingDirectory, filePath);
+}
+
+/**
+ * Resolve and validate a path intended for file creation/replacement.
+ * This validates the nearest existing ancestor realpath, closing ENOENT +
+ * symlink-parent escapes before write_file can create a new path.
+ */
+export async function resolveCreatePath(workingDirectory: string, filePath: string): Promise<string> {
+  return resolveWorkspaceCreatePath(workingDirectory, filePath);
 }

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-tools.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-tools.ts
@@ -72,6 +72,7 @@ export interface CatAgentToolRegistryOptions {
   nativeToolLevel?: NativeToolLevel;
   commandPolicy?: readonly CommandPolicyEntry[];
   commandTimeoutMs?: number;
+  commandKillGraceMs?: number;
   audit?: CatAgentToolAuditSink;
   scopedCallbacks?: CatAgentScopedCallbacks;
 }

--- a/packages/api/src/domains/cats/services/orchestration/EventAuditLog.ts
+++ b/packages/api/src/domains/cats/services/orchestration/EventAuditLog.ts
@@ -216,6 +216,8 @@ export const AuditEventTypes = {
   CLI_TOOL_STARTED: 'cli_tool_started',
   /** CLI 工具执行完成（command_execution completed） */
   CLI_TOOL_COMPLETED: 'cli_tool_completed',
+  /** CatAgent native side-effect tool execution/rejection (F159 Phase F) */
+  CATAGENT_SIDE_EFFECT: 'catagent_side_effect',
 
   // === 记忆治理 (Phase 5.0 Step 2a) ===
 

--- a/packages/api/src/domains/cats/services/types.ts
+++ b/packages/api/src/domains/cats/services/types.ts
@@ -3,7 +3,7 @@
  * Agent 服务的共享类型定义
  */
 
-import type { CatId, MessageContent, ReplyPreview } from '@cat-cafe/shared';
+import type { CatId, MessageContent, ReplyPreview, TaskStatus } from '@cat-cafe/shared';
 import type { Span } from '@opentelemetry/api';
 import type { CliDiagnostics } from '../../../utils/cli-diagnostics.js';
 import type { CliSpawnOptions } from '../../../utils/cli-types.js';
@@ -111,6 +111,19 @@ export interface AuditContext {
   threadId: string;
   userId: string;
   catId: CatId;
+}
+
+/** F159 Phase F: scoped host-native callbacks available to CatAgent tools. */
+export interface CatAgentScopedCallbackOptions {
+  currentTask?: {
+    invocationId: string;
+    currentTaskId: string;
+    updateCurrentTaskStatus: (patch: {
+      status?: TaskStatus;
+      progress?: number;
+      summary?: string;
+    }) => void | Promise<void>;
+  };
 }
 
 /**
@@ -259,6 +272,8 @@ export interface AgentServiceOptions {
   signal?: AbortSignal;
   /** Correlation context for audit logging and raw trace linking */
   auditContext?: AuditContext;
+  /** F159 Phase F: host-owned scoped callbacks for CatAgent native tools. */
+  catAgentScopedCallbacks?: CatAgentScopedCallbackOptions;
   /** Static identity prompt (Claude: --append-system-prompt, others: prepend to prompt) */
   systemPrompt?: string;
   /** F089: Override spawnCli with tmux-based spawner (set per-invocation) */

--- a/packages/api/src/domains/workspace/workspace-security.ts
+++ b/packages/api/src/domains/workspace/workspace-security.ts
@@ -9,6 +9,69 @@ const DENYLIST_PATTERNS = [/^\.env/, /\.pem$/, /\.key$/, /^id_rsa/];
 
 const DENYLIST_DIRS = new Set(['.git', 'secrets']);
 
+function assertDenylistAllowed(relPath: string): void {
+  for (const seg of relPath.split(sep)) {
+    if (!seg) continue;
+    if (DENYLIST_DIRS.has(seg)) {
+      throw new WorkspaceSecurityError(`Access denied: ${seg}`, 'DENIED');
+    }
+    for (const pat of DENYLIST_PATTERNS) {
+      if (pat.test(seg)) {
+        throw new WorkspaceSecurityError(`Access denied: ${seg}`, 'DENIED');
+      }
+    }
+  }
+}
+
+function assertInsideRoot(root: string, resolved: string): string {
+  const relFromRoot = relative(root, resolved);
+  if (relFromRoot.startsWith('..') || resolve(root, relFromRoot) !== resolved) {
+    throw new WorkspaceSecurityError('Path outside workspace root', 'TRAVERSAL');
+  }
+  return relFromRoot;
+}
+
+function assertRealPathInside(realRoot: string, real: string): void {
+  if (!real.startsWith(realRoot + sep) && real !== realRoot) {
+    throw new WorkspaceSecurityError('Symlink escapes workspace root', 'TRAVERSAL');
+  }
+}
+
+async function isExistingDirectory(path: string): Promise<boolean> {
+  try {
+    const pathStat = await stat(path);
+    if (!pathStat.isDirectory()) {
+      throw new WorkspaceSecurityError('Parent path is not a directory', 'TRAVERSAL');
+    }
+    return true;
+  } catch (err) {
+    if (err instanceof WorkspaceSecurityError) throw err;
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw err;
+  }
+}
+
+async function findExistingDirectoryAncestor(resolvedRoot: string, initialAncestor: string): Promise<string> {
+  let ancestor = initialAncestor;
+  for (;;) {
+    const relAncestor = assertInsideRoot(resolvedRoot, ancestor);
+    assertDenylistAllowed(relAncestor);
+
+    if (await isExistingDirectory(ancestor)) {
+      return ancestor;
+    }
+
+    if (ancestor === resolvedRoot) {
+      throw new WorkspaceSecurityError('Workspace root does not exist', 'NOT_FOUND');
+    }
+    const parent = dirname(ancestor);
+    if (parent === ancestor) {
+      throw new WorkspaceSecurityError('Path outside workspace root', 'TRAVERSAL');
+    }
+    ancestor = parent;
+  }
+}
+
 /**
  * In-memory registry: worktreeId → absolute root path.
  * Populated when /api/workspace/worktrees lists foreign repos.
@@ -38,23 +101,8 @@ export class WorkspaceSecurityError extends Error {
 export async function resolveWorkspacePath(root: string, userPath: string): Promise<string> {
   const decoded = decodeURIComponent(userPath);
   const resolved = resolve(root, decoded);
-  const relFromRoot = relative(root, resolved);
-
-  if (relFromRoot.startsWith('..') || resolve(root, relFromRoot) !== resolved) {
-    throw new WorkspaceSecurityError('Path outside workspace root', 'TRAVERSAL');
-  }
-
-  const segments = relFromRoot.split(sep);
-  for (const seg of segments) {
-    if (DENYLIST_DIRS.has(seg)) {
-      throw new WorkspaceSecurityError(`Access denied: ${seg}`, 'DENIED');
-    }
-    for (const pat of DENYLIST_PATTERNS) {
-      if (pat.test(seg)) {
-        throw new WorkspaceSecurityError(`Access denied: ${seg}`, 'DENIED');
-      }
-    }
-  }
+  const relFromRoot = assertInsideRoot(root, resolved);
+  assertDenylistAllowed(relFromRoot);
 
   // Symlink escape check: resolve the FULL real path (follows all symlinks
   // in every segment, not just the final one). This catches both
@@ -63,23 +111,12 @@ export async function resolveWorkspacePath(root: string, userPath: string): Prom
   // symlinks (e.g. macOS /tmp → /private/tmp).
   try {
     const [real, realRoot] = await Promise.all([realpath(resolved), realpath(root)]);
-    if (!real.startsWith(realRoot + sep) && real !== realRoot) {
-      throw new WorkspaceSecurityError('Symlink escapes workspace root', 'TRAVERSAL');
-    }
+    assertRealPathInside(realRoot, real);
     // Re-check denylist on the realpath result — a symlink named "safe"
     // pointing to ".env" would pass the pre-realpath check above but the
     // resolved target must still be denied.
     const realRel = relative(realRoot, real);
-    for (const seg of realRel.split(sep)) {
-      if (DENYLIST_DIRS.has(seg)) {
-        throw new WorkspaceSecurityError(`Access denied: ${seg}`, 'DENIED');
-      }
-      for (const pat of DENYLIST_PATTERNS) {
-        if (pat.test(seg)) {
-          throw new WorkspaceSecurityError(`Access denied: ${seg}`, 'DENIED');
-        }
-      }
-    }
+    assertDenylistAllowed(realRel);
   } catch (e) {
     if (e instanceof WorkspaceSecurityError) throw e;
     // ENOENT = file doesn't exist yet; traversal check above covers it
@@ -88,6 +125,29 @@ export async function resolveWorkspacePath(root: string, userPath: string): Prom
     }
   }
 
+  return resolved;
+}
+
+/**
+ * Resolve a path that may be created by a write operation.
+ *
+ * Unlike resolveWorkspacePath(), this validates the nearest existing ancestor
+ * instead of accepting ENOENT after only lexical traversal checks. That closes
+ * the "workspace/safe-link/new.txt" case where "safe-link" is a symlink to a
+ * directory outside the workspace.
+ */
+export async function resolveWorkspaceCreatePath(root: string, userPath: string): Promise<string> {
+  const decoded = decodeURIComponent(userPath);
+  const resolvedRoot = resolve(root);
+  const resolved = resolve(resolvedRoot, decoded);
+  const relFromRoot = assertInsideRoot(resolvedRoot, resolved);
+  assertDenylistAllowed(relFromRoot);
+
+  const realRoot = await realpath(resolvedRoot);
+  const ancestor = await findExistingDirectoryAncestor(resolvedRoot, dirname(resolved));
+  const realAncestor = await realpath(ancestor);
+  assertRealPathInside(realRoot, realAncestor);
+  assertDenylistAllowed(relative(realRoot, realAncestor));
   return resolved;
 }
 

--- a/packages/api/test/catagent-phase-f.test.js
+++ b/packages/api/test/catagent-phase-f.test.js
@@ -1,0 +1,315 @@
+/**
+ * CatAgent Phase F Tests — Write/Exec Tool Surface
+ *
+ * Covers F1/F2/F3-min primitives:
+ * - nativeToolLevel gates L0/L1/L2 tool registration
+ * - resolveCreatePath blocks symlink-parent creation escapes
+ * - write_file / patch_file perform bounded, CAS-protected writes with audit
+ * - run_command uses structured argv + allowlist-first policy + constrained env
+ * - update_current_task_status is a host-native scoped callback tool
+ */
+
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, before, describe, test } from 'node:test';
+
+const { buildToolRegistry, findTool } = await import(
+  '../dist/domains/cats/services/agents/providers/catagent/catagent-read-tools.js'
+);
+const { CatAgentService, executeCatAgentTools } = await import(
+  '../dist/domains/cats/services/agents/providers/catagent/CatAgentService.js'
+);
+const { resolveCreatePath } = await import('../dist/domains/cats/services/agents/providers/catagent/catagent-tools.js');
+const { resetMigrationState } = await import('../dist/config/catalog-accounts.js');
+
+function sha256(text) {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+async function collect(iter) {
+  const msgs = [];
+  for await (const msg of iter) msgs.push(msg);
+  return msgs;
+}
+
+function sseEvent(data) {
+  return `data: ${JSON.stringify(data)}\n\n`;
+}
+
+function sseStream(text) {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text));
+      controller.close();
+    },
+  });
+}
+
+function mockDoneResponse() {
+  return {
+    ok: true,
+    headers: new Headers({ 'content-type': 'text/event-stream' }),
+    body: sseStream(
+      [
+        sseEvent({ type: 'message_start', message: { id: 'msg-f', usage: { input_tokens: 1 } } }),
+        sseEvent({ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } }),
+        sseEvent({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'ok' } }),
+        sseEvent({ type: 'content_block_stop', index: 0 }),
+        sseEvent({ type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { output_tokens: 1 } }),
+        sseEvent({ type: 'message_stop' }),
+      ].join(''),
+    ),
+  };
+}
+
+let tmpDir;
+let outsideDir;
+
+before(() => {
+  tmpDir = join(tmpdir(), `catagent-f-${Date.now()}`);
+  outsideDir = join(tmpdir(), `catagent-f-outside-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+  mkdirSync(outsideDir, { recursive: true });
+  writeFileSync(join(tmpDir, 'existing.txt'), 'alpha beta gamma');
+  writeFileSync(join(tmpDir, 'dupe.txt'), 'same same');
+  mkdirSync(join(tmpDir, '.cat-cafe'), { recursive: true });
+  writeFileSync(join(tmpDir, '.cat-cafe', 'accounts.json'), JSON.stringify({ 'test-ant': { authType: 'api_key' } }));
+  writeFileSync(join(tmpDir, '.cat-cafe', 'credentials.json'), JSON.stringify({ 'test-ant': { apiKey: 'sk-test-f' } }));
+});
+
+after(() => {
+  try {
+    rmSync(tmpDir, { recursive: true, force: true });
+    rmSync(outsideDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+describe('F1: tiered tool registry', () => {
+  test('defaults to L0 read-only tools', async () => {
+    const tools = await buildToolRegistry(tmpDir);
+    assert.ok(findTool(tools, 'read_file'));
+    assert.ok(findTool(tools, 'list_files'));
+    assert.equal(findTool(tools, 'write_file'), undefined);
+    assert.equal(findTool(tools, 'patch_file'), undefined);
+    assert.equal(findTool(tools, 'run_command'), undefined);
+  });
+
+  test('L1 registers write_file and patch_file but not run_command', async () => {
+    const tools = await buildToolRegistry(tmpDir, { nativeToolLevel: 'L1' });
+    assert.ok(findTool(tools, 'write_file'));
+    assert.ok(findTool(tools, 'patch_file'));
+    assert.equal(findTool(tools, 'run_command'), undefined);
+  });
+
+  test('L2 registers run_command and still fails closed with empty policy', async () => {
+    const tools = await buildToolRegistry(tmpDir, { nativeToolLevel: 'L2' });
+    const run = findTool(tools, 'run_command');
+    assert.ok(run);
+    await assert.rejects(() => run.execute({ binary: 'git', args: ['status'] }), /No command policy configured/);
+  });
+
+  test('service sends tool schemas according to nativeToolLevel', async () => {
+    let capturedBody = null;
+    const prevFetch = globalThis.fetch;
+    const prevEnv = process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT;
+    process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = tmpDir;
+    resetMigrationState();
+    globalThis.fetch = async (_url, init) => {
+      capturedBody = JSON.parse(init.body);
+      return mockDoneResponse();
+    };
+    try {
+      const svc = new CatAgentService({
+        catId: 'opus',
+        projectRoot: tmpDir,
+        catConfig: { accountRef: 'test-ant', nativeToolLevel: 'L1' },
+      });
+      await collect(svc.invoke('test', { workingDirectory: tmpDir }));
+    } finally {
+      globalThis.fetch = prevFetch;
+      if (prevEnv !== undefined) process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = prevEnv;
+      else delete process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT;
+      resetMigrationState();
+    }
+
+    const names = capturedBody.tools.map((t) => t.name);
+    assert.ok(names.includes('write_file'));
+    assert.ok(names.includes('patch_file'));
+    assert.ok(!names.includes('run_command'));
+  });
+});
+
+describe('F1: create-safe write and patch tools', () => {
+  test('resolveCreatePath rejects creation through symlink parent escape', async () => {
+    const linkPath = join(tmpDir, 'outside-link');
+    if (!existsSync(linkPath)) symlinkSync(outsideDir, linkPath);
+    await assert.rejects(() => resolveCreatePath(tmpDir, 'outside-link/new.txt'), /Symlink escapes workspace root/);
+  });
+
+  test('write_file writes atomically within workspace and audits hashes', async () => {
+    const audit = [];
+    const tools = await buildToolRegistry(tmpDir, { nativeToolLevel: 'L1', audit: (event) => audit.push(event) });
+    const write = findTool(tools, 'write_file');
+
+    const result = await write.execute({ path: 'created.txt', content: 'created content' });
+
+    assert.equal(readFileSync(join(tmpDir, 'created.txt'), 'utf-8'), 'created content');
+    assert.ok(result.includes('Wrote'));
+    assert.equal(audit.length, 1);
+    assert.equal(audit[0].tool, 'write_file');
+    assert.equal(audit[0].outcome, 'ok');
+    assert.equal(audit[0].path, 'created.txt');
+    assert.equal(audit[0].hashBefore, null);
+    assert.equal(audit[0].hashAfter, sha256('created content'));
+  });
+
+  test('write_file rejects files over 256 KiB', async () => {
+    const tools = await buildToolRegistry(tmpDir, { nativeToolLevel: 'L1' });
+    const write = findTool(tools, 'write_file');
+    await assert.rejects(() => write.execute({ path: 'too-big.txt', content: 'x'.repeat(256 * 1024 + 1) }), /256 KiB/);
+  });
+
+  test('patch_file requires expected_hash and unique old_text', async () => {
+    const audit = [];
+    const tools = await buildToolRegistry(tmpDir, { nativeToolLevel: 'L1', audit: (event) => audit.push(event) });
+    const patch = findTool(tools, 'patch_file');
+
+    await assert.rejects(
+      () => patch.execute({ path: 'existing.txt', old_text: 'alpha', new_text: 'omega', expected_hash: 'deadbeef' }),
+      /expected_hash mismatch/,
+    );
+    await assert.rejects(
+      () =>
+        patch.execute({
+          path: 'dupe.txt',
+          old_text: 'same',
+          new_text: 'once',
+          expected_hash: sha256('same same').slice(0, 12),
+        }),
+      /old_text must match exactly once/,
+    );
+
+    const before = 'alpha beta gamma';
+    const result = await patch.execute({
+      path: 'existing.txt',
+      old_text: 'beta',
+      new_text: 'BETA',
+      expected_hash: sha256(before).slice(0, 12),
+    });
+
+    assert.equal(readFileSync(join(tmpDir, 'existing.txt'), 'utf-8'), 'alpha BETA gamma');
+    assert.ok(result.includes('Patched'));
+    assert.equal(audit.at(-1).tool, 'patch_file');
+    assert.equal(audit.at(-1).hashBefore, sha256(before));
+    assert.equal(audit.at(-1).hashAfter, sha256('alpha BETA gamma'));
+  });
+});
+
+describe('F2: run_command policy', () => {
+  test('runs only policy-allowed structured argv', async () => {
+    const audit = [];
+    const tools = await buildToolRegistry(tmpDir, {
+      nativeToolLevel: 'L2',
+      commandPolicy: [
+        {
+          binary: process.execPath,
+          allowedFlags: ['-e'],
+          allowedArgPatterns: ['^console\\.log\\("ok"\\)$'],
+        },
+      ],
+      audit: (event) => audit.push(event),
+    });
+    const run = findTool(tools, 'run_command');
+
+    const result = await run.execute({ binary: process.execPath, args: ['-e', 'console.log("ok")'] });
+
+    assert.ok(result.includes('exitCode: 0'));
+    assert.ok(result.includes('ok'));
+    assert.equal(audit[0].tool, 'run_command');
+    assert.equal(audit[0].exitCode, 0);
+    await assert.rejects(
+      () => run.execute({ binary: process.execPath, args: ['-e', 'require("fs").readdirSync(".")'] }),
+      /not allowed by command policy/,
+    );
+  });
+
+  test('does not pass HOME to command env', async () => {
+    const tools = await buildToolRegistry(tmpDir, {
+      nativeToolLevel: 'L2',
+      commandPolicy: [{ binary: 'env' }],
+    });
+    const run = findTool(tools, 'run_command');
+
+    const result = await run.execute({ binary: 'env', args: [] });
+
+    assert.ok(result.includes('PATH='));
+    assert.ok(!result.includes('HOME='), 'HOME must not be present');
+  });
+
+  test('kills commands that exceed timeout', async () => {
+    const tools = await buildToolRegistry(tmpDir, {
+      nativeToolLevel: 'L2',
+      commandTimeoutMs: 50,
+      commandPolicy: [
+        {
+          binary: process.execPath,
+          allowedFlags: ['-e'],
+          allowedArgPatterns: ['^setTimeout'],
+        },
+      ],
+    });
+    const run = findTool(tools, 'run_command');
+
+    await assert.rejects(
+      () => run.execute({ binary: process.execPath, args: ['-e', 'setTimeout(() => {}, 500)'] }),
+      /timed out/,
+    );
+  });
+});
+
+describe('F3-min: host-native scoped callback tool', () => {
+  test('does not register update_current_task_status without current task scope', async () => {
+    const tools = await buildToolRegistry(undefined, { nativeToolLevel: 'L1' });
+    assert.equal(findTool(tools, 'update_current_task_status'), undefined);
+  });
+
+  test('updates only current task controlled fields and audits changedFields', async () => {
+    const updates = [];
+    const audit = [];
+    const tools = await buildToolRegistry(undefined, {
+      nativeToolLevel: 'L1',
+      audit: (event) => audit.push(event),
+      scopedCallbacks: {
+        currentTask: {
+          invocationId: 'inv-1',
+          currentTaskId: 'task-1',
+          updateCurrentTaskStatus: async (patch) => {
+            updates.push(patch);
+          },
+        },
+      },
+    });
+    const update = findTool(tools, 'update_current_task_status');
+    assert.ok(update);
+
+    const result = await update.execute({ status: 'doing', progress: 50, summary: 'halfway' });
+    assert.ok(result.includes('Updated current task'));
+    assert.deepEqual(updates, [{ status: 'doing', progress: 50, summary: 'halfway' }]);
+    assert.equal(audit[0].tool, 'update_current_task_status');
+    assert.equal(audit[0].invocationId, 'inv-1');
+    assert.equal(audit[0].currentTaskId, 'task-1');
+    assert.deepEqual(audit[0].changedFields, ['status', 'progress', 'summary']);
+
+    const forbidden = await executeCatAgentTools(
+      [{ id: 'tu-forbidden', type: 'tool_use', name: 'update_current_task_status', input: { taskId: 'other' } }],
+      tools,
+    );
+    assert.equal(forbidden[0].status, 'error');
+    assert.ok(forbidden[0].content.includes('undeclared field "taskId"'));
+  });
+});

--- a/packages/api/test/catagent-phase-f.test.js
+++ b/packages/api/test/catagent-phase-f.test.js
@@ -117,7 +117,9 @@ describe('F1: tiered tool registry', () => {
     let capturedBody = null;
     const prevFetch = globalThis.fetch;
     const prevEnv = process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT;
+    const prevModel = process.env.CAT_OPUS_MODEL;
     process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = tmpDir;
+    process.env.CAT_OPUS_MODEL = 'claude-opus-4-6';
     resetMigrationState();
     globalThis.fetch = async (_url, init) => {
       capturedBody = JSON.parse(init.body);
@@ -134,6 +136,8 @@ describe('F1: tiered tool registry', () => {
       globalThis.fetch = prevFetch;
       if (prevEnv !== undefined) process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = prevEnv;
       else delete process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT;
+      if (prevModel !== undefined) process.env.CAT_OPUS_MODEL = prevModel;
+      else delete process.env.CAT_OPUS_MODEL;
       resetMigrationState();
     }
 
@@ -208,6 +212,39 @@ describe('F1: create-safe write and patch tools', () => {
     assert.equal(audit.at(-1).hashBefore, sha256(before));
     assert.equal(audit.at(-1).hashAfter, sha256('alpha BETA gamma'));
   });
+
+  test('patch_file treats overlapping old_text matches as non-unique', async () => {
+    const tools = await buildToolRegistry(tmpDir, { nativeToolLevel: 'L1' });
+    const patch = findTool(tools, 'patch_file');
+    writeFileSync(join(tmpDir, 'overlap.txt'), 'aaa');
+
+    await assert.rejects(
+      () =>
+        patch.execute({
+          path: 'overlap.txt',
+          old_text: 'aa',
+          new_text: 'X',
+          expected_hash: sha256('aaa').slice(0, 12),
+        }),
+      /old_text must match exactly once \(found 2\)/,
+    );
+  });
+
+  test('patch_file writes replacement text literally when new_text contains dollar sequences', async () => {
+    const tools = await buildToolRegistry(tmpDir, { nativeToolLevel: 'L1' });
+    const patch = findTool(tools, 'patch_file');
+    const replacement = '$$HOME $& $1';
+    writeFileSync(join(tmpDir, 'dollar.txt'), 'alpha');
+
+    await patch.execute({
+      path: 'dollar.txt',
+      old_text: 'alpha',
+      new_text: replacement,
+      expected_hash: sha256('alpha').slice(0, 12),
+    });
+
+    assert.equal(readFileSync(join(tmpDir, 'dollar.txt'), 'utf-8'), replacement);
+  });
 });
 
 describe('F2: run_command policy', () => {
@@ -267,6 +304,31 @@ describe('F2: run_command policy', () => {
 
     await assert.rejects(
       () => run.execute({ binary: process.execPath, args: ['-e', 'setTimeout(() => {}, 500)'] }),
+      /timed out/,
+    );
+  });
+
+  test('kills commands that ignore SIGTERM after the grace window', async () => {
+    const tools = await buildToolRegistry(tmpDir, {
+      nativeToolLevel: 'L2',
+      commandTimeoutMs: 50,
+      commandKillGraceMs: 50,
+      commandPolicy: [
+        {
+          binary: process.execPath,
+          allowedFlags: ['-e'],
+          allowedArgPatterns: ['^process\\.on\\("SIGTERM"'],
+        },
+      ],
+    });
+    const run = findTool(tools, 'run_command');
+
+    await assert.rejects(
+      () =>
+        run.execute({
+          binary: process.execPath,
+          args: ['-e', 'process.on("SIGTERM", () => {}); setInterval(() => {}, 100);'],
+        }),
       /timed out/,
     );
   });

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -326,6 +326,143 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     assert.equal(payload.invocationId, 'inv-1');
   });
 
+  it('passes CatAgent current-task callback only for the explicitly selected task', async () => {
+    const { MemoryTaskProgressStore } = await import(
+      '../dist/domains/cats/services/agents/invocation/MemoryTaskProgressStore.js'
+    );
+    let task = {
+      id: 'task-current',
+      kind: 'work',
+      threadId: 'thread-current-task',
+      subjectKey: null,
+      title: 'Selected task',
+      ownerCatId: 'codex',
+      status: 'todo',
+      why: '',
+      createdBy: 'user',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    const taskStore = {
+      get: async (id) => (id === task.id ? task : null),
+      update: async (id, input) => {
+        if (id !== task.id) return null;
+        task = { ...task, ...input, updatedAt: Date.now() };
+        return task;
+      },
+    };
+    const threadStore = {
+      get: async () => ({
+        id: 'thread-current-task',
+        projectPath: 'default',
+        title: null,
+        createdBy: 'user1',
+        participants: ['codex'],
+        lastActiveAt: Date.now(),
+        createdAt: Date.now(),
+        firstRunQuestState: {
+          v: 1,
+          phase: 'quest-4-task-running',
+          startedAt: Date.now(),
+          selectedTaskId: 'task-current',
+        },
+      }),
+      isRebornSession: async () => false,
+    };
+    const taskProgressStore = new MemoryTaskProgressStore();
+    const deps = { ...makeDeps(), threadStore, taskStore, taskProgressStore };
+    let callbackOptions;
+    const service = {
+      l0CompilerFn: dummyL0CompilerFn,
+      async *invoke(_prompt, options) {
+        callbackOptions = options.catAgentScopedCallbacks;
+        await callbackOptions.currentTask.updateCurrentTaskStatus({
+          status: 'doing',
+          progress: 42,
+          summary: 'Halfway done',
+        });
+        yield { type: 'done', catId: 'codex', timestamp: Date.now() };
+      },
+    };
+
+    await collect(
+      invokeSingleCat(deps, {
+        catId: 'codex',
+        service,
+        prompt: 'test',
+        userId: 'user1',
+        threadId: 'thread-current-task',
+        isLastCat: true,
+      }),
+    );
+
+    assert.equal(callbackOptions.currentTask.currentTaskId, 'task-current');
+    assert.equal(task.status, 'doing');
+    assert.equal(task.why, 'Halfway done');
+    const snapshot = await taskProgressStore.getSnapshot('thread-current-task', 'codex');
+    assert.equal(snapshot.tasks[0].id, 'task-current');
+    assert.equal(snapshot.tasks[0].status, 'in_progress');
+    assert.equal(snapshot.tasks[0].activeForm, 'Halfway done');
+  });
+
+  it('does not pass CatAgent current-task callback for another cat owner', async () => {
+    const taskStore = {
+      get: async () => ({
+        id: 'task-owned-by-gemini',
+        kind: 'work',
+        threadId: 'thread-current-task-owner',
+        subjectKey: null,
+        title: 'Other owner task',
+        ownerCatId: 'gemini',
+        status: 'todo',
+        why: '',
+        createdBy: 'user',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+    };
+    const threadStore = {
+      get: async () => ({
+        id: 'thread-current-task-owner',
+        projectPath: 'default',
+        title: null,
+        createdBy: 'user1',
+        participants: ['codex'],
+        lastActiveAt: Date.now(),
+        createdAt: Date.now(),
+        firstRunQuestState: {
+          v: 1,
+          phase: 'quest-4-task-running',
+          startedAt: Date.now(),
+          selectedTaskId: 'task-owned-by-gemini',
+        },
+      }),
+      isRebornSession: async () => false,
+    };
+    const deps = { ...makeDeps(), threadStore, taskStore };
+    let callbackOptions = 'not-called';
+    const service = {
+      l0CompilerFn: dummyL0CompilerFn,
+      async *invoke(_prompt, options) {
+        callbackOptions = options.catAgentScopedCallbacks;
+        yield { type: 'done', catId: 'codex', timestamp: Date.now() };
+      },
+    };
+
+    await collect(
+      invokeSingleCat(deps, {
+        catId: 'codex',
+        service,
+        prompt: 'test',
+        userId: 'user1',
+        threadId: 'thread-current-task-owner',
+        isLastCat: true,
+      }),
+    );
+
+    assert.equal(callbackOptions, undefined);
+  });
+
   it('persists task progress snapshot with completed status on done even when tasks are not all completed', async () => {
     const { MemoryTaskProgressStore } = await import(
       '../dist/domains/cats/services/agents/invocation/MemoryTaskProgressStore.js'

--- a/packages/shared/src/types/cat-breed.ts
+++ b/packages/shared/src/types/cat-breed.ts
@@ -7,7 +7,7 @@
  * Phase 4-F: 支持多 Variant（多版本猫召唤）
  */
 
-import type { AgyProfileConfig, CatColor, ClientId } from './cat.js';
+import type { AgyProfileConfig, CatColor, ClientId, CommandPolicyEntry, NativeToolLevel } from './cat.js';
 import type { CatId } from './ids.js';
 import type { VoiceConfig } from './tts.js';
 
@@ -85,6 +85,10 @@ export interface CatVariant {
   readonly color?: CatColor;
   /** Per-cat context budget (optional, falls back to defaults) */
   readonly contextBudget?: ContextBudget;
+  /** F159 Phase F: CatAgent native tool level. Omitted = L0. */
+  readonly nativeToolLevel?: NativeToolLevel;
+  /** F159 Phase F: allowlist-first command policy for L2 run_command. */
+  readonly commandPolicy?: readonly CommandPolicyEntry[];
   /** Optional per-variant override for sessionChain; falls back to breed.features.sessionChain. */
   readonly sessionChain?: boolean;
   /** F34: Per-cat TTS voice (optional, falls back to defaults in cat-voices.ts) */

--- a/packages/shared/src/types/cat.ts
+++ b/packages/shared/src/types/cat.ts
@@ -5,7 +5,6 @@
 
 import type { CliConfig, ContextBudget } from './cat-breed.js';
 import type { CatId, SessionId } from './ids.js';
-import { createCatId } from './ids.js';
 import type { VoiceConfig } from './tts.js';
 
 /**
@@ -25,6 +24,19 @@ export type ClientId =
 
 /** @deprecated clowder-ai#340: Use {@link ClientId} instead. Kept as alias for backward compatibility. */
 export type CatProvider = ClientId;
+
+/** F159 Phase F: native CatAgent tool capability tier. */
+export type NativeToolLevel = 'L0' | 'L1' | 'L2';
+
+/** F159 Phase F: allowlist-first command policy for CatAgent run_command. */
+export interface CommandPolicyEntry {
+  readonly binary: string;
+  readonly allowedSubcommands?: readonly string[];
+  readonly allowedFlags?: readonly string[];
+  readonly allowedArgPatterns?: readonly string[];
+  /** Defense-in-depth only; never grants permission by itself. */
+  readonly deniedFlags?: readonly string[];
+}
 
 /**
  * Cat status in the system
@@ -73,6 +85,10 @@ export interface CatConfig {
   readonly agyProfile?: AgyProfileConfig;
   readonly commandArgs?: readonly string[];
   readonly contextBudget?: ContextBudget;
+  /** F159 Phase F: CatAgent native tool level. Omitted = L0. */
+  readonly nativeToolLevel?: NativeToolLevel;
+  /** F159 Phase F: allowlist-first command policy for L2 run_command. */
+  readonly commandPolicy?: readonly CommandPolicyEntry[];
   readonly roleDescription: string;
   readonly personality: string;
   /** F32-b: Which breed this cat belongs to (for frontend grouping) */

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -165,6 +165,8 @@ export type {
   CatState,
   CatStatus,
   ClientId,
+  CommandPolicyEntry,
+  NativeToolLevel,
 } from './cat.js';
 // Cat breed/variant types (Breed+Variant two-layer schema)
 export type {


### PR DESCRIPTION
## Summary

Implements F159 Phase F for CatAgent as an opt-in native provider tool surface:

- Adds `nativeToolLevel` (`L0`/`L1`/`L2`) and `commandPolicy` config support.
- Adds L1 `write_file` / `patch_file` with create-safe workspace path validation, atomic write, CAS hash checks, overlapping-match rejection, and structured side-effect audit.
- Adds L2 `run_command` with structured command input, allowlist-first policy validation, locked workspace cwd, bounded output/env, timeout handling, and SIGTERM/SIGKILL grace cleanup.
- Adds scoped `update_current_task_status` callback wiring only when the host has an explicit selected current task and owner/thread validation passes.
- Updates F159 and ADR-001 docs for the Phase F boundary.

## Why

Phase A-E left CatAgent read-only. Phase F makes the native provider capable of small, scoped work while keeping CLI as the default heavy agent path and keeping side effects behind explicit config, policy, workspace security, and audit boundaries.

## Review Notes

The follow-up commit hardens review findings around `patch_file` replacement semantics and overlapping matches, and makes `run_command` timeout cleanup hold the child handle so SIGKILL is sent after the grace period if SIGTERM is ignored.

## Validation

- `pnpm check`
- API build
- focused `catagent-phase-f` suite
- CatAgent regression tests
- `invoke-single-cat` hot-path tests
- Biome/checks on changed files
- `git diff --check`
