### PR TITLE
feat(F159): Phase G Slice G1 — protocol adapter seam (refactor-only)

### DIFF
--- a/packages/api/scripts/verify-catagent-service-neutrality.mjs
+++ b/packages/api/scripts/verify-catagent-service-neutrality.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * AC-G12 Verifier — F159 Phase G Slice G1
+ *
+ * Asserts CatAgentService.ts contains zero `Anthropic*` code identifiers
+ * (after stripping comments). Per @gpt555 review note: must cover
+ *   - Type imports (`import type { Anthropic... }`)
+ *   - Helper names (`mapAnthropic...`, `parseAnthropic...`,
+ *     `buildAnthropic...`)
+ *   - Local type aliases / variable names
+ *   - `new Anthropic...` constructor calls
+ *
+ * Also asserts CatAgentService.ts does NOT manually construct an
+ * AdapterMessage (no `__adapterMessage: true` literal) — per @gpt555
+ * step-3 advisory.
+ *
+ * Usage: node packages/api/scripts/verify-catagent-service-neutrality.mjs
+ * Exit: 0 = pass, 1 = fail
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SERVICE_FILE = path.resolve(
+  __dirname,
+  '../src/domains/cats/services/agents/providers/catagent/CatAgentService.ts',
+);
+
+const src = fs.readFileSync(SERVICE_FILE, 'utf-8');
+
+/** Strip TypeScript block comments and line comments so we only inspect code. */
+function stripComments(s) {
+  // Block comments — non-greedy across lines
+  let out = s.replace(/\/\*[\s\S]*?\*\//g, '');
+  // Line comments — from // to end of line
+  out = out.replace(/\/\/[^\n]*/g, '');
+  return out;
+}
+
+const code = stripComments(src);
+
+// Match identifier-shaped tokens beginning with Anthropic
+const anthropicHits = [...new Set((code.match(/\bAnthropic[A-Za-z0-9_]*/g) || []))];
+const lowerHits = [...new Set((code.match(/\banthropic[A-Za-z0-9_]*/g) || []))];
+const opaqueLeak = code.includes('__adapterMessage');
+
+let failed = false;
+
+if (anthropicHits.length > 0) {
+  console.error('❌ AC-G12 FAIL: CatAgentService.ts contains `Anthropic*` code identifiers:');
+  for (const id of anthropicHits) console.error(`  - ${id}`);
+  failed = true;
+}
+
+if (lowerHits.length > 0) {
+  console.error('❌ AC-G12 FAIL: CatAgentService.ts contains lowercase `anthropic*` code identifiers:');
+  for (const id of lowerHits) console.error(`  - ${id}`);
+  failed = true;
+}
+
+if (opaqueLeak) {
+  console.error(
+    '❌ AC-G12 FAIL: CatAgentService.ts contains `__adapterMessage` literal — service must not manually construct AdapterMessage. Use adapter.encode* methods instead.',
+  );
+  failed = true;
+}
+
+if (failed) {
+  process.exit(1);
+}
+
+console.log('✅ AC-G12 PASS: CatAgentService.ts has zero `Anthropic*` / `anthropic*` code identifiers');
+console.log('✅ AdapterMessage opacity preserved (no manual `__adapterMessage` literal in service)');

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/CatAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/CatAgentService.ts
@@ -1,9 +1,17 @@
 /**
- * CatAgent Native Provider — F159 Phase E: SSE Streaming + Agentic Loop
+ * CatAgent Native Provider — F159 Phase E (G1: vendor-neutral adapter seam)
  *
- * Calls Anthropic Messages API directly with SSE streaming.
- * Phase E adds: per-token text streaming, streaming tool collection,
- * proper EOF validation. Strict streaming fail-closed — no non-streaming fallback.
+ * Generic "cat-as-an-agent" native provider. Protocol-specific wire shape
+ * (URL, headers, body, stream events, transcript codec, error formatting,
+ * terminal-stop classification) is delegated to a {@link CatAgentProtocolAdapter}
+ * obtained from {@link createCatAgentProtocolAdapter}. This file is intended
+ * to be vendor-neutral: AC-G12 grep verifier asserts no `Anthropic*`
+ * identifier appears here (imports, types, helper names, or local aliases).
+ *
+ * Pre-G1 (Phase E) this file directly called `parseAnthropicSSE`, held
+ * `AnthropicContentBlock[]` turn state, and pushed `{ role: 'assistant',
+ * content }` / `{ role: 'user', content: tool_result[] }` messages — see
+ * F159 Phase G spec for the design gate that drove the refactor.
  */
 
 import type { CatConfig, CatId } from '@cat-cafe/shared';
@@ -13,11 +21,15 @@ import { AuditEventTypes, getEventAuditLog } from '../../../orchestration/EventA
 import type { AgentMessage, AgentService, AgentServiceOptions, MessageMetadata, TokenUsage } from '../../../types.js';
 import { mergeTokenUsage } from '../../../types.js';
 import { resolveApiCredentials } from './catagent-credentials.js';
-import type { AnthropicContentBlock, AnthropicToolUseBlock } from './catagent-event-bridge.js';
-import { mapAnthropicError, mapAnthropicUsage, TERMINAL_STOP_REASONS } from './catagent-event-bridge.js';
+import type { CatAgentProtocolAdapter } from './catagent-protocol-adapter.js';
+import { createCatAgentProtocolAdapter } from './catagent-protocol-factory.js';
+import type {
+  AdapterMessage,
+  CatAgentNeutralBlock,
+  CatAgentStreamEvent,
+  CatAgentToolCallBlock,
+} from './catagent-protocol-types.js';
 import { buildToolRegistry, findTool, getToolSchemas } from './catagent-read-tools.js';
-import type { CatAgentStreamEvent } from './catagent-stream-parser.js';
-import { parseAnthropicSSE } from './catagent-stream-parser.js';
 import { validateToolInput } from './catagent-tool-guard.js';
 import type {
   CatAgentTool,
@@ -28,17 +40,8 @@ import type {
 
 const log = createModuleLogger('catagent');
 
-const ANTHROPIC_API_VERSION = '2023-06-01';
-const DEFAULT_BASE_URL = 'https://api.anthropic.com';
-const DEFAULT_MAX_TOKENS = 4096;
 const MAX_TOOL_TURNS = 15;
 const TOOL_RESULT_DIGEST_LIMIT = 500;
-
-function buildAnthropicMessagesUrl(baseURL?: string): string {
-  const rawBaseUrl = baseURL?.trim() || DEFAULT_BASE_URL;
-  const root = rawBaseUrl.replace(/\/+$/, '').replace(/\/v1$/i, '');
-  return `${root}/v1/messages`;
-}
 
 interface CatAgentServiceOptions {
   catId: CatId;
@@ -48,8 +51,9 @@ interface CatAgentServiceOptions {
 
 /** Per-turn result accumulated from stream events. */
 interface TurnResult {
-  contentBlocks: AnthropicContentBlock[];
+  contentBlocks: CatAgentNeutralBlock[];
   stopReason: string | null;
+  isTerminal: boolean;
   turnUsage: TokenUsage;
   hadStreamError: boolean;
 }
@@ -68,7 +72,11 @@ export interface CatAgentToolExecResult {
 }
 
 /**
- * Execute Anthropic tool_use blocks against the local tool registry.
+ * Execute neutral tool_call blocks against the local tool registry.
+ * (G1: signature changed from `AnthropicToolUseBlock[]` to neutral
+ * `ReadonlyArray<CatAgentToolCallBlock>`; field reads are identical because
+ * the neutral block carries the same `id` / `name` / `input` triple.)
+ *
  * Exported (vs the previous private method) so unit tests can verify the
  * status mapping without standing up the full streaming HTTP pipeline.
  *
@@ -78,7 +86,7 @@ export interface CatAgentToolExecResult {
  * - thrown error (schema validation, tool.execute reject) → `status: 'error'`
  */
 export async function executeCatAgentTools(
-  blocks: AnthropicToolUseBlock[],
+  blocks: ReadonlyArray<CatAgentToolCallBlock>,
   tools: CatAgentTool[],
 ): Promise<CatAgentToolExecResult[]> {
   const results: CatAgentToolExecResult[] = [];
@@ -116,11 +124,17 @@ export class CatAgentService implements AgentService {
   readonly catId: CatId;
   private readonly projectRoot: string;
   private readonly catConfig: CatConfig | null;
+  private readonly adapter: CatAgentProtocolAdapter;
 
   constructor(options: CatAgentServiceOptions) {
     this.catId = options.catId;
     this.projectRoot = options.projectRoot;
     this.catConfig = options.catConfig;
+    // G1: protocol adapter is the single source of truth for vendor-specific
+    // wire shape; service never instantiates AnthropicMessagesAdapter directly
+    // (AC-G12 grep verifier asserts service contains no `new
+    // AnthropicMessagesAdapter` call).
+    this.adapter = createCatAgentProtocolAdapter(options.catConfig);
   }
 
   async *invoke(prompt: string, options?: AgentServiceOptions): AsyncIterable<AgentMessage> {
@@ -132,7 +146,14 @@ export class CatAgentService implements AgentService {
       yield* emitError('Model resolution failed — no configured model', this.catId, 'unknown', now);
       return;
     }
-    const credentials = resolveApiCredentials(this.projectRoot, this.catId as string, this.catConfig);
+    // G1: credentials resolution now keyed on adapter.clientFamily so future
+    // OpenAI / Gemini adapters select their own profile family.
+    const credentials = resolveApiCredentials(
+      this.projectRoot,
+      this.catId as string,
+      this.catConfig,
+      this.adapter.clientFamily,
+    );
     if (!credentials) {
       yield* emitError('Credential resolution failed — no bound account', this.catId, model, now);
       return;
@@ -154,7 +175,11 @@ export class CatAgentService implements AgentService {
     const workDir = options?.workingDirectory;
     const tools = await buildToolRegistry(workDir, this.createToolRegistryOptions(options));
     const toolSchemas = getToolSchemas(tools);
-    const messages: Array<{ role: string; content: unknown }> = [{ role: 'user', content: prompt }];
+    // G1: messages held as opaque AdapterMessage; service never destructures.
+    // Initial user prompt + per-turn assistant blocks + per-turn tool results
+    // are all encoded by the adapter (replaces pre-G1 service-side `{ role,
+    // content }` construction at CatAgentService.ts:157/229/231).
+    const messages: AdapterMessage[] = [this.adapter.encodeUserPrompt(prompt)];
     let totalUsage: TokenUsage | undefined;
 
     for (let turn = 0; turn < MAX_TOOL_TURNS; turn++) {
@@ -162,7 +187,7 @@ export class CatAgentService implements AgentService {
       try {
         resp = await this.fetchApi(messages, toolSchemas, model, credentials, options);
       } catch (err: unknown) {
-        yield* this.handleFetchError(err, metadata, model, totalUsage);
+        yield* this.handleFetchError(err, metadata, totalUsage);
         return;
       }
 
@@ -170,7 +195,7 @@ export class CatAgentService implements AgentService {
       totalUsage = mergeTokenUsage(totalUsage, result.turnUsage);
 
       if (result.hadStreamError) {
-        const orphanTools = result.contentBlocks.filter((b): b is AnthropicToolUseBlock => b.type === 'tool_use');
+        const orphanTools = result.contentBlocks.filter((b): b is CatAgentToolCallBlock => b.type === 'tool_call');
         for (const t of orphanTools) {
           // F153 Phase J AC-J2: carry native tool_use_id + structured error status.
           yield {
@@ -188,13 +213,12 @@ export class CatAgentService implements AgentService {
         return;
       }
 
-      const isTerminal = result.stopReason != null && TERMINAL_STOP_REASONS.has(result.stopReason);
-      if (isTerminal) {
+      if (result.isTerminal) {
         yield { type: 'done', catId: this.catId, metadata: { ...metadata, usage: totalUsage }, timestamp: Date.now() };
         return;
       }
 
-      const toolBlocks = result.contentBlocks.filter((b): b is AnthropicToolUseBlock => b.type === 'tool_use');
+      const toolBlocks = result.contentBlocks.filter((b): b is CatAgentToolCallBlock => b.type === 'tool_call');
       if (toolBlocks.length === 0) {
         const reason = result.stopReason ?? 'unknown';
         log.warn(`[${this.catId}] Non-terminal stop_reason "${reason}" with no tool calls`);
@@ -226,11 +250,12 @@ export class CatAgentService implements AgentService {
           timestamp: Date.now(),
         };
       }
-      messages.push({ role: 'assistant', content: result.contentBlocks });
-      messages.push({
-        role: 'user',
-        content: toolResults.map((r) => ({ type: 'tool_result', tool_use_id: r.id, content: r.content })),
-      });
+      // G1: assistant turn + tool results encoded by adapter — replaces pre-G1
+      // direct push of `{ role: 'assistant', content: contentBlocks }` and
+      // `{ role: 'user', content: tool_result[] }` (the Anthropic shape leak
+      // @gpt555 flagged at CatAgentService.ts:229-233 during design gate).
+      messages.push(this.adapter.encodeAssistantTurn(result.contentBlocks));
+      messages.push(this.adapter.encodeToolResults(toolResults));
     }
 
     log.warn(`[${this.catId}] Tool loop exceeded ${MAX_TOOL_TURNS} turns`);
@@ -244,30 +269,34 @@ export class CatAgentService implements AgentService {
     yield* emitDone(this.catId, metadata, totalUsage);
   }
 
-  /** Consume one streaming turn, yielding text deltas and tool_use events. */
+  /** Consume one streaming turn, yielding text deltas and tool_call events. */
   private async *consumeTurn(
     resp: Response,
     metadata: MessageMetadata,
     signal?: AbortSignal,
   ): AsyncGenerator<AgentMessage, TurnResult> {
-    const contentBlocks: AnthropicContentBlock[] = [];
-    const blocksByIndex = new Map<number, AnthropicContentBlock>();
+    const contentBlocks: CatAgentNeutralBlock[] = [];
+    const blocksByIndex = new Map<number, CatAgentNeutralBlock>();
     let stopReason: string | null = null;
-    let inputUsage: TokenUsage = { inputTokens: 0, outputTokens: 0 };
-    let outputTokens = 0;
+    // G1: turn usage merged directly from neutral CatAgentUsageDelta events.
+    // No more `mapAnthropicUsage(evt.inputUsage)` call from service — the
+    // adapter has already normalised the input usage upstream (parser).
+    const turnUsage: TokenUsage = { inputTokens: 0, outputTokens: 0 };
     let hadStreamError = false;
 
     if (!resp.body) {
       yield { type: 'error', catId: this.catId, error: 'Response has no body', metadata, timestamp: Date.now() };
-      return { contentBlocks, stopReason, turnUsage: inputUsage, hadStreamError: true };
+      return { contentBlocks, stopReason, isTerminal: false, turnUsage, hadStreamError: true };
     }
 
-    for await (const evt of parseAnthropicSSE(resp.body, signal)) {
+    for await (const evt of this.adapter.parseStreamEvents(resp.body, signal)) {
       yield* this.mapStreamEvent(evt, metadata, blocksByIndex);
 
       if (evt.type === 'usage_update') {
-        if (evt.inputUsage) inputUsage = mapAnthropicUsage(evt.inputUsage);
-        if (evt.outputTokens !== undefined) outputTokens = evt.outputTokens;
+        if (evt.usage.inputTokens !== undefined) turnUsage.inputTokens = evt.usage.inputTokens;
+        if (evt.usage.outputTokens !== undefined) turnUsage.outputTokens = evt.usage.outputTokens;
+        if (evt.usage.cacheReadTokens !== undefined) turnUsage.cacheReadTokens = evt.usage.cacheReadTokens;
+        if (evt.usage.cacheCreationTokens !== undefined) turnUsage.cacheCreationTokens = evt.usage.cacheCreationTokens;
       } else if (evt.type === 'stop') {
         stopReason = evt.stopReason;
       } else if (evt.type === 'stream_error') {
@@ -282,22 +311,28 @@ export class CatAgentService implements AgentService {
       if (block) contentBlocks.push(block);
     }
 
-    const turnUsage: TokenUsage = { ...inputUsage, outputTokens };
-    return { contentBlocks, stopReason, turnUsage, hadStreamError };
+    // G1: terminal classification deferred to adapter (replaces pre-G1 direct
+    // service-side `TERMINAL_STOP_REASONS.has(...)` consult — that whitelist
+    // was Anthropic-specific and leaked the vendor's terminal set into
+    // generic loop logic).
+    const isTerminal = this.adapter.isTerminalStopReason(stopReason);
+    return { contentBlocks, stopReason, isTerminal, turnUsage, hadStreamError };
   }
 
-  /** Map a single stream event to AgentMessage(s). */
+  /** Map a single neutral stream event to AgentMessage(s). */
   private *mapStreamEvent(
     evt: CatAgentStreamEvent,
     metadata: MessageMetadata,
-    blocksByIndex: Map<number, AnthropicContentBlock>,
+    blocksByIndex: Map<number, CatAgentNeutralBlock>,
   ): Iterable<AgentMessage> {
     if (evt.type === 'text_delta') {
       yield { type: 'text', catId: this.catId, content: evt.text, metadata, timestamp: Date.now() };
     } else if (evt.type === 'content_block_complete') {
       blocksByIndex.set(evt.blockIndex, evt.block);
-      if (evt.block.type === 'tool_use') {
-        // F153 Phase J AC-J2: carry native Anthropic tool_use.id (from stream parser).
+      if (evt.block.type === 'tool_call') {
+        // F153 Phase J AC-J2: carry upstream protocol tool call id (neutral
+        // CatAgentToolCallBlock.id; adapter mapped from Anthropic tool_use.id
+        // / OpenAI call_*).
         yield {
           type: 'tool_use',
           catId: this.catId,
@@ -314,25 +349,30 @@ export class CatAgentService implements AgentService {
   }
 
   private async fetchApi(
-    messages: Array<{ role: string; content: unknown }>,
+    messages: ReadonlyArray<AdapterMessage>,
     tools: Array<{ name: string; description: string; input_schema: unknown }>,
     model: string,
     credentials: { apiKey: string; baseURL?: string },
     options?: AgentServiceOptions,
   ): Promise<Response> {
-    const url = buildAnthropicMessagesUrl(credentials.baseURL);
-    const body: Record<string, unknown> = { model, max_tokens: DEFAULT_MAX_TOKENS, messages, stream: true };
-    if (tools.length > 0) body.tools = tools;
-    if (options?.systemPrompt) body.system = options.systemPrompt;
+    // G1: URL / headers / body shape all delegated to adapter — service has
+    // no idea about `/v1/messages`, `x-api-key`, `anthropic-version`, or
+    // `{ model, max_tokens, messages, stream, tools, system }` shape.
+    const url = this.adapter.buildRequestUrl(credentials.baseURL);
+    const headers = this.adapter.buildRequestHeaders({ apiKey: credentials.apiKey });
+    const body = this.adapter.buildRequestBody({
+      model,
+      messages,
+      tools: tools.map((t) => ({ name: t.name, description: t.description, inputSchema: t.input_schema })),
+      ...(options?.systemPrompt ? { systemPrompt: options.systemPrompt } : {}),
+    });
 
-    log.info(`[${this.catId}] API call: model=${model}, turns=${messages.length}, stream=true`);
+    log.info(
+      `[${this.catId}] API call: model=${model}, turns=${messages.length}, stream=true, protocol=${this.adapter.protocolId}`,
+    );
     const resp = await fetch(url, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-api-key': credentials.apiKey,
-        'anthropic-version': ANTHROPIC_API_VERSION,
-      },
+      headers,
       body: JSON.stringify(body),
       signal: options?.signal,
     });
@@ -344,7 +384,7 @@ export class CatAgentService implements AgentService {
   }
 
   private executeTools(
-    blocks: AnthropicToolUseBlock[],
+    blocks: ReadonlyArray<CatAgentToolCallBlock>,
     tools: CatAgentTool[],
     _metadata: MessageMetadata,
   ): Promise<CatAgentToolExecResult[]> {
@@ -382,7 +422,6 @@ export class CatAgentService implements AgentService {
   private *handleFetchError(
     err: unknown,
     metadata: MessageMetadata,
-    model: string,
     totalUsage: TokenUsage | undefined,
   ): Iterable<AgentMessage> {
     if (err instanceof DOMException && err.name === 'AbortError') {
@@ -398,10 +437,18 @@ export class CatAgentService implements AgentService {
     } else {
       log.error(`[${this.catId}] Unexpected error: ${message}`);
     }
-    for (const msg of mapAnthropicError({ status: httpStatus ?? 0, message }, this.catId, 'catagent', model)) {
-      const usage = totalUsage ?? msg.metadata?.usage;
-      yield { ...msg, metadata: { ...metadata, ...msg.metadata, usage } };
-    }
+    // G1: adapter formats the protocol-aware error text; service composes the
+    // neutral error + done AgentMessage pair around it. Replaces pre-G1
+    // direct `mapAnthropicError(...)` call (Anthropic identifier in service).
+    const { errorText } = this.adapter.mapError({ status: httpStatus ?? 0, message });
+    const now = Date.now();
+    yield { type: 'error', catId: this.catId, error: errorText, metadata, timestamp: now };
+    yield {
+      type: 'done',
+      catId: this.catId,
+      metadata: { ...metadata, usage: totalUsage ?? { inputTokens: 0, outputTokens: 0 } },
+      timestamp: now,
+    };
   }
 }
 

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/anthropic-messages-adapter.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/anthropic-messages-adapter.ts
@@ -1,0 +1,182 @@
+/**
+ * Anthropic Messages Adapter — F159 Phase G Slice G1
+ *
+ * Concrete implementation of {@link CatAgentProtocolAdapter} for the Anthropic
+ * Messages API (`POST /v1/messages`, `anthropic-version: 2023-06-01`, SSE
+ * stream).
+ *
+ * KD-15 (truthful naming): adapter is intentionally named `Anthropic*` —
+ * this file owns the Anthropic-specific wire shape (URL, headers, body,
+ * stream events, transcript codec). The neutral seam in
+ * `CatAgentService` only sees `CatAgentProtocolAdapter`.
+ *
+ * KD-17: this adapter covers all four seam layers — HTTP, stream, transcript
+ * codec, and family/id — so service never has to know the Anthropic message
+ * shape (`{ role: 'assistant', content: AnthropicContentBlock[] }`,
+ * `{ role: 'user', content: tool_result[] }` etc.).
+ *
+ * Per @gpt555 step-3 advisory: `AdapterMessage` opacity is preserved by the
+ * private {@link wrapMessage} factory + AC-G12 grep verifier — service must
+ * never construct `{ __adapterMessage: true, payload: ... }` directly.
+ */
+
+import type {
+  AdapterCredentials,
+  AdapterRequestInput,
+  AdapterToolResult,
+  CatAgentProtocolAdapter,
+} from './catagent-protocol-adapter.js';
+import type { AnthropicContentBlock } from './catagent-event-bridge.js';
+import type {
+  AdapterMessage,
+  CatAgentNeutralBlock,
+  CatAgentStreamEvent,
+} from './catagent-protocol-types.js';
+import { TERMINAL_STOP_REASONS } from './catagent-event-bridge.js';
+import { parseAnthropicSSE } from './catagent-stream-parser.js';
+
+// ── Anthropic protocol constants (adapter-owned, not service-owned) ──
+
+const ANTHROPIC_API_VERSION = '2023-06-01';
+const DEFAULT_BASE_URL = 'https://api.anthropic.com';
+const DEFAULT_MAX_TOKENS = 4096;
+
+/**
+ * Build the Anthropic Messages endpoint URL, normalising trailing `/v1` so
+ * proxies that publish `baseUrl: https://gateway.example/v1` (OpenAI-style
+ * convention) don't double-prefix into `/v1/v1/messages`.
+ *
+ * Moved here from `CatAgentService.ts` (develop@90810122) as part of G1 —
+ * the helper is Anthropic-protocol-specific and belongs in the adapter.
+ */
+function buildAnthropicMessagesUrl(baseURL?: string): string {
+  const rawBaseUrl = baseURL?.trim() || DEFAULT_BASE_URL;
+  const root = rawBaseUrl.replace(/\/+$/, '').replace(/\/v1$/i, '');
+  return `${root}/v1/messages`;
+}
+
+// ── AdapterMessage factory (private — opacity guardrail) ──
+
+/**
+ * Internal AdapterMessage payload shape for Anthropic Messages protocol —
+ * `{ role: 'user' | 'assistant', content: <text | content[] | tool_result[]> }`.
+ * Service-layer code never sees or constructs this; only the adapter does.
+ */
+interface AnthropicMessagePayload {
+  role: 'user' | 'assistant';
+  content: string | AnthropicContentBlock[] | AnthropicToolResultBlock[];
+}
+
+interface AnthropicToolResultBlock {
+  type: 'tool_result';
+  tool_use_id: string;
+  content: string;
+}
+
+/**
+ * Private factory — only place in the adapter (and the whole codebase) where
+ * a fresh `AdapterMessage` is constructed. AC-G12 grep verifier asserts no
+ * other module — especially `CatAgentService` — contains `__adapterMessage`
+ * as a literal key. Per @gpt555 step-3 advisory.
+ */
+function wrapMessage(payload: AnthropicMessagePayload): AdapterMessage {
+  return { __adapterMessage: true, payload };
+}
+
+function unwrapMessage(message: AdapterMessage): AnthropicMessagePayload {
+  return message.payload as AnthropicMessagePayload;
+}
+
+// ── Neutral block → Anthropic content block ──
+
+function neutralBlockToAnthropic(block: CatAgentNeutralBlock): AnthropicContentBlock {
+  if (block.type === 'text') return { type: 'text', text: block.text };
+  return { type: 'tool_use', id: block.id, name: block.name, input: block.input };
+}
+
+// ── The adapter ──
+
+export class AnthropicMessagesAdapter implements CatAgentProtocolAdapter {
+  readonly clientFamily = 'anthropic' as const;
+  readonly protocolId = 'anthropic-messages-v1' as const;
+
+  buildRequestUrl(baseURL?: string): string {
+    return buildAnthropicMessagesUrl(baseURL);
+  }
+
+  buildRequestHeaders(credentials: AdapterCredentials): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      'x-api-key': credentials.apiKey,
+      'anthropic-version': ANTHROPIC_API_VERSION,
+    };
+  }
+
+  buildRequestBody(input: AdapterRequestInput): unknown {
+    const messages = input.messages.map((m) => unwrapMessage(m));
+    const body: Record<string, unknown> = {
+      model: input.model,
+      max_tokens: input.maxTokens ?? DEFAULT_MAX_TOKENS,
+      messages,
+      stream: true,
+    };
+    if (input.tools.length > 0) {
+      // Anthropic tool schema shape: { name, description, input_schema }
+      body.tools = input.tools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        input_schema: t.inputSchema,
+      }));
+    }
+    if (input.systemPrompt) body.system = input.systemPrompt;
+    return body;
+  }
+
+  parseStreamEvents(
+    body: ReadableStream<Uint8Array>,
+    signal?: AbortSignal,
+  ): AsyncIterable<CatAgentStreamEvent> {
+    // Parser already yields neutral CatAgentStreamEvent post-G1 step 4.
+    return parseAnthropicSSE(body, signal);
+  }
+
+  encodeUserPrompt(prompt: string): AdapterMessage {
+    return wrapMessage({ role: 'user', content: prompt });
+  }
+
+  encodeAssistantTurn(blocks: ReadonlyArray<CatAgentNeutralBlock>): AdapterMessage {
+    const content: AnthropicContentBlock[] = blocks.map(neutralBlockToAnthropic);
+    return wrapMessage({ role: 'assistant', content });
+  }
+
+  isTerminalStopReason(stopReason: string | null): boolean {
+    return stopReason != null && TERMINAL_STOP_REASONS.has(stopReason);
+  }
+
+  mapError(err: { status?: number; message?: string }): { errorText: string } {
+    // Byte-stable with pre-G1 mapAnthropicError text format
+    // (catagent-event-bridge.ts:163) so AC-G10 golden-wire test locks down
+    // the user-facing error message shape across the refactor.
+    const status = err.status ?? 0;
+    const msg = err.message ?? 'Unknown API error';
+    return { errorText: `Anthropic API error (${status}): ${msg}` };
+  }
+
+  encodeToolResults(results: ReadonlyArray<AdapterToolResult>): AdapterMessage {
+    // G1 refactor-only: byte-stable with pre-G1 service code at
+    // CatAgentService.ts:231 — only { type, tool_use_id, content } are
+    // emitted. AdapterToolResult.status flows through the AgentMessage
+    // tool_result event (carried by service into the audit chain via
+    // toolResultStatus) but is intentionally NOT mapped into the Anthropic
+    // wire transcript here, preserving the exact pre-G1 request body shape
+    // that AC-G10 golden-wire test will lock down. Future iterations may
+    // surface status as Anthropic `is_error` — that's a behavior change and
+    // must go through its own design gate.
+    const content: AnthropicToolResultBlock[] = results.map((r) => ({
+      type: 'tool_result' as const,
+      tool_use_id: r.id,
+      content: r.content,
+    }));
+    return wrapMessage({ role: 'user', content });
+  }
+}

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-credentials.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-credentials.ts
@@ -12,6 +12,10 @@
 
 import type { CatConfig } from '@cat-cafe/shared';
 import { resolveForClient } from '../../../../../../config/account-resolver.js';
+// `BuiltinAccountClient` is the resolver's narrow union (subset of ClientId).
+// Imported as a type-only re-export from account-resolver to avoid importing
+// from @cat-cafe/shared twice in this file.
+import type { BuiltinAccountClient } from '../../../../../../config/account-resolver.js';
 import { resolveBoundAccountRefForCat } from '../../../../../../config/cat-account-binding.js';
 import { createModuleLogger } from '../../../../../../infrastructure/logger.js';
 
@@ -47,7 +51,13 @@ export function resolveApiCredentials(
     return null;
   }
 
-  const profile = resolveForClient(projectRoot, clientFamily, boundRef);
+  // G1: adapter declares clientFamily as `string` to leave room for future
+  // protocols (G2 OpenAI Chat / G3 Gemini); resolveForClient currently
+  // accepts a narrow `BuiltinAccountClient | AccountProtocol` union. Cast
+  // at this boundary — if a future adapter ships a clientFamily not in
+  // that union, resolveForClient will return null and credentials resolution
+  // will fail closed (existing behaviour for unknown profiles, AC-B1).
+  const profile = resolveForClient(projectRoot, clientFamily as BuiltinAccountClient, boundRef);
   if (!profile?.apiKey) {
     log.warn(`[${catId}] Bound account "${boundRef}" did not resolve to an API key (family=${clientFamily})`);
     return null;

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-credentials.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-credentials.ts
@@ -63,6 +63,34 @@ export function resolveApiCredentials(
     return null;
   }
 
+  // G1 P2 fix (@gpt555 implementation review on PR #23): `clientFamily`
+  // must actually guard the resolved profile, not just be passed through.
+  // resolveForClient's `preferredAccountRef` branch (account-resolver.ts:161-162)
+  // returns the account by ref without verifying its family — so an OAuth
+  // Anthropic builtin (e.g. `claude`) could resolve under
+  // `clientFamily='openai'` silently, making AC-G5 cosmetic and exposing
+  // G2 to silent family routing failures when OpenAIChatAdapter lands.
+  //
+  // Post-check: if the profile carries a builtin client identity
+  // (`profile.client` is set only for OAuth/builtin accounts per
+  // `accountToRuntimeProfile`), it MUST match the requested clientFamily.
+  // Mismatch → fail closed.
+  //
+  // Scope note (deferred to G2 spec): api_key accounts today have no
+  // explicit family on schema (`accountToRuntimeProfile` only sets
+  // `profile.client` for OAuth builtins). The G2 spec must define how
+  // api_key accounts declare family so this guard becomes complete
+  // (not just OAuth/builtin half). For now api_key + missing family is
+  // best-effort and falls through — the runtime API call will fail if
+  // the proxy doesn't speak the requested protocol, surfacing the
+  // mismatch at first invocation rather than silently routing.
+  if (profile.client !== undefined && profile.client !== clientFamily) {
+    log.warn(
+      `[${catId}] Bound account "${boundRef}" client=${profile.client} mismatch with adapter clientFamily=${clientFamily} — fail closed`,
+    );
+    return null;
+  }
+
   log.info(`[${catId}] Resolved API key from bound account: ${boundRef} (family=${clientFamily})`);
   return { apiKey: profile.apiKey, baseURL: profile.baseUrl, source: `bound:${boundRef}` };
 }

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-credentials.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-credentials.ts
@@ -1,10 +1,12 @@
 /**
  * CatAgent Credentials — F159: Native Provider Security Baseline
  *
- * Resolves Anthropic API key for direct API calls using the
- * account-binding fail-closed pattern from invoke-single-cat.
+ * Resolves API credentials for direct API calls using the account-binding
+ * fail-closed pattern from invoke-single-cat. G1 (AC-G5): `clientFamily`
+ * is parameterised so adapters that don't speak Anthropic (G2 OpenAI Chat;
+ * G3 Gemini) can resolve their own account profile family.
  *
- * Single source of truth: catConfig.accountRef → resolveForClient.
+ * Single source of truth: catConfig.accountRef → resolveForClient(clientFamily).
  * No env override, no fallback scan — fail closed if binding is missing.
  */
 
@@ -27,11 +29,17 @@ export interface ApiCredentials {
  * Single resolution path: catConfig.accountRef → resolveBoundAccountRefForCat → resolveForClient.
  * No env override — account binding is the sole source of truth (AC-B1).
  * No wildcard credential scan — if the bound account doesn't resolve, returns null.
+ *
+ * `clientFamily` defaults to `'anthropic'` for backward compatibility with
+ * pre-G1 call sites; new G1+ callers (`CatAgentService` via adapter)
+ * pass `adapter.clientFamily` explicitly to keep the adapter as the single
+ * source of truth for protocol identity.
  */
 export function resolveApiCredentials(
   projectRoot: string,
   catId: string,
   catConfig: CatConfig | null | undefined,
+  clientFamily: string = 'anthropic',
 ): ApiCredentials | null {
   const boundRef = resolveBoundAccountRefForCat(projectRoot, catId, catConfig);
   if (!boundRef) {
@@ -39,12 +47,12 @@ export function resolveApiCredentials(
     return null;
   }
 
-  const profile = resolveForClient(projectRoot, 'anthropic', boundRef);
+  const profile = resolveForClient(projectRoot, clientFamily, boundRef);
   if (!profile?.apiKey) {
-    log.warn(`[${catId}] Bound account "${boundRef}" did not resolve to an API key`);
+    log.warn(`[${catId}] Bound account "${boundRef}" did not resolve to an API key (family=${clientFamily})`);
     return null;
   }
 
-  log.info(`[${catId}] Resolved API key from bound account: ${boundRef}`);
+  log.info(`[${catId}] Resolved API key from bound account: ${boundRef} (family=${clientFamily})`);
   return { apiKey: profile.apiKey, baseURL: profile.baseUrl, source: `bound:${boundRef}` };
 }

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-protocol-adapter.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-protocol-adapter.ts
@@ -154,4 +154,37 @@ export interface CatAgentProtocolAdapter {
    * `tool`-role messages, or something else is an adapter-internal concern.
    */
   encodeToolResults(results: ReadonlyArray<AdapterToolResult>): AdapterMessage;
+
+  // ── Error formatting (protocol-neutral surface, protocol-aware text) ──
+
+  /**
+   * Map a HTTP-level fetch error (status + message) into a user-facing error
+   * text. Replaces pre-G1 `service.handleFetchError` directly calling
+   * `mapAnthropicError` (which emitted `"Anthropic API error (...)"` strings
+   * straight from service code, leaking the protocol vendor name into a
+   * service-layer responsibility).
+   *
+   * Service composes the returned `errorText` into the standard `error` +
+   * `done` AgentMessage pair using its own context (catId, model, usage).
+   */
+  mapError(err: { status?: number; message?: string }): { errorText: string };
+
+  // ── Stop-reason classification (protocol-aware terminal set) ──
+
+  /**
+   * Whether a `stop` event's `stopReason` indicates a terminal turn end
+   * (model finished naturally, hit max tokens, refused, etc.) vs. a
+   * pause-for-tool-use intermediate stop.
+   *
+   * Each protocol has its own terminal set:
+   * - Anthropic: `end_turn` / `max_tokens` / `stop_sequence` / `refusal` /
+   *   `model_context_window_exceeded`
+   * - OpenAI: `stop` / `length` / `content_filter`
+   * - Gemini: `STOP` / `MAX_TOKENS` / `SAFETY` / `RECITATION`
+   *
+   * Keeping this on the adapter (instead of letting service consult a shared
+   * `TERMINAL_STOP_REASONS` constant) avoids the pre-G1 leak where service
+   * had to know the Anthropic-specific terminal whitelist.
+   */
+  isTerminalStopReason(stopReason: string | null): boolean;
 }

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-protocol-adapter.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-protocol-adapter.ts
@@ -1,0 +1,157 @@
+/**
+ * CatAgent Protocol Adapter — F159 Phase G Slice G1
+ *
+ * Vendor-neutral seam between `CatAgentService` (the generic
+ * "cat-as-an-agent" native provider) and protocol-specific wire implementations
+ * (Anthropic Messages today; OpenAI Chat Completions in G2; Gemini in G3).
+ *
+ * `CatAgentService` only depends on this interface + the neutral types in
+ * `catagent-protocol-types.ts`. No `Anthropic*` (or any other protocol-specific)
+ * identifier may appear in service-layer code (AC-G12 — enforced by grep
+ * verifier covering values, type imports, helper names, and local aliases).
+ *
+ * Each adapter is the truthful owner of its protocol:
+ * - URL / headers / body serialisation
+ * - Streaming response → neutral events parsing
+ * - Transcript codec: encode service-held neutral blocks back into protocol-
+ *   specific message shapes (`{ role, content }` for Anthropic; OpenAI's
+ *   `{ role: 'assistant', content, tool_calls }` + `{ role: 'tool', ... }` etc.)
+ * - Client family identity (used by account resolver to pick profile shape)
+ * - Protocol id (used for audit + Hub UI label)
+ */
+
+import type {
+  AdapterMessage,
+  CatAgentNeutralBlock,
+  CatAgentStreamEvent,
+} from './catagent-protocol-types.js';
+
+/** Credentials passed into the adapter at request build time (per-invocation). */
+export interface AdapterCredentials {
+  apiKey: string;
+  baseURL?: string;
+}
+
+/** Tool definition surface used by `buildRequestBody`. Protocol-neutral. */
+export interface AdapterToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: unknown;
+}
+
+/**
+ * Inputs to `buildRequestBody` — protocol-neutral fields that every adapter
+ * must be able to render into a protocol-specific request body.
+ */
+export interface AdapterRequestInput {
+  model: string;
+  /**
+   * The full opaque transcript (initial user prompt + per-turn assistant
+   * encoded blocks + per-turn tool result encodings). Adapter internally
+   * unwraps `payload` to its known shape; service never touches it.
+   */
+  messages: ReadonlyArray<AdapterMessage>;
+  /** Tool definitions to expose to the model this turn. */
+  tools: ReadonlyArray<AdapterToolDefinition>;
+  /** Optional system prompt; placed per protocol convention. */
+  systemPrompt?: string;
+  /** Optional per-turn max output tokens cap (adapter may apply protocol default). */
+  maxTokens?: number;
+}
+
+/**
+ * Single tool execution result passed to `encodeToolResults` to compose the
+ * next-turn user message (Anthropic) or tool message batch (OpenAI).
+ */
+export interface AdapterToolResult {
+  /** Upstream protocol tool call id (echoed from the matching `CatAgentToolCallBlock.id`). */
+  id: string;
+  content: string;
+  status: 'ok' | 'error';
+}
+
+/**
+ * Protocol adapter seam.
+ *
+ * Per @gpt555 design gate (KD-17): the seam covers **HTTP + stream +
+ * transcript codec + neutral identity** — not just HTTP/stream. Otherwise
+ * service still has to know assistant-turn / tool-result message shapes,
+ * and G2 (OpenAI Chat) would force a second refactor of the same surface.
+ */
+export interface CatAgentProtocolAdapter {
+  /**
+   * Account family identifier consumed by `resolveApiCredentials` to select
+   * the correct profile shape (`'anthropic'` for `AnthropicMessagesAdapter`;
+   * `'openai'` for the future `OpenAIChatAdapter`; etc.).
+   */
+  readonly clientFamily: string;
+
+  /**
+   * Protocol identifier used for audit + Hub UI label. Stable per
+   * adapter class (e.g. `'anthropic-messages-v1'`).
+   */
+  readonly protocolId: string;
+
+  // ── HTTP / wire layer ──
+
+  /**
+   * Build the absolute request URL. Adapter knows its default base URL +
+   * endpoint path suffix; normalises trailing `/` and any redundant version
+   * segments (see {@link https://github.com/clowder-labs/clowder-ai/pull/15
+   * develop@90810122} `buildAnthropicMessagesUrl` for prior art).
+   */
+  buildRequestUrl(baseURL?: string): string;
+
+  /**
+   * Build HTTP headers — protocol version markers, auth, content type.
+   * Caller provides only credentials; adapter knows its own version pins.
+   */
+  buildRequestHeaders(credentials: AdapterCredentials): Record<string, string>;
+
+  /**
+   * Build the request body as a JSON-serialisable object. Adapter is the
+   * sole owner of body shape — service never constructs `{ model, messages,
+   * stream, tools, system, max_tokens }` style structures directly.
+   */
+  buildRequestBody(input: AdapterRequestInput): unknown;
+
+  // ── Stream layer ──
+
+  /**
+   * Consume the streaming HTTP response body and yield protocol-neutral
+   * stream events. Internal SSE / chunked / JSONL parsing + Anthropic-shape
+   * mapping (input usage, content block deltas, stop_reason) all stay inside
+   * the adapter.
+   */
+  parseStreamEvents(
+    body: ReadableStream<Uint8Array>,
+    signal?: AbortSignal,
+  ): AsyncIterable<CatAgentStreamEvent>;
+
+  // ── Transcript codec (KD-17 core: the half that was missing pre-iteration) ──
+
+  /**
+   * Encode the initial user prompt into an `AdapterMessage`. Always the
+   * first entry of `messages` in {@link AdapterRequestInput}.
+   */
+  encodeUserPrompt(prompt: string): AdapterMessage;
+
+  /**
+   * Encode an assistant turn (mix of text + tool_call blocks, in order)
+   * into an `AdapterMessage`. The service accumulates `CatAgentNeutralBlock[]`
+   * during streaming via `parseStreamEvents` and hands them off here at the
+   * end of each turn — replacing the pre-G1 `messages.push({ role:
+   * 'assistant', content: contentBlocks })` Anthropic shape leak at
+   * `CatAgentService.ts:229`.
+   */
+  encodeAssistantTurn(blocks: ReadonlyArray<CatAgentNeutralBlock>): AdapterMessage;
+
+  /**
+   * Encode tool execution results into an `AdapterMessage`. Replaces the
+   * pre-G1 `messages.push({ role: 'user', content: tool_result[] })`
+   * Anthropic shape leak at `CatAgentService.ts:231`. Whether this maps to
+   * Anthropic's `user`-with-`tool_result[]`, OpenAI's separate
+   * `tool`-role messages, or something else is an adapter-internal concern.
+   */
+  encodeToolResults(results: ReadonlyArray<AdapterToolResult>): AdapterMessage;
+}

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-protocol-factory.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-protocol-factory.ts
@@ -1,0 +1,29 @@
+/**
+ * CatAgent Protocol Factory — F159 Phase G Slice G1
+ *
+ * Single entry point for service to obtain a configured
+ * {@link CatAgentProtocolAdapter}. G1 currently only knows about
+ * `AnthropicMessagesAdapter`; G2 (KD-16) will extend this with
+ * `OpenAIChatAdapter`, gated on `CatConfig.catAgentProtocol` (selection
+ * strategy A from the spec's Slice G2 options).
+ *
+ * Service code never instantiates adapters directly — it calls this factory.
+ * AC-G12 grep verifier asserts service contains no `new
+ * AnthropicMessagesAdapter` (or any other adapter constructor).
+ */
+
+import type { CatConfig } from '@cat-cafe/shared';
+import { AnthropicMessagesAdapter } from './anthropic-messages-adapter.js';
+import type { CatAgentProtocolAdapter } from './catagent-protocol-adapter.js';
+
+/**
+ * Select and instantiate the protocol adapter for a CatAgent member.
+ *
+ * G1: always returns `AnthropicMessagesAdapter`. The `catConfig` parameter
+ * is reserved for G2 — `catConfig.catAgentProtocol === 'openai-chat'` will
+ * dispatch to `OpenAIChatAdapter` (and pick `clientFamily='openai'` for
+ * account resolution downstream).
+ */
+export function createCatAgentProtocolAdapter(_catConfig: CatConfig | null): CatAgentProtocolAdapter {
+  return new AnthropicMessagesAdapter();
+}

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-protocol-types.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-protocol-types.ts
@@ -1,0 +1,110 @@
+/**
+ * CatAgent Protocol Types — F159 Phase G Slice G1
+ *
+ * Protocol-neutral block / event / usage types for CatAgent.
+ *
+ * G1 把 service 层从 Anthropic-specific 类型解耦：service 只持有 neutral
+ * 类型；协议特定的形状（Anthropic content blocks / tool_result / usage 字段）
+ * 封闭在 adapter 内（见 anthropic-messages-adapter.ts）。
+ *
+ * 这是 KD-17 / AC-G11 的实施：CatAgentStreamEvent 必须只引用 neutral 类型，
+ * 不再 import 任何 `Anthropic*` 类型。
+ */
+
+import type { TokenUsage } from '../../../types.js';
+
+// ── Neutral content blocks (assistant turn state) ──
+
+/** Neutral text block — adapter maps from protocol-specific text content. */
+export interface CatAgentTextBlock {
+  type: 'text';
+  text: string;
+}
+
+/**
+ * Neutral tool call block — adapter maps from
+ *   Anthropic `tool_use` / OpenAI `function_call` / Gemini `functionCall` etc.
+ *
+ * `id` is the upstream protocol's tool call ID (Anthropic `toolu_*`,
+ * OpenAI `call_*`). Carried back into next-turn `tool_result` / `tool_call_id`
+ * by `adapter.encodeToolResults`.
+ */
+export interface CatAgentToolCallBlock {
+  type: 'tool_call';
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+/**
+ * Discriminated union — service-side turn state type.
+ *
+ * Replaces `AnthropicContentBlock` as the type of `contentBlocks` in `TurnResult`
+ * and the per-block accumulator in `consumeTurn` (`CatAgentService.ts:253/293`
+ * before G1).
+ */
+export type CatAgentNeutralBlock = CatAgentTextBlock | CatAgentToolCallBlock;
+
+// ── Neutral usage delta ──
+
+/**
+ * Neutral usage delta — adapter normalises protocol-specific usage shape
+ * (Anthropic `input_tokens` / `output_tokens` / `cache_*`; OpenAI
+ * `prompt_tokens` / `completion_tokens`; Gemini `promptTokenCount` /
+ * `candidatesTokenCount`) before yielding `usage_update`.
+ *
+ * Carries the same fields as {@link TokenUsage} but every field is optional
+ * because a single `usage_update` event may only deliver part of the delta
+ * (e.g. Anthropic `message_start` delivers input, `message_delta` delivers
+ * output). The service merges these into a complete `TokenUsage` per turn.
+ *
+ * NOTE: `cacheReadTokens` / `cacheCreationTokens` are kept on this event
+ * surface (rather than collapsed into `inputTokens`) so audit / OTel
+ * downstream can keep the Anthropic prompt-cache observability without
+ * leaking Anthropic-shaped types into service-layer code.
+ */
+export interface CatAgentUsageDelta {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+}
+
+// ── Adapter message (opaque to service) ──
+
+/**
+ * Opaque transcript message — service holds `messages: AdapterMessage[]` and
+ * **never reads / destructures it**. The adapter's `encodeAssistantTurn` /
+ * `encodeToolResults` produce these; only the adapter's `buildRequestBody`
+ * knows how to serialise them back into the protocol-specific request shape.
+ *
+ * AC-G12: opacity is enforced by the type system (no exported shape) + grep
+ * verifier (service module must not import / alias / inspect any
+ * `Anthropic*` typedef). The `__adapterMessage` brand exists purely to make
+ * the type nominal — accidental object literals don't satisfy it.
+ */
+export interface AdapterMessage {
+  readonly __adapterMessage: true;
+  /** Adapter-internal payload — concrete adapters use whatever shape they need. */
+  readonly payload: unknown;
+}
+
+// ── Stream event surface (replaces AnthropicContentBlock-bearing variant) ──
+
+/**
+ * Protocol-neutral stream event.
+ *
+ * All `CatAgentProtocolAdapter.parseStreamEvents` implementations yield this
+ * discriminated union; service consumes it without any Anthropic-specific
+ * knowledge.
+ *
+ * Moved here from `catagent-stream-parser.ts` as part of G1 to enforce
+ * neutrality at the type boundary (AC-G11). The parser file becomes a private
+ * implementation helper of `AnthropicMessagesAdapter`.
+ */
+export type CatAgentStreamEvent =
+  | { type: 'text_delta'; text: string; blockIndex: number }
+  | { type: 'content_block_complete'; block: CatAgentNeutralBlock; blockIndex: number }
+  | { type: 'usage_update'; usage: CatAgentUsageDelta }
+  | { type: 'stop'; stopReason: string | null }
+  | { type: 'stream_error'; error: string };

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-stream-parser.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-stream-parser.ts
@@ -1,23 +1,46 @@
 /**
- * CatAgent SSE Stream Parser — F159 Phase E
+ * CatAgent SSE Stream Parser — F159 Phase E (G1: now yields neutral events)
  *
- * Parses Anthropic Messages API SSE stream into typed events.
+ * Parses Anthropic Messages API SSE stream into protocol-neutral
+ * `CatAgentStreamEvent`s. Anthropic-shaped types (`AnthropicContentBlock`,
+ * `AnthropicUsage`) stay strictly inside this file as Anthropic-specific
+ * intermediate types; the parser maps them to neutral
+ * `CatAgentNeutralBlock` / `CatAgentUsageDelta` before yielding.
+ *
+ * G1 design note: This file is logically a private implementation detail of
+ * `AnthropicMessagesAdapter` — but is kept at this path to minimise rename
+ * churn during the refactor. The grep verifier (AC-G12) treats this file as
+ * adapter-owned, not service-layer, so `Anthropic*` imports here are
+ * expected and allowed.
+ *
  * Handles proper SSE framing (multi-line data, CRLF, comments, event:error).
  * No @anthropic-ai/sdk dependency — raw fetch + TextDecoder.
  */
 
 import type { AnthropicContentBlock, AnthropicUsage } from './catagent-event-bridge.js';
+import { mapAnthropicUsage } from './catagent-event-bridge.js';
+import type { CatAgentNeutralBlock, CatAgentStreamEvent, CatAgentUsageDelta } from './catagent-protocol-types.js';
 
 const MAX_TOOL_INPUT_BYTES = 65_536;
 
-// ── Stream event types ──
+// ── Neutral block / usage normalisation (Anthropic → neutral, adapter-private) ──
 
-export type CatAgentStreamEvent =
-  | { type: 'text_delta'; text: string; blockIndex: number }
-  | { type: 'content_block_complete'; block: AnthropicContentBlock; blockIndex: number }
-  | { type: 'usage_update'; inputUsage?: AnthropicUsage; outputTokens?: number }
-  | { type: 'stop'; stopReason: string | null }
-  | { type: 'stream_error'; error: string };
+function anthropicBlockToNeutral(block: AnthropicContentBlock): CatAgentNeutralBlock {
+  if (block.type === 'text') return { type: 'text', text: block.text };
+  // block.type === 'tool_use'
+  return { type: 'tool_call', id: block.id, name: block.name, input: block.input };
+}
+
+function anthropicInputUsageToNeutral(usage: AnthropicUsage): CatAgentUsageDelta {
+  // Reuse mapAnthropicUsage to keep the cache-aware totalInput convention
+  // (raw + cache_read + cache_creation) — single source of truth for
+  // Anthropic prompt-cache observability normalisation.
+  const tokenUsage = mapAnthropicUsage(usage);
+  const delta: CatAgentUsageDelta = { inputTokens: tokenUsage.inputTokens };
+  if (tokenUsage.cacheReadTokens !== undefined) delta.cacheReadTokens = tokenUsage.cacheReadTokens;
+  if (tokenUsage.cacheCreationTokens !== undefined) delta.cacheCreationTokens = tokenUsage.cacheCreationTokens;
+  return delta;
+}
 
 // ── SSE line parser state ──
 
@@ -157,7 +180,7 @@ function* handleSSEEvent(evt: ParsedSSEEvent, ctx: StreamContext): Iterable<CatA
   if (eventType === 'message_start') {
     const message = parsed.message as Record<string, unknown> | undefined;
     const usage = message?.usage as AnthropicUsage | undefined;
-    if (usage) yield { type: 'usage_update', inputUsage: usage };
+    if (usage) yield { type: 'usage_update', usage: anthropicInputUsageToNeutral(usage) };
     return;
   }
 
@@ -202,7 +225,11 @@ function* handleSSEEvent(evt: ParsedSSEEvent, ctx: StreamContext): Iterable<CatA
     ctx.blocks.delete(index);
 
     if (block.type === 'text') {
-      yield { type: 'content_block_complete', block: { type: 'text', text: block.text }, blockIndex: index };
+      yield {
+        type: 'content_block_complete',
+        block: anthropicBlockToNeutral({ type: 'text', text: block.text }),
+        blockIndex: index,
+      };
     } else {
       let input: Record<string, unknown> = {};
       if (block.toolInputBytes > MAX_TOOL_INPUT_BYTES) {
@@ -216,7 +243,7 @@ function* handleSSEEvent(evt: ParsedSSEEvent, ctx: StreamContext): Iterable<CatA
       }
       yield {
         type: 'content_block_complete',
-        block: { type: 'tool_use', id: block.toolId, name: block.toolName, input },
+        block: anthropicBlockToNeutral({ type: 'tool_use', id: block.toolId, name: block.toolName, input }),
         blockIndex: index,
       };
     }
@@ -227,7 +254,7 @@ function* handleSSEEvent(evt: ParsedSSEEvent, ctx: StreamContext): Iterable<CatA
     const delta = parsed.delta as Record<string, unknown> | undefined;
     const usage = parsed.usage as Record<string, unknown> | undefined;
     const outputTokens = usage?.output_tokens as number | undefined;
-    if (outputTokens !== undefined) yield { type: 'usage_update', outputTokens };
+    if (outputTokens !== undefined) yield { type: 'usage_update', usage: { outputTokens } };
     const stopReason = delta?.stop_reason as string | null | undefined;
     if (stopReason !== undefined) yield { type: 'stop', stopReason };
     return;

--- a/packages/api/test/anthropic-messages-adapter-golden.test.js
+++ b/packages/api/test/anthropic-messages-adapter-golden.test.js
@@ -1,0 +1,369 @@
+/**
+ * AnthropicMessagesAdapter Golden-Wire Contract Test — F159 Phase G G1 AC-G10
+ *
+ * Byte-stable lock on the Anthropic Messages protocol shape:
+ *
+ * - Request URL formation (base URL normalisation: bare host, /v1 suffix,
+ *   trailing slash, empty/undefined, custom proxy without /v1)
+ * - Request headers (x-api-key, anthropic-version pinned, Content-Type)
+ * - Request body JSON shape (model / max_tokens / messages / stream / tools /
+ *   system field presence + value structure)
+ * - Stream event → neutral CatAgentStreamEvent mapping for every Anthropic
+ *   SSE event type (message_start, content_block_*, message_delta, message_stop)
+ *   plus boundary cases (unclosed block, missing message_stop)
+ * - Transcript codec output shape for encodeUserPrompt /
+ *   encodeAssistantTurn / encodeToolResults — verified by round-tripping
+ *   through buildRequestBody and asserting on the serialised JSON keys/values
+ * - mapError text format byte-stability with pre-G1 mapAnthropicError
+ *   ("Anthropic API error (<status>): <msg>")
+ * - isTerminalStopReason classification (terminal whitelist intact)
+ * - clientFamily / protocolId stable identifiers
+ *
+ * Per @gpt555 design gate KD-18: refactor-only "behavior保持" cannot be
+ * proven by broad suite alone; this contract test locks every protocol
+ * detail at byte level so future G2 / G3 changes can't drift Anthropic
+ * wire shape silently.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { AnthropicMessagesAdapter } from '../dist/domains/cats/services/agents/providers/catagent/anthropic-messages-adapter.js';
+
+// ── helpers ──
+
+function toStream(chunks) {
+  let i = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(new TextEncoder().encode(chunks[i++]));
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+function sse(event) {
+  return `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`;
+}
+
+async function collect(iter) {
+  const out = [];
+  for await (const e of iter) out.push(e);
+  return out;
+}
+
+// ── adapter identity ──
+
+describe('AnthropicMessagesAdapter: identity', () => {
+  test('clientFamily and protocolId are stable identifiers', () => {
+    const a = new AnthropicMessagesAdapter();
+    assert.equal(a.clientFamily, 'anthropic');
+    assert.equal(a.protocolId, 'anthropic-messages-v1');
+  });
+});
+
+// ── buildRequestUrl ──
+
+describe('AnthropicMessagesAdapter: buildRequestUrl', () => {
+  const a = new AnthropicMessagesAdapter();
+
+  test('undefined baseURL uses default', () => {
+    assert.equal(a.buildRequestUrl(undefined), 'https://api.anthropic.com/v1/messages');
+  });
+
+  test('empty string baseURL falls back to default', () => {
+    assert.equal(a.buildRequestUrl(''), 'https://api.anthropic.com/v1/messages');
+  });
+
+  test('bare host preserved + /v1/messages appended', () => {
+    assert.equal(a.buildRequestUrl('https://api.anthropic.com'), 'https://api.anthropic.com/v1/messages');
+  });
+
+  test('trailing slash stripped', () => {
+    assert.equal(a.buildRequestUrl('https://api.anthropic.com/'), 'https://api.anthropic.com/v1/messages');
+  });
+
+  test('/v1 suffix not double-prefixed (develop@90810122 fix)', () => {
+    assert.equal(a.buildRequestUrl('https://proxy.example/v1'), 'https://proxy.example/v1/messages');
+  });
+
+  test('/v1/ suffix (trailing slash variant) handled', () => {
+    assert.equal(a.buildRequestUrl('https://proxy.example/v1/'), 'https://proxy.example/v1/messages');
+  });
+
+  test('uppercase /V1 suffix case-insensitive', () => {
+    assert.equal(a.buildRequestUrl('https://proxy.example/V1'), 'https://proxy.example/v1/messages');
+  });
+
+  test('custom proxy without /v1 keeps full path', () => {
+    assert.equal(
+      a.buildRequestUrl('https://api.mycorp.com/anthropic'),
+      'https://api.mycorp.com/anthropic/v1/messages',
+    );
+  });
+});
+
+// ── buildRequestHeaders ──
+
+describe('AnthropicMessagesAdapter: buildRequestHeaders', () => {
+  test('produces exact header set with anthropic-version pinned', () => {
+    const a = new AnthropicMessagesAdapter();
+    const headers = a.buildRequestHeaders({ apiKey: 'sk-test-abc' });
+    assert.deepEqual(headers, {
+      'Content-Type': 'application/json',
+      'x-api-key': 'sk-test-abc',
+      'anthropic-version': '2023-06-01',
+    });
+  });
+});
+
+// ── buildRequestBody (round-tripped through encode methods) ──
+
+describe('AnthropicMessagesAdapter: buildRequestBody', () => {
+  const a = new AnthropicMessagesAdapter();
+
+  test('minimal body (no tools, no system) — wire-stable keys', () => {
+    const messages = [a.encodeUserPrompt('hi')];
+    const body = a.buildRequestBody({ model: 'claude-opus-4-6', messages, tools: [] });
+    // Round-trip serialise to assert JSON shape byte-stably
+    const j = JSON.parse(JSON.stringify(body));
+    assert.deepEqual(j, {
+      model: 'claude-opus-4-6',
+      max_tokens: 4096,
+      messages: [{ role: 'user', content: 'hi' }],
+      stream: true,
+    });
+  });
+
+  test('body with tools — anthropic tool schema shape (name/description/input_schema)', () => {
+    const messages = [a.encodeUserPrompt('do thing')];
+    const body = a.buildRequestBody({
+      model: 'claude-opus-4-6',
+      messages,
+      tools: [{ name: 'read_file', description: 'reads a file', inputSchema: { type: 'object' } }],
+    });
+    const j = JSON.parse(JSON.stringify(body));
+    assert.deepEqual(j.tools, [
+      { name: 'read_file', description: 'reads a file', input_schema: { type: 'object' } },
+    ]);
+  });
+
+  test('body with systemPrompt — placed as top-level "system" field', () => {
+    const messages = [a.encodeUserPrompt('q')];
+    const body = a.buildRequestBody({ model: 'claude-opus-4-6', messages, tools: [], systemPrompt: 'You are X.' });
+    const j = JSON.parse(JSON.stringify(body));
+    assert.equal(j.system, 'You are X.');
+  });
+
+  test('maxTokens override respected', () => {
+    const messages = [a.encodeUserPrompt('q')];
+    const body = a.buildRequestBody({ model: 'm', messages, tools: [], maxTokens: 8192 });
+    const j = JSON.parse(JSON.stringify(body));
+    assert.equal(j.max_tokens, 8192);
+  });
+});
+
+// ── Transcript codec wire shape ──
+
+describe('AnthropicMessagesAdapter: encodeUserPrompt', () => {
+  test('byte-stable Anthropic user message shape', () => {
+    const a = new AnthropicMessagesAdapter();
+    const msg = a.encodeUserPrompt('hello');
+    const body = a.buildRequestBody({ model: 'm', messages: [msg], tools: [] });
+    const j = JSON.parse(JSON.stringify(body));
+    assert.deepEqual(j.messages, [{ role: 'user', content: 'hello' }]);
+  });
+});
+
+describe('AnthropicMessagesAdapter: encodeAssistantTurn', () => {
+  test('mixed text + tool_call blocks render in Anthropic content order', () => {
+    const a = new AnthropicMessagesAdapter();
+    const initial = a.encodeUserPrompt('go');
+    const assistant = a.encodeAssistantTurn([
+      { type: 'text', text: 'thinking…' },
+      { type: 'tool_call', id: 'tu1', name: 'read_file', input: { path: 'a.txt' } },
+    ]);
+    const body = a.buildRequestBody({ model: 'm', messages: [initial, assistant], tools: [] });
+    const j = JSON.parse(JSON.stringify(body));
+    assert.deepEqual(j.messages[1], {
+      role: 'assistant',
+      content: [
+        { type: 'text', text: 'thinking…' },
+        { type: 'tool_use', id: 'tu1', name: 'read_file', input: { path: 'a.txt' } },
+      ],
+    });
+  });
+});
+
+describe('AnthropicMessagesAdapter: encodeToolResults', () => {
+  test('byte-stable Anthropic user-message-with-tool_result shape (no is_error in G1)', () => {
+    const a = new AnthropicMessagesAdapter();
+    const initial = a.encodeUserPrompt('go');
+    const tr = a.encodeToolResults([
+      { id: 'tu1', content: 'file content', status: 'ok' },
+      { id: 'tu2', content: 'Error: nope', status: 'error' },
+    ]);
+    const body = a.buildRequestBody({ model: 'm', messages: [initial, tr], tools: [] });
+    const j = JSON.parse(JSON.stringify(body));
+    // G1 refactor-only: NO is_error field on tool_result blocks (locked
+    // against accidental introduction; G2+ may surface status). Pre-G1 wire
+    // shape preserved exactly.
+    assert.deepEqual(j.messages[1], {
+      role: 'user',
+      content: [
+        { type: 'tool_result', tool_use_id: 'tu1', content: 'file content' },
+        { type: 'tool_result', tool_use_id: 'tu2', content: 'Error: nope' },
+      ],
+    });
+  });
+});
+
+// ── parseStreamEvents: SSE → neutral event mapping ──
+
+describe('AnthropicMessagesAdapter: parseStreamEvents — text + usage + stop', () => {
+  test('message_start usage → neutral CatAgentUsageDelta with cache normalisation', async () => {
+    const a = new AnthropicMessagesAdapter();
+    const stream =
+      sse({ type: 'message_start', message: { id: 'm1', usage: { input_tokens: 100, cache_read_input_tokens: 50, cache_creation_input_tokens: 10 } } }) +
+      sse({ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } }) +
+      sse({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'hi' } }) +
+      sse({ type: 'content_block_stop', index: 0 }) +
+      sse({ type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { output_tokens: 25 } }) +
+      sse({ type: 'message_stop' });
+    const events = await collect(a.parseStreamEvents(toStream([stream])));
+
+    const usage = events.find((e) => e.type === 'usage_update' && e.usage.inputTokens !== undefined);
+    assert.ok(usage, 'has input usage event');
+    // mapAnthropicUsage convention: inputTokens = raw + cache_read + cache_creation
+    assert.equal(usage.usage.inputTokens, 160);
+    assert.equal(usage.usage.cacheReadTokens, 50);
+    assert.equal(usage.usage.cacheCreationTokens, 10);
+
+    const outUsage = events.find((e) => e.type === 'usage_update' && e.usage.outputTokens !== undefined);
+    assert.ok(outUsage);
+    assert.equal(outUsage.usage.outputTokens, 25);
+  });
+
+  test('text_delta → neutral text_delta event with blockIndex preserved', async () => {
+    const a = new AnthropicMessagesAdapter();
+    const stream =
+      sse({ type: 'message_start', message: { id: 'm', usage: { input_tokens: 1 } } }) +
+      sse({ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } }) +
+      sse({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'hel' } }) +
+      sse({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'lo' } }) +
+      sse({ type: 'content_block_stop', index: 0 }) +
+      sse({ type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { output_tokens: 2 } }) +
+      sse({ type: 'message_stop' });
+    const events = await collect(a.parseStreamEvents(toStream([stream])));
+    const deltas = events.filter((e) => e.type === 'text_delta');
+    assert.deepEqual(
+      deltas.map((e) => ({ text: e.text, blockIndex: e.blockIndex })),
+      [
+        { text: 'hel', blockIndex: 0 },
+        { text: 'lo', blockIndex: 0 },
+      ],
+    );
+  });
+
+  test('stop event carries raw stopReason (service consults isTerminalStopReason separately)', async () => {
+    const a = new AnthropicMessagesAdapter();
+    const stream =
+      sse({ type: 'message_start', message: { id: 'm', usage: { input_tokens: 1 } } }) +
+      sse({ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } }) +
+      sse({ type: 'content_block_stop', index: 0 }) +
+      sse({ type: 'message_delta', delta: { stop_reason: 'tool_use' }, usage: { output_tokens: 1 } }) +
+      sse({ type: 'message_stop' });
+    const events = await collect(a.parseStreamEvents(toStream([stream])));
+    const stop = events.find((e) => e.type === 'stop');
+    assert.ok(stop);
+    assert.equal(stop.stopReason, 'tool_use');
+  });
+});
+
+describe('AnthropicMessagesAdapter: parseStreamEvents — tool_call mapping', () => {
+  test('Anthropic tool_use content block → neutral tool_call block (id/name/input preserved)', async () => {
+    const a = new AnthropicMessagesAdapter();
+    const stream =
+      sse({ type: 'message_start', message: { id: 'm', usage: { input_tokens: 1 } } }) +
+      sse({ type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'tu1', name: 'read_file' } }) +
+      sse({ type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{"path":"x.txt"}' } }) +
+      sse({ type: 'content_block_stop', index: 0 }) +
+      sse({ type: 'message_delta', delta: { stop_reason: 'tool_use' }, usage: { output_tokens: 1 } }) +
+      sse({ type: 'message_stop' });
+    const events = await collect(a.parseStreamEvents(toStream([stream])));
+    const complete = events.find((e) => e.type === 'content_block_complete');
+    assert.ok(complete);
+    assert.equal(complete.block.type, 'tool_call'); // NOT 'tool_use' — neutral
+    assert.equal(complete.block.id, 'tu1');
+    assert.equal(complete.block.name, 'read_file');
+    assert.deepEqual(complete.block.input, { path: 'x.txt' });
+  });
+});
+
+describe('AnthropicMessagesAdapter: parseStreamEvents — boundary cases', () => {
+  test('unclosed content block → stream_error', async () => {
+    const a = new AnthropicMessagesAdapter();
+    const stream =
+      sse({ type: 'message_start', message: { id: 'm', usage: { input_tokens: 1 } } }) +
+      sse({ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } }) +
+      sse({ type: 'message_stop' }); // missing content_block_stop
+    const events = await collect(a.parseStreamEvents(toStream([stream])));
+    const err = events.find((e) => e.type === 'stream_error');
+    assert.ok(err);
+    assert.match(err.error, /unclosed content block/i);
+  });
+
+  test('missing message_stop → stream_error', async () => {
+    const a = new AnthropicMessagesAdapter();
+    const stream =
+      sse({ type: 'message_start', message: { id: 'm', usage: { input_tokens: 1 } } }) +
+      sse({ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } }) +
+      sse({ type: 'content_block_stop', index: 0 });
+    // no message_delta, no message_stop
+    const events = await collect(a.parseStreamEvents(toStream([stream])));
+    const err = events.find((e) => e.type === 'stream_error');
+    assert.ok(err);
+    assert.match(err.error, /message_stop/i);
+  });
+});
+
+// ── mapError text format ──
+
+describe('AnthropicMessagesAdapter: mapError', () => {
+  test('byte-stable error text matches pre-G1 mapAnthropicError format', () => {
+    const a = new AnthropicMessagesAdapter();
+    assert.equal(
+      a.mapError({ status: 404, message: 'Not Found' }).errorText,
+      'Anthropic API error (404): Not Found',
+    );
+    assert.equal(
+      a.mapError({ status: 500 }).errorText,
+      'Anthropic API error (500): Unknown API error',
+    );
+    assert.equal(
+      a.mapError({ message: 'Network failed' }).errorText,
+      'Anthropic API error (0): Network failed',
+    );
+  });
+});
+
+// ── isTerminalStopReason ──
+
+describe('AnthropicMessagesAdapter: isTerminalStopReason', () => {
+  const a = new AnthropicMessagesAdapter();
+
+  for (const r of ['end_turn', 'max_tokens', 'stop_sequence', 'refusal', 'model_context_window_exceeded']) {
+    test(`'${r}' is terminal`, () => {
+      assert.equal(a.isTerminalStopReason(r), true);
+    });
+  }
+
+  for (const r of ['tool_use', 'pause_turn', null, undefined, 'future_reason', '']) {
+    test(`${JSON.stringify(r)} is NOT terminal`, () => {
+      assert.equal(a.isTerminalStopReason(r), false);
+    });
+  }
+});

--- a/packages/api/test/catagent-security-baseline.test.js
+++ b/packages/api/test/catagent-security-baseline.test.js
@@ -45,6 +45,33 @@ test('resolveApiCredentials ignores env var — only bound account is authoritat
   }
 });
 
+// F159 Phase G G1 AC-G5 P2 fix (@gpt555 review on PR #23):
+// `clientFamily` must actually guard the resolved profile — an OAuth Anthropic
+// builtin must NOT silently resolve under `clientFamily='openai'`.
+test('resolveApiCredentials fail-closes when OAuth builtin family mismatches requested clientFamily', () => {
+  const tmpDir = realpathSync(mkdtempSync(join(tmpdir(), 'catagent-cred-fam-')));
+  const configDir = join(tmpDir, '.cat-cafe');
+  mkdirSync(configDir, { recursive: true });
+  // `claude` is the Anthropic OAuth builtin per BUILTIN_ACCOUNT_MAP.
+  writeFileSync(join(configDir, 'accounts.json'), JSON.stringify({ claude: { authType: 'oauth' } }));
+  writeFileSync(
+    join(configDir, 'credentials.json'),
+    JSON.stringify({ claude: { apiKey: 'sk-ant-test' } }),
+    { mode: 0o600 },
+  );
+  try {
+    // Sanity: same family resolves (anthropic adapter binding to claude).
+    const ok = resolveApiCredentials(tmpDir, 'opus', { accountRef: 'claude' }, 'anthropic');
+    assert.ok(ok && ok.apiKey === 'sk-ant-test', 'matching clientFamily must resolve');
+
+    // Mismatch: anthropic builtin must not satisfy openai adapter.
+    const mismatch = resolveApiCredentials(tmpDir, 'opus', { accountRef: 'claude' }, 'openai');
+    assert.equal(mismatch, null, 'mismatched clientFamily must fail closed (anthropic builtin under openai adapter)');
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test('resolveApiCredentials does not scan credentials.json even when key exists nearby', () => {
   // Seed a real credential file so a wildcard scanner would find it
   const tmpDir = realpathSync(mkdtempSync(join(tmpdir(), 'catagent-cred-')));

--- a/packages/api/test/catagent-stream-parser.test.js
+++ b/packages/api/test/catagent-stream-parser.test.js
@@ -97,7 +97,7 @@ describe('SSE parser: tool_use streaming', () => {
       sseEvent({ type: 'message_stop' });
 
     const events = await collect(parseAnthropicSSE(toStream([sse])));
-    const complete = events.find((e) => e.type === 'content_block_complete' && e.block.type === 'tool_use');
+    const complete = events.find((e) => e.type === 'content_block_complete' && e.block.type === 'tool_call');
     assert.ok(complete);
     assert.equal(complete.block.name, 'read_file');
     assert.deepEqual(complete.block.input, { path: 'hello.txt' });
@@ -121,7 +121,7 @@ describe('SSE parser: tool_use streaming', () => {
       sseEvent({ type: 'message_stop' });
 
     const events = await collect(parseAnthropicSSE(toStream([sse])));
-    const complete = events.find((e) => e.type === 'content_block_complete' && e.block.type === 'tool_use');
+    const complete = events.find((e) => e.type === 'content_block_complete' && e.block.type === 'tool_call');
     assert.ok(complete);
     assert.ok(complete.block.input._error, 'has error marker');
   });
@@ -142,12 +142,17 @@ describe('SSE parser: usage and stop', () => {
     const events = await collect(parseAnthropicSSE(toStream([sse])));
     const usageEvents = events.filter((e) => e.type === 'usage_update');
     assert.ok(usageEvents.length >= 1, 'has usage events');
-    const inputEvt = usageEvents.find((e) => e.inputUsage);
+    // G1: parser now yields neutral CatAgentUsageDelta (`usage.inputTokens` /
+    // `usage.outputTokens` / `usage.cacheReadTokens` / `usage.cacheCreationTokens`),
+    // and `mapAnthropicUsage` is applied internally so `inputTokens` already
+    // includes the cache normalisation (raw + cache_read + cache_creation).
+    const inputEvt = usageEvents.find((e) => e.usage?.inputTokens !== undefined);
     assert.ok(inputEvt);
-    assert.equal(inputEvt.inputUsage.input_tokens, 100);
-    const outputEvt = usageEvents.find((e) => e.outputTokens !== undefined);
+    assert.equal(inputEvt.usage.inputTokens, 150); // 100 + 50 cache_read
+    assert.equal(inputEvt.usage.cacheReadTokens, 50);
+    const outputEvt = usageEvents.find((e) => e.usage?.outputTokens !== undefined);
     assert.ok(outputEvt);
-    assert.equal(outputEvt.outputTokens, 25);
+    assert.equal(outputEvt.usage.outputTokens, 25);
   });
 
   test('yields stop event with stop_reason', async () => {
@@ -294,6 +299,6 @@ describe('SSE parser: multi-block ordering', () => {
     assert.equal(completes[0].blockIndex, 0);
     assert.equal(completes[0].block.type, 'text');
     assert.equal(completes[1].blockIndex, 1);
-    assert.equal(completes[1].block.type, 'tool_use');
+    assert.equal(completes[1].block.type, 'tool_call');
   });
 });


### PR DESCRIPTION
## Summary

F159 **Phase G Slice G1** implementation — extract the CatAgentProtocolAdapter seam approved in spec PR #21. **Refactor-only**: no behavior change, byte-stable wire shape; the runtime CatAgent fix on develop (\`90810122 fix(catagent): normalize anthropic base url\`) is preserved unchanged.

### Stats
- 5 commits (\`7deac051\` → \`f5c093bf\`)
- New files: 4 (\`catagent-protocol-types.ts\`, \`catagent-protocol-adapter.ts\`, \`anthropic-messages-adapter.ts\`, \`catagent-protocol-factory.ts\`, \`anthropic-messages-adapter-golden.test.js\`, \`verify-catagent-service-neutrality.mjs\`)
- Modified: \`CatAgentService.ts\` / \`catagent-stream-parser.ts\` / \`catagent-credentials.ts\` / \`catagent-stream-parser.test.js\`
- 165/165 tests pass (130 baseline + 35 golden-wire)

## Architecture (per spec Phase G + design gate iteration)

\`\`\`
CatAgentService          ← vendor-neutral entry (AC-G12 verified)
  └─ adapter.buildRequestUrl / Headers / Body
  └─ adapter.parseStreamEvents → yields CatAgentStreamEvent (neutral)
  └─ adapter.encodeUserPrompt / encodeAssistantTurn / encodeToolResults
  └─ adapter.mapError / isTerminalStopReason
      ↓
AnthropicMessagesAdapter ← truthful protocol-specific implementation (KD-15)
  ├─ buildAnthropicMessagesUrl (Anthropic /v1/messages + base URL norm)
  ├─ Anthropic SSE → neutral event mapping (parser-delegated)
  └─ Anthropic transcript shape encoding (\`{role, content[]}\`)
\`\`\`

## Acceptance Criteria

| AC | Status | Evidence |
|---|---|---|
| **G1** \`CatAgentProtocolAdapter\` interface | ✅ | \`catagent-protocol-adapter.ts\` |
| **G2** \`AnthropicMessagesAdapter\` impl (truthful naming) | ✅ | \`anthropic-messages-adapter.ts\` |
| **G3** Service全部走 adapter, no \`Anthropic*\` standalone | ✅ | \`CatAgentService.ts\` + AC-G12 verifier |
| **G4** Factory落地 | ✅ | \`catagent-protocol-factory.ts\` |
| **G5** \`resolveApiCredentials\` accepts \`clientFamily\` param | ✅ | \`catagent-credentials.ts\` |
| **G6** Phase A-F suites 100% pass | ✅ | 67/67 phase-b-completion + security + parser; 38/38 provider+phase-d |
| **G7** Phase E SSE regression 100% pass | ✅ | catagent-phase-e.test.js 9/9 |
| **G8** Phase F write/exec e2e 100% pass | ✅ | catagent-phase-f.test.js 16/16 |
| **G9** Cross-family review通过 | ⏳ pending | @gpt555 |
| **G10** Golden-wire contract test | ✅ | anthropic-messages-adapter-golden.test.js 35/35 |
| **G11** \`CatAgentStreamEvent\` neutral types only | ✅ | \`catagent-protocol-types.ts\` |
| **G12** Service全文搜不到 \`Anthropic*\` identifier (代码层, 不含注释) | ✅ | \`verify-catagent-service-neutrality.mjs\` PASS |

## @gpt555 design gate findings → addressed

- **P1 transcript codec gap** (spec PR #21): G1 seam includes \`encodeUserPrompt\` / \`encodeAssistantTurn\` / \`encodeToolResults\` + neutral \`CatAgentNeutralBlock\` / \`CatAgentUsageDelta\` event types. Service holds opaque \`AdapterMessage[]\`, never reads \`{ role, content }\`.
- **P2 golden-wire**: \`anthropic-messages-adapter-golden.test.js\` byte-locks request URL / headers / body / SSE event mapping / transcript shape / mapError text / isTerminalStopReason set.
- **Step-3 \`__adapterMessage\` opacity**: verifier script asserts service file contains zero \`__adapterMessage\` literal — only the private \`wrapMessage\` factory in adapter constructs them.
- **AC-G12 type imports + helper names + local aliases coverage**: verifier script strips comments first, then matches \`/Anthropic[A-Za-z0-9_]*/g\` + \`/anthropic[A-Za-z0-9_]*/g\` regex (covers type imports, helper calls, variables, constructors).

## Test plan

- [ ] @gpt555 cross-family code review — focus on:
  - Adapter interface coverage vs real耦合点 (CatAgentService line refs from spec PR P1)
  - Golden-wire test完备性 (request shape, stream event mapping, transcript, error, terminal classification)
  - AC-G12 verifier script的 regex粒度是否真把"类型 import + helper名 + 局部 alias"覆盖（不只值层）
  - 是否还有遗漏的 Anthropic 形状 leak 我没抓到
- [ ] Run \`node packages/api/scripts/verify-catagent-service-neutrality.mjs\` 自验
- [ ] Run \`pnpm --dir packages/api run build && CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 node --test packages/api/test/catagent-*.test.js packages/api/test/anthropic-messages-adapter-golden.test.js\` 165/165 pass

## Refs

- Spec: F159 Phase G section (merged in #21)
- Trigger: co-creator feedback "应该把 catagent 拼 endpoint URL 入口改为通用命名，不绑定某个厂商" → KD-15 (truthful naming) + KD-17 (4层 seam) + KD-18 (golden-wire merge gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)