### PR TITLE
fix(ci): sync gate skips capability-tips check (incremental vs batch mismatch)

### DIFF
--- a/.github/workflows/sync-upstream-main.yml
+++ b/.github/workflows/sync-upstream-main.yml
@@ -77,9 +77,30 @@ jobs:
 
       - name: Gate merged main
         if: steps.main.outputs.changed == 'true'
+        # Runs the same gate the upstream CI workflow enforces, but expanded
+        # explicitly so we can skip `pnpm check:capability-tips`. That check is
+        # an incremental guard (each PR adding a new feature doc must also add
+        # a matching capability tip), gated on `git diff origin/main...HEAD`.
+        # In this batch-merge sync context, that diff includes every upstream
+        # commit's file changes, so every newly synced feature/skill file is
+        # treated as "missing" — which is the wrong semantics for sync. The
+        # incremental check still runs on regular PRs against fork develop,
+        # where the diff range is correct.
         run: |
           set -euo pipefail
-          pnpm check
+          pnpm biome check . --diagnostic-level=error
+          pnpm check:features
+          pnpm check:sop-definitions
+          pnpm check:skills:manifest
+          pnpm check:skills:surfaces
+          pnpm check:env-ports
+          pnpm check:env-registry
+          pnpm check:env-example
+          pnpm check:start-profile-isolation
+          pnpm check:pre-merge-gate
+          pnpm check:guides
+          pnpm check:followup-tails
+          pnpm check:scripts-ascii-only
           pnpm --filter @cat-cafe/shared build
           pnpm --filter @cat-cafe/api build
           pnpm --filter @cat-cafe/web build


### PR DESCRIPTION
## Summary

- Sync workflow's `Gate merged main` step now runs an explicit list of sub-checks instead of `pnpm check`
- The only sub-check dropped is `pnpm check:capability-tips` — all 12 others retained, plus builds + test:public + dir-size unchanged
- Fixes the dispatch run [`28073487876`](https://github.com/clowder-labs/clowder-ai/actions/runs/28073487876) failure (post PR #19 merge)

## Root cause (evidence-based)

`check:capability-tips` is an **incremental guard**: for every new feature/skill doc, the PR must also add a matching tip in `capability-tips.seed.json`. It uses `git diff --name-only origin/main...HEAD` to discover "changed files".

This semantics breaks under sync's **batch merge**:

1. Sync checks out fork `main` (`origin/main` in the runner)
2. Merges `upstream/main` into the working tree
3. Runs `pnpm check` → `git diff origin/main...HEAD` now expands to **the full upstream delta** (every file every upstream commit touched since fork last synced)
4. All 31 surfaced "missing capability tip or tips_exempt" entries in run 28073487876 are **upstream-owned files** that already passed upstream's own PR-time capability-tips gate

The root cause is **not** "fork docs missing exempt frontmatter" — it is "incremental check applied to batch merge produces false positives".

## Why this is the right fix (vs alternatives)

| Option | Verdict | Why |
|---|---|---|
| **C' (this PR)**: skip capability-tips in sync gate only | ✅ Correct | Incremental check stays active on PRs against fork develop (correct diff range); sync drops it (wrong diff range) |
| A: add `tips_exempt` to 31 files | ✗ Treats symptom | 29/31 are upstream-owned, will be overwritten on next sync; needs reapplying forever |
| B: sync gate advisory (don't block push) | ✗ Real protection lost | Push main would happen on real failures too |
| D: extend script to support fork-private paths | ✗ Wrong root cause | Problem isn't private paths, it's diff-range semantics in batch context |

## Scope

- Single file changed: `.github/workflows/sync-upstream-main.yml`
- `+22 / -1`
- Comment in YAML explains the design choice

## What still runs in sync gate

```
pnpm biome check . --diagnostic-level=error
pnpm check:features
pnpm check:sop-definitions
pnpm check:skills:manifest
pnpm check:skills:surfaces
pnpm check:env-ports
pnpm check:env-registry
pnpm check:env-example
pnpm check:start-profile-isolation
pnpm check:pre-merge-gate
pnpm check:guides
pnpm check:followup-tails
pnpm check:scripts-ascii-only
pnpm --filter @cat-cafe/{shared,api,web} build
pnpm --filter @cat-cafe/api run test:public
bash scripts/check-dir-size.sh
```

## What the incremental capability-tips check still protects

Regular PRs against fork `develop`: `pnpm check` in `ci.yml` lint job. There `origin/main...HEAD` correctly equals the PR's own additions, so capability-tips behaves as designed — fork's own new features still must add tips.

## Test plan

- [ ] After merge, manual `workflow_dispatch` of `sync-upstream-main.yml` to confirm full path: merge → install → gate → push main → open develop PR
- [ ] Verify upstream's 4 pending commits flow into fork `main` cleanly
- [ ] Confirm the develop sync PR opens successfully

## Note for reviewer

The 12 sub-checks are hardcoded (not `pnpm check`) intentionally — `pnpm check` would be the upstream-merged version of the string (13 sub-checks including capability-tips), reintroducing the failure. Hardcoded list is a known maintenance trade-off: if upstream renames/adds sub-checks, sync gate needs a manual update. This is acceptable: sub-check additions on upstream are rare events, and any drift surfaces immediately when the gate misses a new check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)