### PR TITLE
F241 Phase B Slice 2a: agentProvider manifest descriptor

### DIFF
--- a/packages/api/src/domains/plugin/PluginRegistry.ts
+++ b/packages/api/src/domains/plugin/PluginRegistry.ts
@@ -147,6 +147,7 @@ export class PluginRegistry {
         path: r.path,
         name: r.name,
         enabled: capEntry?.enabled ?? false,
+        ...(capEntry?.agentProvider?.state ? { agentProviderState: capEntry.agentProvider.state } : {}),
       };
     });
 

--- a/packages/api/src/domains/plugin/PluginResourceActivator.ts
+++ b/packages/api/src/domains/plugin/PluginResourceActivator.ts
@@ -3,6 +3,7 @@ import { realpath, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute, join, relative } from 'node:path';
 import {
+  type AgentProviderCapabilityDescriptor,
   type CapabilitiesConfig,
   type CapabilityEntry,
   type ILimbNode,
@@ -57,6 +58,8 @@ export interface PluginResourceActivatorDeps {
   taskRunner?: ScheduleTaskRunner;
   /** F202 Phase 2: Dependencies injected into schedule factory createTaskSpec */
   scheduleFactoryDeps?: ScheduleFactoryDeps;
+  /** F241 Phase B Slice 2a: host-owned provider transport registry. */
+  providerTransportRegistry?: { has(transportId: string): boolean };
 }
 
 export function withPersistedLimbNodeId<T extends ILimbNode>(node: T, persistedNodeId?: string): T {
@@ -221,6 +224,9 @@ export class PluginResourceActivator {
       case 'schedule':
         await this.activateSchedule(manifest, resource);
         break;
+      case 'agentProvider':
+        await this.activateAgentProvider(manifest, resource);
+        break;
       default:
         throw new Error(`Unsupported resource type: ${resource.type}`);
     }
@@ -239,6 +245,9 @@ export class PluginResourceActivator {
         break;
       case 'schedule':
         await this.deactivateSchedule(manifest, resource);
+        break;
+      case 'agentProvider':
+        await this.deactivateAgentProvider(manifest, resource);
         break;
       default:
         throw new Error(`Unsupported resource type: ${resource.type}`);
@@ -481,12 +490,33 @@ export class PluginResourceActivator {
     }
   }
 
+  private async activateAgentProvider(manifest: PluginManifest, resource: PluginResourceDef): Promise<void> {
+    if (!resource.agentProvider) throw new Error('AgentProvider resource must have an agentProvider descriptor');
+    if (!this.deps.providerTransportRegistry) throw new Error('ProviderTransportRegistry not configured');
+    if (!this.deps.providerTransportRegistry.has(resource.agentProvider.transport)) {
+      throw new Error(`Unknown agentProvider transport '${resource.agentProvider.transport}'`);
+    }
+
+    const agentProvider: AgentProviderCapabilityDescriptor = {
+      ...resource.agentProvider,
+      state: 'transportReady',
+      routeable: false,
+      routeableApproved: false,
+    };
+    await this.upsertCapabilityEntry(manifest, resource, true, undefined, undefined, agentProvider);
+  }
+
+  private async deactivateAgentProvider(manifest: PluginManifest, resource: PluginResourceDef): Promise<void> {
+    await this.removeCapabilityEntry(manifest, resource);
+  }
+
   private async upsertCapabilityEntry(
     manifest: PluginManifest,
     resource: PluginResourceDef,
     enabled: boolean,
     limbNodeId?: string,
     scheduleTaskId?: string,
+    agentProvider?: AgentProviderCapabilityDescriptor,
   ): Promise<CapabilitiesConfig | null> {
     return this.deps.withCapabilityLock(async () => {
       const config = await this.deps.readCapabilities();
@@ -528,14 +558,22 @@ export class PluginResourceActivator {
         if (resource.type === 'mcp') {
           delete existing.limbNodeId;
           delete existing.scheduleTaskId;
+          delete existing.agentProvider;
           existing.mcpServer = this.buildMcpServer(manifest, resource);
         } else if (resource.type === 'schedule') {
           delete existing.mcpServer;
           delete existing.limbNodeId;
+          delete existing.agentProvider;
           if (scheduleTaskId) existing.scheduleTaskId = scheduleTaskId;
+        } else if (resource.type === 'agentProvider') {
+          delete existing.mcpServer;
+          delete existing.limbNodeId;
+          delete existing.scheduleTaskId;
+          if (agentProvider) existing.agentProvider = agentProvider;
         } else {
           delete existing.mcpServer;
           delete existing.scheduleTaskId;
+          delete existing.agentProvider;
           if (resource.type === 'limb' && limbNodeId !== undefined) {
             existing.limbNodeId = limbNodeId;
           } else {
@@ -553,6 +591,7 @@ export class PluginResourceActivator {
           pluginId: manifest.id,
           ...(limbNodeId ? { limbNodeId } : {}),
           ...(scheduleTaskId ? { scheduleTaskId } : {}),
+          ...(agentProvider ? { agentProvider } : {}),
         };
 
         if (resource.type === 'mcp') {

--- a/packages/api/src/domains/plugin/agent-provider-manifest.ts
+++ b/packages/api/src/domains/plugin/agent-provider-manifest.ts
@@ -1,0 +1,186 @@
+import type { PluginResourceDef } from '@cat-cafe/shared';
+
+const AGENT_PROVIDER_TRANSPORTS = new Set(['acp', 'cli-jsonl']);
+const AGENT_PROVIDER_SESSION_POLICIES = new Set(['resume', 'stateless']);
+const AGENT_PROVIDER_OUTPUT_PROFILES = new Set(['clowder-code-turn-result-v1']);
+const AGENT_PROVIDER_SANDBOX_REQUESTS = new Set(['workspace-read', 'workspace-write']);
+const AGENT_PROVIDER_HEALTH_CHECK_TYPES = new Set(['acpInitialize', 'cliProbe']);
+
+type AgentProviderResource = NonNullable<PluginResourceDef['agentProvider']>;
+
+function requireNonBlankString(value: unknown, fieldName: string, yamlPath: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`AgentProvider resource in ${yamlPath} must have a non-empty '${fieldName}' field`);
+  }
+  return value.trim();
+}
+
+function parseStringArrayField(value: unknown, fieldName: string, yamlPath: string): string[] {
+  if (!Array.isArray(value) || !value.every((arg) => typeof arg === 'string' && arg.length > 0)) {
+    throw new Error(`Invalid agentProvider ${fieldName} in ${yamlPath}: must be an array of non-empty strings`);
+  }
+  return value as string[];
+}
+
+function parseOptionalStringArrayField(value: unknown, fieldName: string, yamlPath: string): string[] | undefined {
+  if (value === undefined) return undefined;
+  return parseStringArrayField(value, fieldName, yamlPath);
+}
+
+function parseAgentProviderHealthCheck(
+  value: unknown,
+  yamlPath: string,
+): AgentProviderResource['healthCheck'] | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`Invalid agentProvider healthCheck in ${yamlPath}: must be an object`);
+  }
+  const rawType = (value as Record<string, unknown>).type;
+  if (typeof rawType !== 'string' || !AGENT_PROVIDER_HEALTH_CHECK_TYPES.has(rawType)) {
+    throw new Error(`Invalid agentProvider healthCheck.type in ${yamlPath}: must be 'acpInitialize' or 'cliProbe'`);
+  }
+  return { type: rawType as NonNullable<AgentProviderResource['healthCheck']>['type'] };
+}
+
+function parseAgentProviderTransport(
+  raw: Record<string, unknown>,
+  yamlPath: string,
+): AgentProviderResource['transport'] {
+  const transport = requireNonBlankString(raw.transport, 'transport', yamlPath);
+  if (!AGENT_PROVIDER_TRANSPORTS.has(transport)) {
+    throw new Error(`Invalid agentProvider transport '${transport}' in ${yamlPath}`);
+  }
+  return transport as AgentProviderResource['transport'];
+}
+
+function parseAgentProviderSessionPolicy(
+  value: unknown,
+  yamlPath: string,
+): AgentProviderResource['sessionPolicy'] | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || !AGENT_PROVIDER_SESSION_POLICIES.has(value)) {
+    throw new Error(`Invalid agentProvider sessionPolicy in ${yamlPath}: must be 'resume' or 'stateless'`);
+  }
+  return value as AgentProviderResource['sessionPolicy'];
+}
+
+function parseAgentProviderOutputProfile(
+  value: unknown,
+  yamlPath: string,
+): AgentProviderResource['outputProfile'] | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || !AGENT_PROVIDER_OUTPUT_PROFILES.has(value)) {
+    throw new Error(`Invalid agentProvider outputProfile in ${yamlPath}: must be 'clowder-code-turn-result-v1'`);
+  }
+  return value as AgentProviderResource['outputProfile'];
+}
+
+function parseAgentProviderSessionFields(
+  raw: Record<string, unknown>,
+  transport: AgentProviderResource['transport'],
+  yamlPath: string,
+): Pick<AgentProviderResource, 'resumeArgs' | 'sessionPolicy' | 'outputProfile'> {
+  const resumeArgs = parseOptionalStringArrayField(raw.resumeArgs, 'resumeArgs', yamlPath);
+  const sessionPolicy = parseAgentProviderSessionPolicy(raw.sessionPolicy, yamlPath);
+  const outputProfile = parseAgentProviderOutputProfile(raw.outputProfile, yamlPath);
+  if (transport === 'cli-jsonl') {
+    return validateCliJsonlSessionFields(resumeArgs, sessionPolicy, outputProfile, yamlPath);
+  }
+  rejectAcpCliJsonlOnlyFields(resumeArgs, sessionPolicy, outputProfile, yamlPath);
+  return {};
+}
+
+function validateCliJsonlSessionFields(
+  resumeArgs: string[] | undefined,
+  sessionPolicy: AgentProviderResource['sessionPolicy'],
+  outputProfile: AgentProviderResource['outputProfile'],
+  yamlPath: string,
+): Pick<AgentProviderResource, 'resumeArgs' | 'sessionPolicy' | 'outputProfile'> {
+  if (!sessionPolicy) {
+    throw new Error(`AgentProvider cli-jsonl resource in ${yamlPath} must have a 'sessionPolicy' field`);
+  }
+  if (!outputProfile) {
+    throw new Error(`AgentProvider cli-jsonl resource in ${yamlPath} must have an 'outputProfile' field`);
+  }
+  if (sessionPolicy === 'resume' && !resumeArgs?.some((arg) => arg.includes('{sessionId}'))) {
+    throw new Error(`AgentProvider cli-jsonl resumeArgs in ${yamlPath} must include '{sessionId}'`);
+  }
+  return {
+    ...(resumeArgs ? { resumeArgs } : {}),
+    sessionPolicy,
+    outputProfile,
+  };
+}
+
+function rejectAcpCliJsonlOnlyFields(
+  resumeArgs: string[] | undefined,
+  sessionPolicy: AgentProviderResource['sessionPolicy'],
+  outputProfile: AgentProviderResource['outputProfile'],
+  yamlPath: string,
+): void {
+  if (resumeArgs !== undefined || sessionPolicy !== undefined || outputProfile !== undefined) {
+    throw new Error(`AgentProvider acp resource in ${yamlPath} must not declare cli-jsonl-only fields`);
+  }
+}
+
+function parseAgentProviderTimeoutMs(value: unknown, yamlPath: string): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+    throw new Error(`Invalid agentProvider timeoutMs in ${yamlPath}: must be a non-negative integer`);
+  }
+  return value;
+}
+
+function parseAgentProviderMcpWhitelistRequest(value: unknown, yamlPath: string): string[] | undefined {
+  if (value === undefined) return undefined;
+  const mcpWhitelistRequest = parseStringArrayField(value, 'mcpWhitelist', yamlPath);
+  if (new Set(mcpWhitelistRequest).size !== mcpWhitelistRequest.length) {
+    throw new Error(`Invalid agentProvider mcpWhitelist in ${yamlPath}: duplicate entries are not allowed`);
+  }
+  return mcpWhitelistRequest;
+}
+
+function parseAgentProviderSandboxRequest(
+  value: unknown,
+  yamlPath: string,
+): AgentProviderResource['sandboxRequest'] | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || !AGENT_PROVIDER_SANDBOX_REQUESTS.has(value)) {
+    throw new Error(`Invalid agentProvider sandbox in ${yamlPath}: must be 'workspace-read' or 'workspace-write'`);
+  }
+  return value as AgentProviderResource['sandboxRequest'];
+}
+
+export function parseAgentProviderResource(
+  raw: Record<string, unknown>,
+  name: string | undefined,
+  yamlPath: string,
+): AgentProviderResource {
+  if (!name || name.trim().length === 0) {
+    throw new Error(`AgentProvider resource in ${yamlPath} must have a 'name' field`);
+  }
+  if (/[/\\]/.test(name)) {
+    throw new Error(`AgentProvider resource name '${name}' in ${yamlPath} must not contain path separators (/ or \\)`);
+  }
+
+  const transport = parseAgentProviderTransport(raw, yamlPath);
+  const command = requireNonBlankString(raw.command, 'command', yamlPath);
+  const startupArgs = parseStringArrayField(raw.startupArgs, 'startupArgs', yamlPath);
+  const sessionFields = parseAgentProviderSessionFields(raw, transport, yamlPath);
+  const timeoutMs = parseAgentProviderTimeoutMs(raw.timeoutMs, yamlPath);
+  const mcpWhitelistRequest = parseAgentProviderMcpWhitelistRequest(raw.mcpWhitelist, yamlPath);
+  const sandboxRequest = parseAgentProviderSandboxRequest(raw.sandbox, yamlPath);
+  const healthCheck = parseAgentProviderHealthCheck(raw.healthCheck, yamlPath);
+
+  return {
+    name,
+    transport,
+    command,
+    startupArgs,
+    ...sessionFields,
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    ...(mcpWhitelistRequest ? { mcpWhitelistRequest } : {}),
+    ...(sandboxRequest ? { sandboxRequest } : {}),
+    ...(healthCheck ? { healthCheck } : {}),
+  };
+}

--- a/packages/api/src/domains/plugin/plugin-manifest.ts
+++ b/packages/api/src/domains/plugin/plugin-manifest.ts
@@ -19,8 +19,15 @@ const SYSTEM_ENV_DENYLIST_PREFIXES = [
 
 const SYSTEM_ENV_DENYLIST_EXACT = new Set(['NODE_OPTIONS', 'NODE_ENV', 'PATH', 'HOME', 'SHELL', 'PORT']);
 
-const SUPPORTED_RESOURCE_TYPES = new Set(['skill', 'mcp', 'limb', 'schedule']);
+const SUPPORTED_RESOURCE_TYPES = new Set(['skill', 'mcp', 'limb', 'schedule', 'agentProvider']);
 const DEFERRED_RESOURCE_TYPES = new Set<string>();
+const AGENT_PROVIDER_TRANSPORTS = new Set(['acp', 'cli-jsonl']);
+const AGENT_PROVIDER_SESSION_POLICIES = new Set(['resume', 'stateless']);
+const AGENT_PROVIDER_OUTPUT_PROFILES = new Set(['clowder-code-turn-result-v1']);
+const AGENT_PROVIDER_SANDBOX_REQUESTS = new Set(['workspace-read', 'workspace-write']);
+const AGENT_PROVIDER_HEALTH_CHECK_TYPES = new Set(['acpInitialize', 'cliProbe']);
+
+type AgentProviderResource = NonNullable<PluginResourceDef['agentProvider']>;
 
 export const BUILTIN_PLUGIN_IDS = new Set<string>();
 
@@ -37,6 +44,183 @@ function isSystemEnv(envName: string): boolean {
 
 function isUnsafeResourcePath(path: string): boolean {
   return posix.isAbsolute(path) || win32.isAbsolute(path) || path.split(/[\\/]+/).includes('..');
+}
+
+function requireNonBlankString(value: unknown, fieldName: string, yamlPath: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`AgentProvider resource in ${yamlPath} must have a non-empty '${fieldName}' field`);
+  }
+  return value.trim();
+}
+
+function parseStringArrayField(value: unknown, fieldName: string, yamlPath: string): string[] {
+  if (!Array.isArray(value) || !value.every((arg) => typeof arg === 'string' && arg.length > 0)) {
+    throw new Error(`Invalid agentProvider ${fieldName} in ${yamlPath}: must be an array of non-empty strings`);
+  }
+  return value as string[];
+}
+
+function parseOptionalStringArrayField(value: unknown, fieldName: string, yamlPath: string): string[] | undefined {
+  if (value === undefined) return undefined;
+  return parseStringArrayField(value, fieldName, yamlPath);
+}
+
+function parseAgentProviderHealthCheck(
+  value: unknown,
+  yamlPath: string,
+): AgentProviderResource['healthCheck'] | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`Invalid agentProvider healthCheck in ${yamlPath}: must be an object`);
+  }
+  const rawType = (value as Record<string, unknown>).type;
+  if (typeof rawType !== 'string' || !AGENT_PROVIDER_HEALTH_CHECK_TYPES.has(rawType)) {
+    throw new Error(`Invalid agentProvider healthCheck.type in ${yamlPath}: must be 'acpInitialize' or 'cliProbe'`);
+  }
+  return { type: rawType as NonNullable<AgentProviderResource['healthCheck']>['type'] };
+}
+
+function parseAgentProviderTransport(
+  raw: Record<string, unknown>,
+  yamlPath: string,
+): AgentProviderResource['transport'] {
+  const transport = requireNonBlankString(raw.transport, 'transport', yamlPath);
+  if (!AGENT_PROVIDER_TRANSPORTS.has(transport)) {
+    throw new Error(`Invalid agentProvider transport '${transport}' in ${yamlPath}`);
+  }
+  return transport as AgentProviderResource['transport'];
+}
+
+function parseAgentProviderSessionPolicy(
+  value: unknown,
+  yamlPath: string,
+): AgentProviderResource['sessionPolicy'] | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || !AGENT_PROVIDER_SESSION_POLICIES.has(value)) {
+    throw new Error(`Invalid agentProvider sessionPolicy in ${yamlPath}: must be 'resume' or 'stateless'`);
+  }
+  return value as AgentProviderResource['sessionPolicy'];
+}
+
+function parseAgentProviderOutputProfile(
+  value: unknown,
+  yamlPath: string,
+): AgentProviderResource['outputProfile'] | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || !AGENT_PROVIDER_OUTPUT_PROFILES.has(value)) {
+    throw new Error(`Invalid agentProvider outputProfile in ${yamlPath}: must be 'clowder-code-turn-result-v1'`);
+  }
+  return value as AgentProviderResource['outputProfile'];
+}
+
+function parseAgentProviderSessionFields(
+  raw: Record<string, unknown>,
+  transport: AgentProviderResource['transport'],
+  yamlPath: string,
+): Pick<AgentProviderResource, 'resumeArgs' | 'sessionPolicy' | 'outputProfile'> {
+  const resumeArgs = parseOptionalStringArrayField(raw.resumeArgs, 'resumeArgs', yamlPath);
+  const sessionPolicy = parseAgentProviderSessionPolicy(raw.sessionPolicy, yamlPath);
+  const outputProfile = parseAgentProviderOutputProfile(raw.outputProfile, yamlPath);
+  if (transport === 'cli-jsonl') {
+    return validateCliJsonlSessionFields(resumeArgs, sessionPolicy, outputProfile, yamlPath);
+  }
+  rejectAcpCliJsonlOnlyFields(resumeArgs, sessionPolicy, outputProfile, yamlPath);
+  return {};
+}
+
+function validateCliJsonlSessionFields(
+  resumeArgs: string[] | undefined,
+  sessionPolicy: AgentProviderResource['sessionPolicy'],
+  outputProfile: AgentProviderResource['outputProfile'],
+  yamlPath: string,
+): Pick<AgentProviderResource, 'resumeArgs' | 'sessionPolicy' | 'outputProfile'> {
+  if (!sessionPolicy) {
+    throw new Error(`AgentProvider cli-jsonl resource in ${yamlPath} must have a 'sessionPolicy' field`);
+  }
+  if (!outputProfile) {
+    throw new Error(`AgentProvider cli-jsonl resource in ${yamlPath} must have an 'outputProfile' field`);
+  }
+  if (sessionPolicy === 'resume' && !resumeArgs?.some((arg) => arg.includes('{sessionId}'))) {
+    throw new Error(`AgentProvider cli-jsonl resumeArgs in ${yamlPath} must include '{sessionId}'`);
+  }
+  return {
+    ...(resumeArgs ? { resumeArgs } : {}),
+    sessionPolicy,
+    outputProfile,
+  };
+}
+
+function rejectAcpCliJsonlOnlyFields(
+  resumeArgs: string[] | undefined,
+  sessionPolicy: AgentProviderResource['sessionPolicy'],
+  outputProfile: AgentProviderResource['outputProfile'],
+  yamlPath: string,
+): void {
+  if (resumeArgs !== undefined || sessionPolicy !== undefined || outputProfile !== undefined) {
+    throw new Error(`AgentProvider acp resource in ${yamlPath} must not declare cli-jsonl-only fields`);
+  }
+}
+
+function parseAgentProviderTimeoutMs(value: unknown, yamlPath: string): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+    throw new Error(`Invalid agentProvider timeoutMs in ${yamlPath}: must be a non-negative integer`);
+  }
+  return value;
+}
+
+function parseAgentProviderMcpWhitelistRequest(value: unknown, yamlPath: string): string[] | undefined {
+  if (value === undefined) return undefined;
+  const mcpWhitelistRequest = parseStringArrayField(value, 'mcpWhitelist', yamlPath);
+  if (new Set(mcpWhitelistRequest).size !== mcpWhitelistRequest.length) {
+    throw new Error(`Invalid agentProvider mcpWhitelist in ${yamlPath}: duplicate entries are not allowed`);
+  }
+  return mcpWhitelistRequest;
+}
+
+function parseAgentProviderSandboxRequest(
+  value: unknown,
+  yamlPath: string,
+): AgentProviderResource['sandboxRequest'] | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || !AGENT_PROVIDER_SANDBOX_REQUESTS.has(value)) {
+    throw new Error(`Invalid agentProvider sandbox in ${yamlPath}: must be 'workspace-read' or 'workspace-write'`);
+  }
+  return value as AgentProviderResource['sandboxRequest'];
+}
+
+function parseAgentProviderResource(
+  raw: Record<string, unknown>,
+  name: string | undefined,
+  yamlPath: string,
+): AgentProviderResource {
+  if (!name || name.trim().length === 0) {
+    throw new Error(`AgentProvider resource in ${yamlPath} must have a 'name' field`);
+  }
+  if (/[/\\]/.test(name)) {
+    throw new Error(`AgentProvider resource name '${name}' in ${yamlPath} must not contain path separators (/ or \\)`);
+  }
+
+  const transport = parseAgentProviderTransport(raw, yamlPath);
+  const command = requireNonBlankString(raw.command, 'command', yamlPath);
+  const startupArgs = parseStringArrayField(raw.startupArgs, 'startupArgs', yamlPath);
+  const sessionFields = parseAgentProviderSessionFields(raw, transport, yamlPath);
+  const timeoutMs = parseAgentProviderTimeoutMs(raw.timeoutMs, yamlPath);
+  const mcpWhitelistRequest = parseAgentProviderMcpWhitelistRequest(raw.mcpWhitelist, yamlPath);
+  const sandboxRequest = parseAgentProviderSandboxRequest(raw.sandbox, yamlPath);
+  const healthCheck = parseAgentProviderHealthCheck(raw.healthCheck, yamlPath);
+
+  return {
+    name,
+    transport,
+    command,
+    startupArgs,
+    ...sessionFields,
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    ...(mcpWhitelistRequest ? { mcpWhitelistRequest } : {}),
+    ...(sandboxRequest ? { sandboxRequest } : {}),
+    ...(healthCheck ? { healthCheck } : {}),
+  };
 }
 
 function envClaimKey(envName: string): string {
@@ -198,6 +382,7 @@ export function parsePluginManifest(yamlPath: string): PluginManifest {
           throw new Error(`Schedule resource name "${name}" in ${yamlPath} must not contain backslashes`);
         }
       }
+      const agentProvider = type === 'agentProvider' ? parseAgentProviderResource(rr, name, yamlPath) : undefined;
 
       // F202 Phase 2 follow-up: parse optional flag for resources
       const optional = rr['optional'] === true;
@@ -205,6 +390,7 @@ export function parsePluginManifest(yamlPath: string): PluginManifest {
       resources.push({
         type: type as PluginResourceDef['type'],
         ...(type === 'schedule' && factoryId ? { factoryId } : {}),
+        ...(agentProvider ? { agentProvider } : {}),
         ...(optional ? { optional } : {}),
         path,
         name,

--- a/packages/api/src/domains/plugin/plugin-manifest.ts
+++ b/packages/api/src/domains/plugin/plugin-manifest.ts
@@ -3,6 +3,7 @@ import { posix, win32 } from 'node:path';
 import type { PluginHealthCheck, PluginManifest, PluginResourceDef, ValueConfigField } from '@cat-cafe/shared';
 import { parse as parseYaml } from 'yaml';
 import { getValueFields, parseConfigFields } from '../../infrastructure/config-field-parser.js';
+import { parseAgentProviderResource } from './agent-provider-manifest.js';
 import { resourceCapId } from './PluginRegistry.js';
 
 const SYSTEM_ENV_DENYLIST_PREFIXES = [
@@ -21,13 +22,6 @@ const SYSTEM_ENV_DENYLIST_EXACT = new Set(['NODE_OPTIONS', 'NODE_ENV', 'PATH', '
 
 const SUPPORTED_RESOURCE_TYPES = new Set(['skill', 'mcp', 'limb', 'schedule', 'agentProvider']);
 const DEFERRED_RESOURCE_TYPES = new Set<string>();
-const AGENT_PROVIDER_TRANSPORTS = new Set(['acp', 'cli-jsonl']);
-const AGENT_PROVIDER_SESSION_POLICIES = new Set(['resume', 'stateless']);
-const AGENT_PROVIDER_OUTPUT_PROFILES = new Set(['clowder-code-turn-result-v1']);
-const AGENT_PROVIDER_SANDBOX_REQUESTS = new Set(['workspace-read', 'workspace-write']);
-const AGENT_PROVIDER_HEALTH_CHECK_TYPES = new Set(['acpInitialize', 'cliProbe']);
-
-type AgentProviderResource = NonNullable<PluginResourceDef['agentProvider']>;
 
 export const BUILTIN_PLUGIN_IDS = new Set<string>();
 
@@ -44,183 +38,6 @@ function isSystemEnv(envName: string): boolean {
 
 function isUnsafeResourcePath(path: string): boolean {
   return posix.isAbsolute(path) || win32.isAbsolute(path) || path.split(/[\\/]+/).includes('..');
-}
-
-function requireNonBlankString(value: unknown, fieldName: string, yamlPath: string): string {
-  if (typeof value !== 'string' || value.trim().length === 0) {
-    throw new Error(`AgentProvider resource in ${yamlPath} must have a non-empty '${fieldName}' field`);
-  }
-  return value.trim();
-}
-
-function parseStringArrayField(value: unknown, fieldName: string, yamlPath: string): string[] {
-  if (!Array.isArray(value) || !value.every((arg) => typeof arg === 'string' && arg.length > 0)) {
-    throw new Error(`Invalid agentProvider ${fieldName} in ${yamlPath}: must be an array of non-empty strings`);
-  }
-  return value as string[];
-}
-
-function parseOptionalStringArrayField(value: unknown, fieldName: string, yamlPath: string): string[] | undefined {
-  if (value === undefined) return undefined;
-  return parseStringArrayField(value, fieldName, yamlPath);
-}
-
-function parseAgentProviderHealthCheck(
-  value: unknown,
-  yamlPath: string,
-): AgentProviderResource['healthCheck'] | undefined {
-  if (value === undefined) return undefined;
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    throw new Error(`Invalid agentProvider healthCheck in ${yamlPath}: must be an object`);
-  }
-  const rawType = (value as Record<string, unknown>).type;
-  if (typeof rawType !== 'string' || !AGENT_PROVIDER_HEALTH_CHECK_TYPES.has(rawType)) {
-    throw new Error(`Invalid agentProvider healthCheck.type in ${yamlPath}: must be 'acpInitialize' or 'cliProbe'`);
-  }
-  return { type: rawType as NonNullable<AgentProviderResource['healthCheck']>['type'] };
-}
-
-function parseAgentProviderTransport(
-  raw: Record<string, unknown>,
-  yamlPath: string,
-): AgentProviderResource['transport'] {
-  const transport = requireNonBlankString(raw.transport, 'transport', yamlPath);
-  if (!AGENT_PROVIDER_TRANSPORTS.has(transport)) {
-    throw new Error(`Invalid agentProvider transport '${transport}' in ${yamlPath}`);
-  }
-  return transport as AgentProviderResource['transport'];
-}
-
-function parseAgentProviderSessionPolicy(
-  value: unknown,
-  yamlPath: string,
-): AgentProviderResource['sessionPolicy'] | undefined {
-  if (value === undefined) return undefined;
-  if (typeof value !== 'string' || !AGENT_PROVIDER_SESSION_POLICIES.has(value)) {
-    throw new Error(`Invalid agentProvider sessionPolicy in ${yamlPath}: must be 'resume' or 'stateless'`);
-  }
-  return value as AgentProviderResource['sessionPolicy'];
-}
-
-function parseAgentProviderOutputProfile(
-  value: unknown,
-  yamlPath: string,
-): AgentProviderResource['outputProfile'] | undefined {
-  if (value === undefined) return undefined;
-  if (typeof value !== 'string' || !AGENT_PROVIDER_OUTPUT_PROFILES.has(value)) {
-    throw new Error(`Invalid agentProvider outputProfile in ${yamlPath}: must be 'clowder-code-turn-result-v1'`);
-  }
-  return value as AgentProviderResource['outputProfile'];
-}
-
-function parseAgentProviderSessionFields(
-  raw: Record<string, unknown>,
-  transport: AgentProviderResource['transport'],
-  yamlPath: string,
-): Pick<AgentProviderResource, 'resumeArgs' | 'sessionPolicy' | 'outputProfile'> {
-  const resumeArgs = parseOptionalStringArrayField(raw.resumeArgs, 'resumeArgs', yamlPath);
-  const sessionPolicy = parseAgentProviderSessionPolicy(raw.sessionPolicy, yamlPath);
-  const outputProfile = parseAgentProviderOutputProfile(raw.outputProfile, yamlPath);
-  if (transport === 'cli-jsonl') {
-    return validateCliJsonlSessionFields(resumeArgs, sessionPolicy, outputProfile, yamlPath);
-  }
-  rejectAcpCliJsonlOnlyFields(resumeArgs, sessionPolicy, outputProfile, yamlPath);
-  return {};
-}
-
-function validateCliJsonlSessionFields(
-  resumeArgs: string[] | undefined,
-  sessionPolicy: AgentProviderResource['sessionPolicy'],
-  outputProfile: AgentProviderResource['outputProfile'],
-  yamlPath: string,
-): Pick<AgentProviderResource, 'resumeArgs' | 'sessionPolicy' | 'outputProfile'> {
-  if (!sessionPolicy) {
-    throw new Error(`AgentProvider cli-jsonl resource in ${yamlPath} must have a 'sessionPolicy' field`);
-  }
-  if (!outputProfile) {
-    throw new Error(`AgentProvider cli-jsonl resource in ${yamlPath} must have an 'outputProfile' field`);
-  }
-  if (sessionPolicy === 'resume' && !resumeArgs?.some((arg) => arg.includes('{sessionId}'))) {
-    throw new Error(`AgentProvider cli-jsonl resumeArgs in ${yamlPath} must include '{sessionId}'`);
-  }
-  return {
-    ...(resumeArgs ? { resumeArgs } : {}),
-    sessionPolicy,
-    outputProfile,
-  };
-}
-
-function rejectAcpCliJsonlOnlyFields(
-  resumeArgs: string[] | undefined,
-  sessionPolicy: AgentProviderResource['sessionPolicy'],
-  outputProfile: AgentProviderResource['outputProfile'],
-  yamlPath: string,
-): void {
-  if (resumeArgs !== undefined || sessionPolicy !== undefined || outputProfile !== undefined) {
-    throw new Error(`AgentProvider acp resource in ${yamlPath} must not declare cli-jsonl-only fields`);
-  }
-}
-
-function parseAgentProviderTimeoutMs(value: unknown, yamlPath: string): number | undefined {
-  if (value === undefined) return undefined;
-  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
-    throw new Error(`Invalid agentProvider timeoutMs in ${yamlPath}: must be a non-negative integer`);
-  }
-  return value;
-}
-
-function parseAgentProviderMcpWhitelistRequest(value: unknown, yamlPath: string): string[] | undefined {
-  if (value === undefined) return undefined;
-  const mcpWhitelistRequest = parseStringArrayField(value, 'mcpWhitelist', yamlPath);
-  if (new Set(mcpWhitelistRequest).size !== mcpWhitelistRequest.length) {
-    throw new Error(`Invalid agentProvider mcpWhitelist in ${yamlPath}: duplicate entries are not allowed`);
-  }
-  return mcpWhitelistRequest;
-}
-
-function parseAgentProviderSandboxRequest(
-  value: unknown,
-  yamlPath: string,
-): AgentProviderResource['sandboxRequest'] | undefined {
-  if (value === undefined) return undefined;
-  if (typeof value !== 'string' || !AGENT_PROVIDER_SANDBOX_REQUESTS.has(value)) {
-    throw new Error(`Invalid agentProvider sandbox in ${yamlPath}: must be 'workspace-read' or 'workspace-write'`);
-  }
-  return value as AgentProviderResource['sandboxRequest'];
-}
-
-function parseAgentProviderResource(
-  raw: Record<string, unknown>,
-  name: string | undefined,
-  yamlPath: string,
-): AgentProviderResource {
-  if (!name || name.trim().length === 0) {
-    throw new Error(`AgentProvider resource in ${yamlPath} must have a 'name' field`);
-  }
-  if (/[/\\]/.test(name)) {
-    throw new Error(`AgentProvider resource name '${name}' in ${yamlPath} must not contain path separators (/ or \\)`);
-  }
-
-  const transport = parseAgentProviderTransport(raw, yamlPath);
-  const command = requireNonBlankString(raw.command, 'command', yamlPath);
-  const startupArgs = parseStringArrayField(raw.startupArgs, 'startupArgs', yamlPath);
-  const sessionFields = parseAgentProviderSessionFields(raw, transport, yamlPath);
-  const timeoutMs = parseAgentProviderTimeoutMs(raw.timeoutMs, yamlPath);
-  const mcpWhitelistRequest = parseAgentProviderMcpWhitelistRequest(raw.mcpWhitelist, yamlPath);
-  const sandboxRequest = parseAgentProviderSandboxRequest(raw.sandbox, yamlPath);
-  const healthCheck = parseAgentProviderHealthCheck(raw.healthCheck, yamlPath);
-
-  return {
-    name,
-    transport,
-    command,
-    startupArgs,
-    ...sessionFields,
-    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-    ...(mcpWhitelistRequest ? { mcpWhitelistRequest } : {}),
-    ...(sandboxRequest ? { sandboxRequest } : {}),
-    ...(healthCheck ? { healthCheck } : {}),
-  };
 }
 
 function envClaimKey(envName: string): string {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -2196,6 +2196,7 @@ async function main(): Promise<void> {
       // F202-2B: Mutable deps ref — populated via rehydrateGitHubSchedules after GitHub services created
       scheduleFactoryDeps:
         scheduleFactoryDeps as import('./domains/plugin/ScheduleFactoryRegistry.js').ScheduleFactoryDeps,
+      providerTransportRegistry,
     });
 
     const startupCaps = await readCapabilitiesConfig(resolveActiveProjectRoot());

--- a/packages/api/test/plugin-agent-provider-activate.test.js
+++ b/packages/api/test/plugin-agent-provider-activate.test.js
@@ -1,0 +1,99 @@
+/**
+ * F241 Phase B Slice 2a: agentProvider manifest activation stays non-routeable.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+const { PluginResourceActivator } = await import('../dist/domains/plugin/PluginResourceActivator.js');
+
+function makeAgentProviderResource(overrides = {}) {
+  return {
+    type: 'agentProvider',
+    name: 'clowder-code',
+    agentProvider: {
+      name: 'clowder-code',
+      transport: 'cli-jsonl',
+      command: 'clowder-code',
+      startupArgs: ['--json', '--non-interactive'],
+      resumeArgs: ['resume', '{sessionId}', '--json'],
+      sessionPolicy: 'resume',
+      outputProfile: 'clowder-code-turn-result-v1',
+      mcpWhitelistRequest: ['cat-cafe-collab'],
+      sandboxRequest: 'workspace-write',
+      healthCheck: { type: 'cliProbe' },
+      ...overrides.agentProvider,
+    },
+    ...overrides,
+  };
+}
+
+function makeManifest(resource = makeAgentProviderResource()) {
+  return {
+    id: 'clowder-code',
+    name: 'Clowder Code',
+    version: '1.0.0',
+    builtin: false,
+    config: [],
+    resources: [resource],
+  };
+}
+
+function makeCapabilitiesStore() {
+  let state = null;
+  return {
+    read: async () => state,
+    write: async (next) => {
+      state = structuredClone(next);
+    },
+    get: () => state,
+  };
+}
+
+function makeActivator({ providerTransportRegistry = { has: (transportId) => transportId === 'cli-jsonl' } } = {}) {
+  const capStore = makeCapabilitiesStore();
+  const activator = new PluginResourceActivator({
+    resolveProjectRoot: () => '/tmp/project',
+    pluginsDir: '/tmp/project/plugins',
+    limbRegistry: { register: async () => {}, deregister: () => {} },
+    readCapabilities: capStore.read,
+    writeCapabilities: capStore.write,
+    withCapabilityLock: async (fn) => fn(),
+    providerTransportRegistry,
+  });
+  return { activator, capStore };
+}
+
+describe('PluginResourceActivator - agentProvider resources', () => {
+  it('activates agentProvider as transportReady but not routeable', async () => {
+    const { activator, capStore } = makeActivator();
+
+    const result = await activator.enablePlugin(makeManifest());
+
+    assert.equal(result.status, 'success');
+    assert.equal(result.resources[0].ok, true);
+
+    const entry = capStore.get()?.capabilities[0];
+    assert.ok(entry);
+    assert.equal(entry.type, 'agentProvider');
+    assert.equal(entry.enabled, true);
+    assert.equal(entry.pluginId, 'clowder-code');
+    assert.equal(entry.agentProvider.state, 'transportReady');
+    assert.equal(entry.agentProvider.routeable, false);
+    assert.equal(entry.agentProvider.routeableApproved, false);
+    assert.equal(entry.agentProvider.name, 'clowder-code');
+    assert.equal(entry.agentProvider.transport, 'cli-jsonl');
+    assert.deepEqual(entry.agentProvider.mcpWhitelistRequest, ['cat-cafe-collab']);
+  });
+
+  it('rejects agentProvider activation when host transport is not registered', async () => {
+    const { activator, capStore } = makeActivator({ providerTransportRegistry: { has: () => false } });
+
+    const result = await activator.enablePlugin(makeManifest());
+
+    assert.equal(result.status, 'failed');
+    assert.equal(result.resources[0].ok, false);
+    assert.match(result.resources[0].error ?? '', /Unknown agentProvider transport/);
+    assert.equal(capStore.get(), null);
+  });
+});

--- a/packages/api/test/plugin-manifest-safety.test.js
+++ b/packages/api/test/plugin-manifest-safety.test.js
@@ -303,6 +303,98 @@ describe('parsePluginManifest security', () => {
     assert.equal(manifest.resources[1].type, 'skill');
   });
 
+  it('parses agentProvider as strict non-routeable transport declaration', () => {
+    tmpDir = mkdtempSync(join(os.tmpdir(), 'plugin-test-'));
+    const yamlPath = writeTmpManifest(
+      tmpDir,
+      'clowder-code',
+      [
+        'id: clowder-code',
+        'name: Clowder Code',
+        'version: 1.0.0',
+        'resources:',
+        '  - type: agentProvider',
+        '    name: clowder-code',
+        '    transport: cli-jsonl',
+        '    command: clowder-code',
+        '    startupArgs: ["--json", "--non-interactive"]',
+        '    resumeArgs: ["resume", "{sessionId}", "--json"]',
+        '    sessionPolicy: resume',
+        '    outputProfile: clowder-code-turn-result-v1',
+        '    timeoutMs: 60000',
+        '    mcpWhitelist:',
+        '      - cat-cafe-collab',
+        '    sandbox: workspace-write',
+        '    healthCheck:',
+        '      type: cliProbe',
+      ].join('\n'),
+    );
+
+    const manifest = parsePluginManifest(yamlPath);
+    const resource = manifest.resources[0];
+
+    assert.equal(resource.type, 'agentProvider');
+    assert.equal(resource.name, 'clowder-code');
+    assert.deepEqual(resource.agentProvider, {
+      name: 'clowder-code',
+      transport: 'cli-jsonl',
+      command: 'clowder-code',
+      startupArgs: ['--json', '--non-interactive'],
+      resumeArgs: ['resume', '{sessionId}', '--json'],
+      sessionPolicy: 'resume',
+      outputProfile: 'clowder-code-turn-result-v1',
+      timeoutMs: 60000,
+      mcpWhitelistRequest: ['cat-cafe-collab'],
+      sandboxRequest: 'workspace-write',
+      healthCheck: { type: 'cliProbe' },
+    });
+  });
+
+  it('rejects agentProvider with unknown transport', () => {
+    tmpDir = mkdtempSync(join(os.tmpdir(), 'plugin-test-'));
+    const yamlPath = writeTmpManifest(
+      tmpDir,
+      'bad-provider',
+      [
+        'id: bad-provider',
+        'name: Bad Provider',
+        'version: 1.0.0',
+        'resources:',
+        '  - type: agentProvider',
+        '    name: bad-provider',
+        '    transport: shell',
+        '    command: bad-provider',
+        '    startupArgs: ["--json"]',
+      ].join('\n'),
+    );
+
+    assert.throws(() => parsePluginManifest(yamlPath), /agentProvider transport/);
+  });
+
+  it('rejects agentProvider with negative timeoutMs', () => {
+    tmpDir = mkdtempSync(join(os.tmpdir(), 'plugin-test-'));
+    const yamlPath = writeTmpManifest(
+      tmpDir,
+      'bad-provider',
+      [
+        'id: bad-provider',
+        'name: Bad Provider',
+        'version: 1.0.0',
+        'resources:',
+        '  - type: agentProvider',
+        '    name: bad-provider',
+        '    transport: cli-jsonl',
+        '    command: bad-provider',
+        '    startupArgs: ["--json"]',
+        '    sessionPolicy: stateless',
+        '    outputProfile: clowder-code-turn-result-v1',
+        '    timeoutMs: -1',
+      ].join('\n'),
+    );
+
+    assert.throws(() => parsePluginManifest(yamlPath), /timeoutMs/);
+  });
+
   it('rejects schedule resource without factoryId', () => {
     tmpDir = mkdtempSync(join(os.tmpdir(), 'plugin-test-'));
     const yamlPath = writeTmpManifest(

--- a/packages/api/test/provider-transport-registry.test.js
+++ b/packages/api/test/provider-transport-registry.test.js
@@ -8,6 +8,9 @@ import { describe, it } from 'node:test';
 
 const { ProviderTransportRegistry, deriveReservedProviderTransportIdentities, markActiveProviderTransportProfile } =
   await import('../dist/domains/cats/services/agents/providers/transport/ProviderTransportRegistry.js');
+const { createCliJsonlProviderTransportFactory } = await import(
+  '../dist/domains/cats/services/agents/providers/cli-jsonl/CliJsonlProviderTransportFactory.js'
+);
 
 function makeService() {
   return {
@@ -66,6 +69,25 @@ describe('ProviderTransportRegistry', () => {
     assert.equal(result.handled, true);
     assert.equal(result.transportId, 'invalid');
     assert.equal(result.service, null);
+  });
+
+  it('rejects cli-jsonl providerTransport with negative timeoutMs', async () => {
+    const registry = new ProviderTransportRegistry();
+    registry.register(createCliJsonlProviderTransportFactory({ log: { warn: () => {} } }));
+
+    const result = await registry.createServiceForConfig({
+      ...makeInput('external-provider'),
+      providerTransport: {
+        transport: 'cli-jsonl',
+        command: 'clowder-code',
+        timeoutMs: -1,
+      },
+    });
+
+    assert.equal(result.handled, true);
+    assert.equal(result.transportId, 'cli-jsonl');
+    assert.equal(result.service, null);
+    assert.equal(result.rejectionReason, 'factory-rejected');
   });
 
   it('rejects explicit providerTransport declarations on builtin client identities', async () => {

--- a/packages/shared/src/types/capability.ts
+++ b/packages/shared/src/types/capability.ts
@@ -7,6 +7,7 @@
 
 import type { MarketplaceEcosystem } from './marketplace.js';
 import type { MountRuleEntry, SkillsSyncState } from './mount-rules.js';
+import type { AgentProviderLifecycleState, PluginAgentProviderResource } from './plugin.js';
 
 /** MCP transport type — stdio (default) or remote HTTP (TD104) */
 export type McpTransport = 'stdio' | 'streamableHttp';
@@ -45,12 +46,18 @@ export interface CatCapabilityOverride {
   enabled: boolean;
 }
 
+export interface AgentProviderCapabilityDescriptor extends PluginAgentProviderResource {
+  state: AgentProviderLifecycleState;
+  routeable: false;
+  routeableApproved: false;
+}
+
 /** Single capability entry in capabilities.json */
 export interface CapabilityEntry {
   /** Unique capability ID (usually MCP server name) */
   id: string;
   /** Type of capability (F126: 'limb' for device/hardware nodes; F202 Phase 2: 'schedule' for plugin-managed tasks) */
-  type: 'mcp' | 'skill' | 'limb' | 'schedule';
+  type: 'mcp' | 'skill' | 'limb' | 'schedule' | 'agentProvider';
   /** Global enabled state (MCP/limb/schedule still use this; skill uses globalEnabled) */
   enabled: boolean;
   /**
@@ -84,6 +91,8 @@ export interface CapabilityEntry {
   limbNodeId?: string;
   /** F202 Phase 2: Runtime task ID assigned by TaskRunnerV2 (schedule resources only) */
   scheduleTaskId?: string;
+  /** F241 Phase B Slice 2a: non-routeable agent provider descriptor. */
+  agentProvider?: AgentProviderCapabilityDescriptor;
 }
 
 /** Sanitized MCP server details included in the capability board payload. */

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -137,6 +137,7 @@ export {
 export type { CallbackPrincipal } from './callback-principal.js';
 // Capability types (F041 统一能力模型)
 export type {
+  AgentProviderCapabilityDescriptor,
   BootstrapAction,
   BootstrapReport,
   CapabilitiesConfig,
@@ -573,6 +574,14 @@ export type {
 } from './pack.js';
 // Plugin Framework types (F202 声明式插件注册)
 export type {
+  AgentProviderHealthCheckRequest,
+  AgentProviderHealthCheckType,
+  AgentProviderLifecycleState,
+  AgentProviderOutputProfile,
+  AgentProviderSandboxRequest,
+  AgentProviderSessionPolicy,
+  AgentProviderTransportId,
+  PluginAgentProviderResource,
   PluginConfigField,
   PluginHealthCheck,
   PluginInfo,

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -19,13 +19,42 @@ export interface PluginHealthCheck {
   mcpProbe?: string;
 }
 
+export type AgentProviderTransportId = 'acp' | 'cli-jsonl';
+export type AgentProviderLifecycleState = 'declared' | 'transportReady' | 'routeableApproved' | 'healthy';
+export type AgentProviderSessionPolicy = 'resume' | 'stateless';
+export type AgentProviderOutputProfile = 'clowder-code-turn-result-v1';
+export type AgentProviderSandboxRequest = 'workspace-read' | 'workspace-write';
+export type AgentProviderHealthCheckType = 'acpInitialize' | 'cliProbe';
+
+export interface AgentProviderHealthCheckRequest {
+  type: AgentProviderHealthCheckType;
+}
+
+export interface PluginAgentProviderResource {
+  name: string;
+  transport: AgentProviderTransportId;
+  command: string;
+  startupArgs: string[];
+  resumeArgs?: string[];
+  sessionPolicy?: AgentProviderSessionPolicy;
+  outputProfile?: AgentProviderOutputProfile;
+  timeoutMs?: number;
+  /** Plugin-requested capability names. Host policy decides the actual grant in later slices. */
+  mcpWhitelistRequest?: string[];
+  /** Plugin-requested sandbox tier. Host policy decides the actual grant in later slices. */
+  sandboxRequest?: AgentProviderSandboxRequest;
+  healthCheck?: AgentProviderHealthCheckRequest;
+}
+
 /** Plugin resource declaration */
 export interface PluginResourceDef {
-  type: 'skill' | 'mcp' | 'limb' | 'schedule';
+  type: 'skill' | 'mcp' | 'limb' | 'schedule' | 'agentProvider';
   /** F202 Phase 2: Factory ID for schedule resources (white-list reference, no arbitrary scripts) */
   factoryId?: string;
   /** F202 Phase 2 follow-up: optional resources don't count toward 'partial' status when deps are missing */
   optional?: boolean;
+  /** F241 Phase B Slice 2a: non-routeable agent provider declaration. */
+  agentProvider?: PluginAgentProviderResource;
   path?: string;
   name?: string;
   command?: string;
@@ -59,6 +88,7 @@ export interface PluginResourceStatus {
   path?: string;
   name?: string;
   enabled: boolean;
+  agentProviderState?: AgentProviderLifecycleState;
   error?: string;
 }
 


### PR DESCRIPTION
## Summary

F241 Phase B Slice 2a adds the declarative `agentProvider` manifest surface as a non-routeable descriptor only.

- adds `agentProvider` to supported plugin resource types with strict manifest parsing
- adds shared `PluginAgentProviderResource` / `AgentProviderCapabilityDescriptor` types and split lifecycle states
- activates valid provider declarations into `transportReady` capabilities with `routeable: false`
- keeps `mcpWhitelist` / `sandbox` as host-grant request fields, not runtime grants
- locks the raw `cli-jsonl` negative `timeoutMs` regression with a provider registry test

## Scope Boundary

This PR intentionally does **not** make manifest providers routeable A2A targets.

Deferred to Slice 2b:

- host-owned binding record
- reserved namespace gate reuse
- routeable cat projection through `syncAgentRegistry` / `createServiceForConfig`
- routeable approval and health gate enforcement

## Validation

- `pnpm install --frozen-lockfile` with production install env unset
- `pnpm --filter @cat-cafe/api run build`
- `pnpm --filter @cat-cafe/api run lint`
- focused tests:
  - `test/plugin-agent-provider-activate.test.js`
  - `test/plugin-manifest-safety.test.js`
  - `test/provider-transport-registry.test.js`
- `pnpm check`
- `git diff --check`
- `CAT_CAFE_GATE_TEST_MODE=public pnpm gate --no-rebase --skip-install` → passed

Note: full API test first hit the existing `test/capabilities-route.test.js` 60s file timeout under the default command. Isolated rerun with `--test-timeout=180000` passed 81/81, and the public gate passed end to end.

[砚砚/gpt-5.5🐾]
