### PR TITLE
F241 Phase B: derive provider transport reserved identities

### DIFF
--- a/docs/features/F241-agent-provider-plugin.md
+++ b/docs/features/F241-agent-provider-plugin.md
@@ -207,6 +207,7 @@ These are no longer blockers for feature-anchor acceptance, but must be settled 
 - Raw `providerTransport` is rejected for builtin client identities and existing routeable cat IDs; the temporary raw surface cannot replace `codex`, `opus`, or other trusted builtin participants.
 - `cli-jsonl` defaults to resumable session behavior when the reference runtime can receive the prompt without lossy encoding. Fresh turns use `startupArgs`; follow-up turns with a host `sessionId` use `resumeArgs` with a required `{sessionId}` placeholder only for raw single-line prompts. If the effective prompt contains real line breaks, the host emits `session_continuity_degraded`, seals the old active SessionRecord, runs a fresh one-shot invocation with the original prompt payload, and binds any fresh `session_init` to a new SessionRecord. A transport that is intentionally stateless must declare `sessionPolicy: "stateless"`.
 - `cli-jsonl` participates in host raw-event archive diagnostics by passing `rawArchivePath` into `spawnCli` and appending sanitized JSONL events by invocation ID.
+- Phase B identity-governance foundation derives reserved routeable IDs from a host-owned base `cat-template.json` builtin baseline plus active non-`providerTransport` profiles. Raw `providerTransport` activation fails closed when that baseline cannot be read, so catalog/plugin input cannot self-remove a trusted cat ID from the reserved set.
 - F202 `agentProvider` manifest parsing/activation is intentionally not part of this first slice.
 
 Temporary raw catalog shape for Phase A smoke activation:
@@ -233,3 +234,4 @@ Temporary raw catalog shape for Phase A smoke activation:
 - 2026-06-18: maintainer decision accepted #941 as F241, with `clowder-code` as the reference runtime, Phase A/B/C rollout, and safety boundaries promoted to acceptance criteria.
 - 2026-06-18: Phase A first implementation slice started with host-owned `ProviderTransportRegistry` and ACP transport factory extraction.
 - 2026-06-18: Phase A second implementation slice started with raw `providerTransport` selection and `cli-jsonl` reference-runtime smoke transport.
+- 2026-06-22: Phase B identity-governance foundation started to replace static routeable denylist drift with template-baseline plus active-catalog reserved identity derivation.

--- a/packages/api/src/config/cat-config-loader.ts
+++ b/packages/api/src/config/cat-config-loader.ts
@@ -579,6 +579,22 @@ export function getAllCatIdsFromConfig(): readonly string[] {
 }
 
 /**
+ * F241 Phase B: host-owned builtin identity baseline.
+ *
+ * Reads the base cat-template.json directly, before .cat-cafe/cat-catalog.json
+ * overlay can inject a raw providerTransport. Callers must treat thrown errors
+ * as fail-closed for providerTransport activation.
+ */
+export function getTemplateBuiltinCatIds(projectRoot?: string): ReadonlySet<string> {
+  const templatePath = projectRoot
+    ? resolveProjectTemplatePath(projectRoot)
+    : (process.env.CAT_TEMPLATE_PATH ?? DEFAULT_CAT_TEMPLATE_PATH);
+  const raw = readTemplate(templatePath);
+  const json = JSON.parse(raw) as { breeds?: BreedWithResolvedCatIds[] };
+  return collectResolvedCatIds(Array.isArray(json.breeds) ? json.breeds : []);
+}
+
+/**
  * Find a breed by checking mention patterns against text.
  * F32-b P4c: Uses longest-match-first to avoid prefix collisions
  * (e.g. `@布偶sonnet` must match Sonnet variant, not breed-level `@布偶`).

--- a/packages/api/src/domains/cats/services/agents/providers/transport/ProviderTransportRegistry.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/transport/ProviderTransportRegistry.ts
@@ -14,6 +14,8 @@ export interface ProviderTransportInput {
   profileId: string;
   config: CatConfig;
   providerTransport?: unknown;
+  reservedRouteableIds?: ReadonlySet<string>;
+  reservedRouteableIdentityError?: string;
 }
 
 export interface ProviderTransportCreateResult {
@@ -55,33 +57,32 @@ const BUILTIN_CLIENT_IDS = new Set([
   'acp',
 ]);
 
-const BUILTIN_ROUTEABLE_IDS = new Set([
-  'opus',
-  'sonnet',
-  'opus-45',
-  'fable-5',
-  'codex',
-  'gpt52',
-  'spark',
-  'gemini',
-  'gemini25',
-  'gemini35',
-  'dare',
-  'antigravity',
-  'antig-opus',
-  'opencode',
-  'kimi',
-  'opus-47',
-]);
+export function deriveReservedProviderTransportIdentities(input: {
+  configs: Readonly<Record<string, CatConfig>>;
+  providerTransportsByProfileId: ReadonlyMap<string, unknown>;
+  templateBuiltinIds: ReadonlySet<string>;
+}): Set<string> {
+  const reserved = new Set<string>(input.templateBuiltinIds);
+  for (const id of Object.keys(input.configs)) {
+    const providerTransport = input.providerTransportsByProfileId.get(id);
+    if (providerTransport === undefined || providerTransport === null) {
+      reserved.add(id);
+    }
+  }
+  return reserved;
+}
 
 function reservedIdentityReason(input: ProviderTransportInput): string | null {
+  if (input.reservedRouteableIdentityError) return 'reserved-routeable-identities-unavailable';
+
   const clientId = String(input.config.clientId ?? '');
   if (BUILTIN_CLIENT_IDS.has(clientId)) return `builtin-client:${clientId}`;
 
+  const reservedRouteableIds = input.reservedRouteableIds;
   const configId = String(input.config.id ?? '');
-  if (BUILTIN_ROUTEABLE_IDS.has(configId)) return `builtin-cat:${configId}`;
+  if (reservedRouteableIds?.has(configId)) return `builtin-cat:${configId}`;
 
-  if (BUILTIN_ROUTEABLE_IDS.has(input.profileId)) return `builtin-profile:${input.profileId}`;
+  if (reservedRouteableIds?.has(input.profileId)) return `builtin-profile:${input.profileId}`;
 
   return null;
 }
@@ -118,30 +119,41 @@ export class ProviderTransportRegistry {
 
   async createServiceForConfig(input: ProviderTransportInput): Promise<ProviderTransportResolution> {
     if (input.providerTransport !== undefined && input.providerTransport !== null) {
-      const transportId = declaredTransportId(input.providerTransport);
-      if (!transportId) {
-        return { handled: true, transportId: 'invalid', service: null, rejectionReason: 'invalid-declaration' };
-      }
-
-      const identityReason = reservedIdentityReason(input);
-      if (identityReason) {
-        return { handled: true, transportId, service: null, rejectionReason: identityReason };
-      }
-
-      const factory = this.factories.get(transportId);
-      if (!factory) {
-        return { handled: true, transportId, service: null, rejectionReason: 'unknown-transport' };
-      }
-
-      const result = await factory.create(input);
-      return {
-        handled: true,
-        transportId,
-        service: result.handled ? (result.service ?? null) : null,
-        ...(!result.handled || !result.service ? { rejectionReason: 'factory-rejected' } : {}),
-      };
+      return this.createServiceForDeclaredTransport(input, input.providerTransport);
     }
 
+    return this.createServiceByFactoryProbe(input);
+  }
+
+  private async createServiceForDeclaredTransport(
+    input: ProviderTransportInput,
+    providerTransport: unknown,
+  ): Promise<ProviderTransportResolution> {
+    const transportId = declaredTransportId(providerTransport);
+    if (!transportId) {
+      return { handled: true, transportId: 'invalid', service: null, rejectionReason: 'invalid-declaration' };
+    }
+
+    const identityReason = reservedIdentityReason(input);
+    if (identityReason) {
+      return { handled: true, transportId, service: null, rejectionReason: identityReason };
+    }
+
+    const factory = this.factories.get(transportId);
+    if (!factory) {
+      return { handled: true, transportId, service: null, rejectionReason: 'unknown-transport' };
+    }
+
+    const result = await factory.create(input);
+    return {
+      handled: true,
+      transportId,
+      service: result.handled ? (result.service ?? null) : null,
+      ...(!result.handled || !result.service ? { rejectionReason: 'factory-rejected' } : {}),
+    };
+  }
+
+  private async createServiceByFactoryProbe(input: ProviderTransportInput): Promise<ProviderTransportResolution> {
     for (const factory of this.factories.values()) {
       const result = await factory.create(input);
       if (!result.handled) continue;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -27,6 +27,7 @@ import {
   getConfigSessionStrategy,
   getDefaultCatId,
   getProviderTransportConfig,
+  getTemplateBuiltinCatIds,
   isCatAvailable,
   toAllCatConfigs,
 } from './config/cat-config-loader.js';
@@ -60,6 +61,7 @@ import {
   warmL0Cache,
 } from './domains/cats/services/agents/providers/l0-compiler.js';
 import {
+  deriveReservedProviderTransportIdentities,
   markActiveProviderTransportProfile,
   ProviderTransportRegistry,
 } from './domains/cats/services/agents/providers/transport/ProviderTransportRegistry.js';
@@ -1173,6 +1175,25 @@ async function main(): Promise<void> {
     clearL0Cache(); // Invalidate stale L0 compilations from previous sync
     const projectRoot = resolveActiveProjectRoot();
     const activeProfileIdsByTransport = new Map<string, Set<string>>();
+    const providerTransportsByProfileId = new Map<string, unknown>();
+    for (const id of Object.keys(configs)) {
+      providerTransportsByProfileId.set(id, getProviderTransportConfig(id, projectRoot));
+    }
+    let reservedRouteableIdentityError: string | undefined;
+    let templateBuiltinIds: ReadonlySet<string> = new Set();
+    try {
+      templateBuiltinIds = getTemplateBuiltinCatIds(projectRoot);
+    } catch (err) {
+      reservedRouteableIdentityError = err instanceof Error ? err.message : String(err);
+      app.log.error({ err }, '[api] Provider transport builtin identity baseline unavailable');
+    }
+    const reservedRouteableIds = reservedRouteableIdentityError
+      ? new Set<string>()
+      : deriveReservedProviderTransportIdentities({
+          configs,
+          providerTransportsByProfileId,
+          templateBuiltinIds,
+        });
     for (const [id, config] of Object.entries(configs)) {
       const catId = config.id;
       // F32-b P1 fix: do NOT pass model here — let constructors resolve via
@@ -1187,7 +1208,9 @@ async function main(): Promise<void> {
         projectRoot,
         profileId: id,
         config,
-        providerTransport: getProviderTransportConfig(id, projectRoot),
+        providerTransport: providerTransportsByProfileId.get(id),
+        reservedRouteableIds,
+        reservedRouteableIdentityError,
       });
       if (providerTransport.handled) {
         if (!providerTransport.service) {

--- a/packages/api/test/cat-config-loader.test.js
+++ b/packages/api/test/cat-config-loader.test.js
@@ -19,6 +19,7 @@ const {
   getCatEffort,
   getAcpConfig,
   getProviderTransportConfig,
+  getTemplateBuiltinCatIds,
   getCatFamily,
   _resetCachedConfig,
 } = await import('../dist/config/cat-config-loader.js');
@@ -1641,5 +1642,48 @@ describe('#772: template breeds must not leak into runtime', () => {
       else process.env.CAT_TEMPLATE_PATH = saved;
       _resetCachedConfig();
     }
+  });
+
+  it('getTemplateBuiltinCatIds reads base template ids before runtime providerTransport overlay', () => {
+    const templateBreed = makeBreed('new-builtin-family', 'future-builtin', ['@future']);
+    templateBreed.variants.push({
+      id: 'future-alt',
+      catId: 'future-alt',
+      clientId: 'anthropic',
+      defaultModel: 'claude-sonnet-4-6',
+      mcpSupport: true,
+      personality: 'future alternate personality',
+    });
+
+    const catalogBreed = makeBreed('new-builtin-family', 'future-builtin', ['@future']);
+    catalogBreed.variants[0].clientId = 'clowder-code';
+    catalogBreed.variants[0].providerTransport = {
+      transport: 'cli-jsonl',
+      command: 'clowder-code',
+    };
+
+    const { projectDir } = setupProjectDir([templateBreed], [catalogBreed]);
+
+    const ids = getTemplateBuiltinCatIds(projectDir);
+
+    assert.equal(ids.has('future-builtin'), true, 'base template builtin remains reserved after PT overlay');
+    assert.equal(ids.has('future-alt'), true, 'variant-level catId is part of the template builtin baseline');
+  });
+
+  it('getTemplateBuiltinCatIds throws when the base template baseline is unavailable', () => {
+    const missingProjectDir = mkdtempSync(join(tmpdir(), 'cat-missing-template-'));
+    assert.throws(
+      () => getTemplateBuiltinCatIds(missingProjectDir),
+      /Failed to read cat-template\.json/,
+      'missing base template must fail closed instead of returning an empty baseline',
+    );
+
+    const corruptProjectDir = mkdtempSync(join(tmpdir(), 'cat-corrupt-template-'));
+    writeFileSync(join(corruptProjectDir, 'cat-template.json'), '{"version": 2,');
+    assert.throws(
+      () => getTemplateBuiltinCatIds(corruptProjectDir),
+      (err) => err instanceof SyntaxError,
+      'corrupt base template JSON must fail closed instead of returning an empty baseline',
+    );
   });
 });

--- a/packages/api/test/provider-transport-registry.test.js
+++ b/packages/api/test/provider-transport-registry.test.js
@@ -6,9 +6,8 @@ import './helpers/setup-cat-registry.js';
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-const { ProviderTransportRegistry, markActiveProviderTransportProfile } = await import(
-  '../dist/domains/cats/services/agents/providers/transport/ProviderTransportRegistry.js'
-);
+const { ProviderTransportRegistry, deriveReservedProviderTransportIdentities, markActiveProviderTransportProfile } =
+  await import('../dist/domains/cats/services/agents/providers/transport/ProviderTransportRegistry.js');
 
 function makeService() {
   return {
@@ -92,12 +91,65 @@ describe('ProviderTransportRegistry', () => {
     const result = await registry.createServiceForConfig({
       ...makeInput('codex'),
       providerTransport: { transport: 'cli-jsonl', command: 'clowder-code' },
+      reservedRouteableIds: new Set(['codex']),
     });
 
     assert.equal(result.handled, true);
     assert.equal(result.transportId, 'cli-jsonl');
     assert.equal(result.service, null);
     assert.equal(result.rejectionReason, 'builtin-cat:codex');
+  });
+
+  it('derives reserved routeable identities from template baseline plus active non-transport cats', () => {
+    const reserved = deriveReservedProviderTransportIdentities({
+      configs: {
+        'template-builtin': { id: 'template-builtin', clientId: 'clowder-code' },
+        'legacy-cat': { id: 'legacy-cat', clientId: 'anthropic' },
+        'external-provider': { id: 'external-provider', clientId: 'clowder-code' },
+      },
+      providerTransportsByProfileId: new Map([
+        ['template-builtin', { transport: 'cli-jsonl' }],
+        ['external-provider', { transport: 'cli-jsonl' }],
+      ]),
+      templateBuiltinIds: new Set(['template-builtin']),
+    });
+
+    assert.equal(reserved.has('template-builtin'), true, 'template builtin stays reserved even after PT injection');
+    assert.equal(reserved.has('legacy-cat'), true, 'active non-PT legacy cats stay reserved');
+    assert.equal(reserved.has('external-provider'), false, 'new external PT profiles remain activatable');
+  });
+
+  it('rejects self-hijack when a template builtin gains providerTransport and non-builtin clientId', async () => {
+    const registry = new ProviderTransportRegistry();
+    registry.register({ id: 'cli-jsonl', create: async () => ({ handled: true, service: makeService() }) });
+
+    const result = await registry.createServiceForConfig({
+      ...makeInput('future-builtin'),
+      config: { id: 'future-builtin', clientId: 'clowder-code' },
+      providerTransport: { transport: 'cli-jsonl', command: 'clowder-code' },
+      reservedRouteableIds: new Set(['future-builtin']),
+    });
+
+    assert.equal(result.handled, true);
+    assert.equal(result.transportId, 'cli-jsonl');
+    assert.equal(result.service, null);
+    assert.equal(result.rejectionReason, 'builtin-cat:future-builtin');
+  });
+
+  it('rejects explicit providerTransport declarations when reserved identity baseline is unavailable', async () => {
+    const registry = new ProviderTransportRegistry();
+    registry.register({ id: 'cli-jsonl', create: async () => ({ handled: true, service: makeService() }) });
+
+    const result = await registry.createServiceForConfig({
+      ...makeInput('external-provider'),
+      providerTransport: { transport: 'cli-jsonl', command: 'clowder-code' },
+      reservedRouteableIdentityError: 'template-baseline-unavailable',
+    });
+
+    assert.equal(result.handled, true);
+    assert.equal(result.transportId, 'cli-jsonl');
+    assert.equal(result.service, null);
+    assert.equal(result.rejectionReason, 'reserved-routeable-identities-unavailable');
   });
 
   it('returns a handled transport service before caller provider switch fallback', async () => {

--- a/packages/api/test/runtime-worktree-script.test.js
+++ b/packages/api/test/runtime-worktree-script.test.js
@@ -371,6 +371,7 @@ server.listen(3010,'127.0.0.1',()=>setInterval(()=>{},1000));`,
       {
         cwd: projectDir,
         encoding: 'utf8',
+        env: isolatedRuntimeEnv(),
       },
     );
 

--- a/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
+++ b/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
@@ -53,6 +53,11 @@ const emptyAcpFields = {
   acpIdleTtlMinutes: '',
 };
 
+const emptyNativeToolFields = {
+  nativeToolLevel: '' as const,
+  commandPolicyPreset: '' as const,
+};
+
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -447,6 +452,7 @@ describe('HubCatEditor', () => {
       maxMessages: '',
       maxContentLengthPerMsg: '',
       ...emptyVoiceFields,
+      ...emptyAcpFields,
     } as HubCatEditorFormState;
 
     const payload = buildCatPayload(form, null) as Record<string, unknown>;
@@ -485,6 +491,7 @@ describe('HubCatEditor', () => {
       maxMessages: '',
       maxContentLengthPerMsg: '',
       ...emptyVoiceFields,
+      ...emptyAcpFields,
     } as HubCatEditorFormState;
     const existingCat = {
       id: 'runtime-catagent',
@@ -537,6 +544,7 @@ describe('HubCatEditor', () => {
       maxMessages: '',
       maxContentLengthPerMsg: '',
       ...emptyVoiceFields,
+      ...emptyAcpFields,
     } as HubCatEditorFormState;
     const existingCat = {
       id: 'runtime-catagent',
@@ -605,6 +613,7 @@ describe('HubCatEditor', () => {
       maxMessages: '',
       maxContentLengthPerMsg: '',
       ...emptyVoiceFields,
+      ...emptyNativeToolFields,
       acpEnabled: true,
       acpTransport: 'stdio',
       acpCommand: 'opencode',
@@ -650,6 +659,7 @@ describe('HubCatEditor', () => {
       maxMessages: '',
       maxContentLengthPerMsg: '',
       ...emptyVoiceFields,
+      ...emptyNativeToolFields,
       acpEnabled: true,
       acpTransport: 'stdio',
       acpCommand: 'opencode',
@@ -741,6 +751,7 @@ describe('HubCatEditor', () => {
       maxMessages: '',
       maxContentLengthPerMsg: '',
       ...emptyVoiceFields,
+      ...emptyNativeToolFields,
       acpEnabled: true,
       acpTransport: 'stdio',
       acpCommand: 'deepseek-cli',
@@ -794,6 +805,7 @@ describe('HubCatEditor', () => {
       maxMessages: '',
       maxContentLengthPerMsg: '',
       ...emptyVoiceFields,
+      ...emptyNativeToolFields,
       acpEnabled: true,
       acpTransport: 'stdio',
       acpCommand: 'opencode',
@@ -854,6 +866,7 @@ describe('HubCatEditor', () => {
       maxMessages: '',
       maxContentLengthPerMsg: '',
       ...emptyVoiceFields,
+      ...emptyNativeToolFields,
       acpEnabled: true,
       acpTransport: 'stdio',
       acpCommand: 'kimi',
@@ -912,6 +925,7 @@ describe('HubCatEditor', () => {
       maxMessages: '',
       maxContentLengthPerMsg: '',
       ...emptyVoiceFields,
+      ...emptyNativeToolFields,
       acpEnabled: true,
       acpTransport: 'stdio',
       acpCommand: 'some-acp-agent',


### PR DESCRIPTION
## Summary
- replace the static routeable providerTransport denylist with derived reserved identities
- reserve host template builtin cat IDs plus active profiles that do not declare providerTransport
- fail closed when the template builtin baseline cannot be read
- add self-hijack regression coverage for a template builtin mutated to providerTransport plus a non-builtin clientId

## Issue
- Tracks zts212653/clowder-ai#941
- Phase B first identity-governance slice was recorded before PR in issue comment 4767896743

## Verification
- pnpm --filter @cat-cafe/api run build
- pnpm --filter @cat-cafe/api run lint
- pnpm exec biome check changed files --diagnostic-level=error
- pnpm check:features
- focused API tests: cat-config-loader, provider-transport-registry, cli-jsonl-provider-transport, invoke-single-cat: 221 tests, 0 fail

[砚砚/gpt-5.5🐾]