### PR TITLE
fix(ci): bump sync-upstream-main workflow node to 24

### DIFF
--- a/.github/workflows/sync-upstream-main.yml
+++ b/.github/workflows/sync-upstream-main.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Configure git


### PR DESCRIPTION
## Summary

- Bump `actions/setup-node` `node-version` from `20` to `24` in `.github/workflows/sync-upstream-main.yml`
- Unblocks the daily upstream-sync cron, which has failed two nights in a row at the `Install dependencies` step

## Root cause (evidence-based)

Sync workflow runs that failed:
- [27989214540](https://github.com/clowder-labs/clowder-ai/actions/runs/27989214540) — 2026-06-22 22:47 UTC
- [28060621842](https://github.com/clowder-labs/clowder-ai/actions/runs/28060621842) — 2026-06-23 22:12 UTC

Both failed at the same step with:

```
[node-runtime] Node 20.20.2 is not supported by this Clowder AI checkout; expected >=24 <26.
```

Why: upstream PR [zts212653/clowder-ai#994](https://github.com/zts212653/clowder-ai/pull/994) (commit `e199b42e`, 2026-06-22 14:17 +0800) did three things:
1. Raised `package.json` `engines.node` from `>=20.0.0` to `>=24.0.0`
2. Bumped the default `minMajor` in `scripts/check-node-runtime.mjs` from `20` to `24`
3. Updated upstream's own `ci.yml` (3 jobs) and `windows-smoke.yml` (1 job) to `node-version: 24`

The sync workflow does `checkout fork main` → `merge upstream/main` → `pnpm install`. After the merge step, the working tree carries upstream's stricter preinstall hook, which then rejects Node 20.

Our fork's `sync-upstream-main.yml` was added in `bfb29e2f` independently of upstream's CI bump in #994, so it still pinned `node 20`. Upstream's `ci.yml` / `windows-smoke.yml` updates will flow back to fork `main` automatically on the first successful sync after this fix.

## Scope

- Single line, single file
- Does NOT touch `ci.yml` / `windows-smoke.yml` / `package.json` engines / `check-node-runtime.mjs` — those changes belong to upstream's #994 and will arrive via the next successful sync (avoids duplication / merge conflicts)
- "Merge upstream → main" step itself was already succeeding in both failed runs; "Push main" never ran because the gate step is conditional on `Install dependencies` succeeding — so `main` was never pushed into an inconsistent state. The "fail-closed" design held.

## Test plan

- [ ] Manual `workflow_dispatch` after merge (or wait for cron at 21:00 UTC) to confirm full path: install → gate → push main → open develop PR
- [ ] Verify subsequent runs pick up upstream's `ci.yml` / `windows-smoke.yml` / engines bumps as part of normal sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)