### PR TITLE
fix(ci): sync gate provides git identity for test:public sandbox

### DIFF
--- a/.github/workflows/sync-upstream-main.yml
+++ b/.github/workflows/sync-upstream-main.yml
@@ -86,6 +86,16 @@ jobs:
         # treated as "missing" — which is the wrong semantics for sync. The
         # incremental check still runs on regular PRs against fork develop,
         # where the diff range is correct.
+        #
+        # GIT_* env vars mirror upstream ci.yml's Test (Public) job (added in
+        # upstream PR #994). F208 execute-apply tests spawn `git commit` inside
+        # scripts/with-test-home.sh sandbox, which switches HOME and drops the
+        # workflow's `git config` settings — env vars survive that switch.
+        env:
+          GIT_AUTHOR_NAME: CI Runner
+          GIT_AUTHOR_EMAIL: ci@clowder-ai.dev
+          GIT_COMMITTER_NAME: CI Runner
+          GIT_COMMITTER_EMAIL: ci@clowder-ai.dev
         run: |
           set -euo pipefail
           pnpm biome check . --diagnostic-level=error


### PR DESCRIPTION
## Summary

Fourth and (hopefully) final fix in the upstream-sync recovery sprint. Adds `GIT_AUTHOR_* / GIT_COMMITTER_*` env vars to the sync workflow's `Gate merged main` step, mirroring upstream PR #994's fix for the same problem in `ci.yml`.

| PR | Fix | Status |
|---|---|---|
| #19 | sync workflow node 20→24 | ✅ merged |
| #20 | sync gate drops incremental capability-tips | ✅ merged |
| #22 | extend 5 expired test exclusions 6-23→6-30 | ✅ merged, PR CI's Test (Public) passed 13m17s |
| **#23 (this)** | git identity env vars for test:public sandbox | last known blocker |

## Root cause (evidence-based)

F208 execute-apply tests (`packages/api/test/dossier-execute-apply.test.js`) spawn `git commit -m init` inside `scripts/with-test-home.sh`, which switches `HOME` to a sandbox dir. The workflow's `git config user.name/email` setting (from the `Configure git` step) is local to the source repo and does not follow the HOME switch, so the sandboxed `git` aborts with `Author identity unknown`.

`GIT_AUTHOR_NAME / GIT_AUTHOR_EMAIL / GIT_COMMITTER_NAME / GIT_COMMITTER_EMAIL` env vars are inherited across HOME switches, so they survive the sandbox transition.

This is the **same root cause and same fix** that upstream applied in PR #994:

> *fix(ci): resolve 3 CI failures — dir-size, lint fetch-depth, test git identity*  
> *Test: configure git user.email/name for with-test-home.sh sandbox (F208 execute-apply tests need git commit in clean HOME)*

Upstream's fix was applied to `ci.yml` (their PR-time CI workflow). Fork's `sync-upstream-main.yml` is a private workflow not covered by upstream's CI patches, so the env var injection was missing here.

## Evidence

Dispatch [`28079401497`](https://github.com/clowder-labs/clowder-ai/actions/runs/28079401497) after #19+#20+#22 all merged:
- merge ✓
- install ✓ (Node 24 from #19)
- 12 sub-checks ✓ (capability-tips skipped from #20)
- shared/api/web builds ✓
- test:public ran for ~13 min, most tests passing, then failed at F208 AC-E3 with:

```
✖ F208 AC-E3: execute-apply endpoint
Error: Command failed: git commit -m init
Author identity unknown
*** Please tell me who you are.
fatal: empty ident name (for <runner@runnervm7b5n9...>) not allowed
status: 128
```

## Scope

- Single file: `.github/workflows/sync-upstream-main.yml`
- `+10 / -0`: 4-line env block + 6-line explanatory comment
- The env vars only scope to the `Gate merged main` step, not other steps
- Identical env var names/values to upstream's ci.yml Test (Public) step

## Test plan

- [ ] After merge, manual `workflow_dispatch` of `sync-upstream-main.yml` — expect first end-to-end success
- [ ] Verify upstream's 4 pending commits flow into fork main
- [ ] Verify a develop sync PR opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)