### PR TITLE
feat(F159): Phase G Slice G2 — OpenAIChatAdapter + 协议选择位

### DIFF
--- a/docs/features/F159-catagent-native-provider.md
+++ b/docs/features/F159-catagent-native-provider.md
@@ -387,9 +387,9 @@ G2 覆盖**四个真相源轴**（任何一个缺，G2 就是局部解，G3 上�
 - [ ] AC-G19: 保留 `client-routing.test.js:10` 旧 assertion 不变（保护 client-level default 语义）；G2 加新测试覆盖 `effectiveProtocolForCat` / `effectiveClientFamilyForCat` 含 `anthropic-messages` + `openai-chat` 两种 + 非 catagent fallthrough；audit 所有 `protocolForClient('catagent')` / `builtinAccountFamilyForClient('catagent')` 调用点，逐个判断走 default 还是迁移到 effective* 变体
 
 ##### Axis 4: AccountConfig api_key clientFamily
-- [ ] AC-G20: `AccountConfig` (@cat-cafe/shared) 在 api_key 账号 schema 加 optional `clientFamily?: 'anthropic' | 'openai' | 'google' | 'kimi' | 'dare' | 'opencode'`
-- [ ] AC-G21: `accountToRuntimeProfile` 对 api_key 账号从 `account.clientFamily` 读 family 设到 `profile.client`；缺省 fall through（向下兼容现有 api_key 账号未声明 family）
-- [ ] AC-G22: `catagent-credentials.ts` 的 G1 narrow guard 在 api_key + 声明 family 路径上也生效（完整 family fail-closed）
+- [x] AC-G20: `AccountConfig` (@cat-cafe/shared) 在 api_key 账号 schema 加 optional `clientFamily?: 'anthropic' | 'openai' | 'google' | 'kimi' | 'dare' | 'opencode'`（coexists with F171 freeform `clientId`；rename 被否决，原因是 `accounts.json` in the wild 已有 `clientId` set，silent data loss > naming duplication；TODO G3+ Hub UI 迁移后 sunset `clientId`）
+- [x] AC-G21: `accountToRuntimeProfile` 对 api_key 账号从 `account.clientFamily` 读 family 设到 `profile.client`；缺省 fall through（向下兼容现有 api_key 账号未声明 family）；严格 NEVER 从 legacy `clientId` 读，避免改动 F171 行为
+- [x] AC-G22: `catagent-credentials.ts` 的 G1 narrow guard 在 api_key + 声明 family 路径上也生效（完整 family fail-closed）；现有 guard `profile.client !== undefined && profile.client !== clientFamily` 行为不变，AC-G21 让 api_key 路径自动落入
 
 ##### Axis 5: OpenAIChatAdapter 实现
 - [ ] AC-G23: `OpenAIChatAdapter` 实现 `CatAgentProtocolAdapter` 全部七个方法 + `clientFamily='openai'` + `protocolId='openai-chat-v1'`
@@ -515,3 +515,4 @@ G2 覆盖**四个真相源轴**（任何一个缺，G2 就是局部解，G3 上�
 | 2026-06-24 | Phase G Slice G1 implementation merge (`b8bab800` PR #23) | refactor-only adapter seam + AnthropicMessagesAdapter 落地；166/166 tests pass + AC-G12 verifier PASS；P2 OAuth builtin family guard 收口 |
 | 2026-06-24 | Phase G Slice G2 升级到 in-design：协议选择位 + OpenAIChatAdapter | 触发：co-creator dogfood 撞 OpenAI-only 代理 `403 permission_error: "This group does not allow /v1/messages dispatch"` 实证 (KD-23)；@gpt555 G2 pre-design push back 扩 scope 到真相源协议选择位 + shared routing contract + api_key clientFamily schema 4 axes (KD-19~22)；新增 AC-G13~G28 |
 | 2026-06-24 | Phase G Slice G2 spec 修订（design gate iteration） | @gpt555 G2 design gate review P1+P2：P1 merge gate gap → AC-G29/G30/G31 + KD-25 把 G1 Anthropic broad suite + golden-wire + factory 默认分支锁成显式硬门；P2 shared helper contract 二选一 → KD-24 拍板保留现有 `protocolForClient` / `builtinAccountFamilyForClient` 作 client-level default，新增 `effectiveProtocolForCat` / `effectiveClientFamilyForCat` 承担 member-level protocol-aware，避免污染 shared routing 语义 |
+| 2026-06-24 | Phase G Slice G2 Axis 4 impl ship (`2af8aad2` + biome chore `f8e6ff6c`) | AC-G20/G21/G22 全过：AccountConfig api_key `clientFamily` 字段 + `accountToRuntimeProfile` 设 `profile.client` + G1 narrow guard 自动 cover api_key 路径；KD-22 收口。106/106 定向回归 PASS (security-baseline 21 + account-resolver 18 + phase-e 8 + phase-f 16 + golden-wire 8 + factory 35) + AC-G12 verifier PASS。Rename `clientId` → `clientFamily` 被否决（数据兼容 > 命名一致），保留两字段共存 + TODO 标记 G3+ sunset |

--- a/docs/features/F159-catagent-native-provider.md
+++ b/docs/features/F159-catagent-native-provider.md
@@ -392,19 +392,19 @@ G2 覆盖**四个真相源轴**（任何一个缺，G2 就是局部解，G3 上�
 - [x] AC-G22: `catagent-credentials.ts` 的 G1 narrow guard 在 api_key + 声明 family 路径上也生效（完整 family fail-closed）；现有 guard `profile.client !== undefined && profile.client !== clientFamily` 行为不变，AC-G21 让 api_key 路径自动落入
 
 ##### Axis 5: OpenAIChatAdapter 实现
-- [ ] AC-G23: `OpenAIChatAdapter` 实现 `CatAgentProtocolAdapter` 全部七个方法 + `clientFamily='openai'` + `protocolId='openai-chat-v1'`
-- [ ] AC-G24: tool calling 在 OpenAI 协议下 lossless 映射：`tool_calls[i].id` ↔ neutral `id`，`tool_calls[i].function.name` ↔ neutral `name`，`JSON.parse(tool_calls[i].function.arguments)` ↔ neutral `input`
-- [ ] AC-G25: 新增 `openai-chat-adapter-golden.test.js` golden-wire byte-stable lock（与 G1 Anthropic golden-wire 同形式）：URL / headers / body / SSE event 映射 / transcript codec / mapError / isTerminalStopReason
-- [ ] AC-G26: 新增 e2e 行为测试：建一只 `clientId='catagent'` + `catAgentProtocol='openai-chat'` 的猫，绑一个 mock OpenAI Chat 账号，跑 single-turn 文本 + 含 tool_call 的多轮路径，断言行为对齐 G1 Anthropic 路径
+- [x] AC-G23: `OpenAIChatAdapter` 实现 `CatAgentProtocolAdapter` 全部七个方法 + `clientFamily='openai'` + `protocolId='openai-chat-v1'`
+- [x] AC-G24: tool calling 在 OpenAI 协议下 lossless 映射：`tool_calls[i].id` ↔ neutral `id`，`tool_calls[i].function.name` ↔ neutral `name`，`JSON.parse(tool_calls[i].function.arguments)` ↔ neutral `input`
+- [x] AC-G25: 新增 `openai-chat-adapter-golden.test.js` golden-wire byte-stable lock（与 G1 Anthropic golden-wire 同形式）：URL / headers / body / SSE event 映射 / transcript codec / mapError / isTerminalStopReason
+- [x] AC-G26: 新增 e2e 行为测试：建一只 `clientId='catagent'` + `catAgentProtocol='openai-chat'` 的猫，绑一个 mock OpenAI Chat 账号，跑 single-turn 文本 + 含 tool_call 的多轮路径，断言行为对齐 G1 Anthropic 路径
 
 ##### Cross-cutting
-- [ ] AC-G27: AC-G12 grep verifier 扩展：service 层也不允许 `Openai*` / `openai*` 代码标识符（保持 vendor-neutral）；扩多协议后 verifier 仍 pass
+- [x] AC-G27: AC-G12 grep verifier 扩展：service 层也不允许 `Openai*` / `openai*` 代码标识符（保持 vendor-neutral）；扩多协议后 verifier 仍 pass
 - [ ] AC-G28: 跨 family review 通过；Hub UI 跨 protocol switch UX 走暹罗猫审美 review
 
 ##### Regression hard gate (G2 merge 必经，收砚砚 P1 finding)
-- [ ] AC-G29: G1 既有的 Anthropic broad suite (catagent-phase-e/f/d/provider/security-baseline/stream-parser/phase-b-completion = 130+ tests) 在 G2 之后 **100% 不变化通过**；任何 regression 视为 G2 blocker，不允许"新路径全绿就 merge"
-- [ ] AC-G30: G1 `AnthropicMessagesAdapter` golden-wire contract test (`anthropic-messages-adapter-golden.test.js`, 35 tests) 在 G2 之后 **byte-stable 100% pass**——共享 routing / catalog / routes / credentials 改动不能让 Anthropic wire shape 漂移哪怕 1 byte
-- [ ] AC-G31: AC-G12 verifier 不仅 service neutrality PASS，还必须验证现有 catagent member 在 `catAgentProtocol` 缺省时**继续走 Anthropic adapter**（factory 默认分支行为不变）
+- [x] AC-G29: G1 既有的 Anthropic broad suite (catagent-phase-e/f/d/provider/security-baseline/stream-parser/phase-b-completion = 130+ tests) 在 G2 之后 **100% 不变化通过**；任何 regression 视为 G2 blocker，不允许"新路径全绿就 merge"
+- [x] AC-G30: G1 `AnthropicMessagesAdapter` golden-wire contract test (`anthropic-messages-adapter-golden.test.js`, 35 tests) 在 G2 之后 **byte-stable 100% pass**——共享 routing / catalog / routes / credentials 改动不能让 Anthropic wire shape 漂移哪怕 1 byte
+- [x] AC-G31: AC-G12 verifier 不仅 service neutrality PASS，还必须验证现有 catagent member 在 `catAgentProtocol` 缺省时**继续走 Anthropic adapter**（factory 默认分支行为不变）
 
 > Implementation note (2026-06-16): `update_current_task_status` 只从 thread metadata 中显式选中的 current task 注入；callback 执行时会重新校验 `threadId` 和 `ownerCatId`。未选中 task、跨 thread、跨 owner 时不注册该工具。`post_current_thread_status` / raw `post_message` / `create_task` / cross-thread / A2A routing 仍未进入 Phase F 工具面。
 
@@ -516,3 +516,4 @@ G2 覆盖**四个真相源轴**（任何一个缺，G2 就是局部解，G3 上�
 | 2026-06-24 | Phase G Slice G2 升级到 in-design：协议选择位 + OpenAIChatAdapter | 触发：co-creator dogfood 撞 OpenAI-only 代理 `403 permission_error: "This group does not allow /v1/messages dispatch"` 实证 (KD-23)；@gpt555 G2 pre-design push back 扩 scope 到真相源协议选择位 + shared routing contract + api_key clientFamily schema 4 axes (KD-19~22)；新增 AC-G13~G28 |
 | 2026-06-24 | Phase G Slice G2 spec 修订（design gate iteration） | @gpt555 G2 design gate review P1+P2：P1 merge gate gap → AC-G29/G30/G31 + KD-25 把 G1 Anthropic broad suite + golden-wire + factory 默认分支锁成显式硬门；P2 shared helper contract 二选一 → KD-24 拍板保留现有 `protocolForClient` / `builtinAccountFamilyForClient` 作 client-level default，新增 `effectiveProtocolForCat` / `effectiveClientFamilyForCat` 承担 member-level protocol-aware，避免污染 shared routing 语义 |
 | 2026-06-24 | Phase G Slice G2 Axis 4 impl ship (`2af8aad2` + biome chore `f8e6ff6c`) | AC-G20/G21/G22 全过：AccountConfig api_key `clientFamily` 字段 + `accountToRuntimeProfile` 设 `profile.client` + G1 narrow guard 自动 cover api_key 路径；KD-22 收口。106/106 定向回归 PASS (security-baseline 21 + account-resolver 18 + phase-e 8 + phase-f 16 + golden-wire 8 + factory 35) + AC-G12 verifier PASS。Rename `clientId` → `clientFamily` 被否决（数据兼容 > 命名一致），保留两字段共存 + TODO 标记 G3+ sunset |
+| 2026-06-24 | Phase G Slice G2 Axis 5 impl ship | AC-G23/G24/G25/G26/G27 + regression hard gate AC-G29/G30/G31 全过：`OpenAIChatAdapter` 落地、factory dispatch 切到真实实现、OpenAI golden-wire + vendor-neutral verifier + OpenAI e2e 行为测试新增；Anthropic broad suite + golden-wire + default-branch verifier 继续全绿。194/194 定向回归 PASS |

--- a/packages/api/scripts/verify-catagent-service-neutrality.mjs
+++ b/packages/api/scripts/verify-catagent-service-neutrality.mjs
@@ -42,8 +42,8 @@ function stripComments(s) {
 const code = stripComments(src);
 
 // Match identifier-shaped tokens beginning with Anthropic
-const anthropicHits = [...new Set((code.match(/\bAnthropic[A-Za-z0-9_]*/g) || []))];
-const lowerHits = [...new Set((code.match(/\banthropic[A-Za-z0-9_]*/g) || []))];
+const anthropicHits = [...new Set(code.match(/\bAnthropic[A-Za-z0-9_]*/g) || [])];
+const lowerHits = [...new Set(code.match(/\banthropic[A-Za-z0-9_]*/g) || [])];
 const opaqueLeak = code.includes('__adapterMessage');
 
 let failed = false;

--- a/packages/api/src/config/account-resolver.ts
+++ b/packages/api/src/config/account-resolver.ts
@@ -241,11 +241,21 @@ function accountToRuntimeProfile(ref: string, account: AccountConfig, projectRoo
   const builtinProtocol = builtinClient ? protocolForClient(builtinClient) : null;
   const isOAuth = account.authType === 'oauth';
   const isBuiltin = !!builtinClient && isOAuth;
+  // F159 G2 AC-G21: api_key accounts with explicit `account.clientFamily` set
+  // `profile.client` to that family — enables the fail-closed family guard in
+  // catagent-credentials.ts (AC-G22) so that e.g. an api_key account marked
+  // `clientFamily='openai'` cannot satisfy an Anthropic adapter request.
+  // Strictly read from `clientFamily` only — never from legacy F171 `clientId`
+  // (which is freeform display, not authoritative routing/security identity).
+  // Legacy api_key accounts without `clientFamily` fall through with
+  // `profile.client=undefined`, preserving pre-G2 best-effort resolution.
+  const apiKeyClient = !isOAuth ? account.clientFamily : undefined;
+  const resolvedClient = isBuiltin ? builtinClient : apiKeyClient;
   return {
     id: ref,
     authType: account.authType,
     kind: isBuiltin ? 'builtin' : 'api_key',
-    ...(isBuiltin && builtinClient ? { client: builtinClient } : {}),
+    ...(resolvedClient ? { client: resolvedClient } : {}),
     ...(builtinProtocol ? { protocol: builtinProtocol } : {}),
     ...(account.baseUrl ? { baseUrl: account.baseUrl } : {}),
     ...(apiKey ? { apiKey } : {}),

--- a/packages/api/src/config/cat-config-loader.ts
+++ b/packages/api/src/config/cat-config-loader.ts
@@ -116,6 +116,7 @@ const catVariantSchema = z.object({
   contextBudget: contextBudgetSchema.optional(),
   nativeToolLevel: z.enum(['L0', 'L1', 'L2']).optional(), // F159 Phase F
   commandPolicy: z.array(commandPolicyEntrySchema).optional(), // F159 Phase F
+  catAgentProtocol: z.enum(['anthropic-messages', 'openai-chat']).optional(), // F159 Phase G G2 AC-G15
   voiceConfig: z // F103: per-cat TTS voice configuration
     .object({
       voice: z.string().min(1),
@@ -535,6 +536,7 @@ export function toAllCatConfigs(config: CatCafeConfig): Record<string, CatConfig
         ...(variant.contextBudget != null ? { contextBudget: variant.contextBudget } : {}),
         ...(variant.nativeToolLevel != null ? { nativeToolLevel: variant.nativeToolLevel } : {}),
         ...(variant.commandPolicy != null ? { commandPolicy: variant.commandPolicy } : {}),
+        ...(variant.catAgentProtocol != null ? { catAgentProtocol: variant.catAgentProtocol } : {}),
         ...(variant.voiceConfig != null ? { voiceConfig: variant.voiceConfig } : {}),
         roleDescription: variant.roleDescription ?? breed.roleDescription,
         personality: variant.personality ?? defaultVariant?.personality ?? '',

--- a/packages/api/src/config/runtime-cat-catalog.ts
+++ b/packages/api/src/config/runtime-cat-catalog.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import type {
+  CatAgentProtocol,
   CatBreed,
   CatCafeConfig,
   CatColor,
@@ -46,6 +47,8 @@ export interface RuntimeCatInput {
   cliConfigArgs?: string[];
   nativeToolLevel?: NativeToolLevel;
   commandPolicy?: CommandPolicyEntry[];
+  /** F159 Phase G G2 (AC-G14): CatAgent wire protocol; only persisted when clientId === 'catagent'. */
+  catAgentProtocol?: CatAgentProtocol;
   contextBudget?: ContextBudget;
   voiceConfig?: VoiceConfig;
   /** clowder-ai#340 P5: Model provider name (renamed from ocProviderName). */
@@ -77,6 +80,8 @@ export interface RuntimeCatUpdate {
   cliConfigArgs?: string[];
   nativeToolLevel?: NativeToolLevel | null;
   commandPolicy?: CommandPolicyEntry[] | null;
+  /** F159 Phase G G2 (AC-G14): CatAgent wire protocol; null to clear, undefined to skip. */
+  catAgentProtocol?: CatAgentProtocol | null;
   contextBudget?: ContextBudget | null;
   voiceConfig?: VoiceConfig | null;
   /** clowder-ai#340 P5: Model provider name (renamed from ocProviderName). */
@@ -238,6 +243,9 @@ function createBreedFromInput(input: RuntimeCatInput): CatBreed {
         ...(input.clientId === 'catagent' && input.nativeToolLevel ? { nativeToolLevel: input.nativeToolLevel } : {}),
         ...(input.clientId === 'catagent' && input.commandPolicy && input.commandPolicy.length > 0
           ? { commandPolicy: input.commandPolicy }
+          : {}),
+        ...(input.clientId === 'catagent' && input.catAgentProtocol
+          ? { catAgentProtocol: input.catAgentProtocol }
           : {}),
         ...(input.provider ? { provider: input.provider } : {}),
         ...(input.contextBudget ? { contextBudget: input.contextBudget } : {}),
@@ -457,9 +465,19 @@ export function updateRuntimeCat(projectRoot: string, catId: string, patch: Runt
         delete variant.commandPolicy;
       }
     }
+    // F159 Phase G G2 (AC-G14): catAgentProtocol persisted only when clientId === 'catagent';
+    // null clears, undefined skips. Switching away from catagent below also clears it.
+    if (patch.catAgentProtocol !== undefined) {
+      if (patch.catAgentProtocol) {
+        variant.catAgentProtocol = patch.catAgentProtocol;
+      } else {
+        delete variant.catAgentProtocol;
+      }
+    }
   } else {
     delete variant.nativeToolLevel;
     delete variant.commandPolicy;
+    delete variant.catAgentProtocol;
   }
   if (patch.provider !== undefined) {
     if (patch.provider) {

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/anthropic-messages-adapter.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/anthropic-messages-adapter.ts
@@ -20,19 +20,15 @@
  * never construct `{ __adapterMessage: true, payload: ... }` directly.
  */
 
+import type { AnthropicContentBlock } from './catagent-event-bridge.js';
+import { TERMINAL_STOP_REASONS } from './catagent-event-bridge.js';
 import type {
   AdapterCredentials,
   AdapterRequestInput,
   AdapterToolResult,
   CatAgentProtocolAdapter,
 } from './catagent-protocol-adapter.js';
-import type { AnthropicContentBlock } from './catagent-event-bridge.js';
-import type {
-  AdapterMessage,
-  CatAgentNeutralBlock,
-  CatAgentStreamEvent,
-} from './catagent-protocol-types.js';
-import { TERMINAL_STOP_REASONS } from './catagent-event-bridge.js';
+import type { AdapterMessage, CatAgentNeutralBlock, CatAgentStreamEvent } from './catagent-protocol-types.js';
 import { parseAnthropicSSE } from './catagent-stream-parser.js';
 
 // ── Anthropic protocol constants (adapter-owned, not service-owned) ──
@@ -132,10 +128,7 @@ export class AnthropicMessagesAdapter implements CatAgentProtocolAdapter {
     return body;
   }
 
-  parseStreamEvents(
-    body: ReadableStream<Uint8Array>,
-    signal?: AbortSignal,
-  ): AsyncIterable<CatAgentStreamEvent> {
+  parseStreamEvents(body: ReadableStream<Uint8Array>, signal?: AbortSignal): AsyncIterable<CatAgentStreamEvent> {
     // Parser already yields neutral CatAgentStreamEvent post-G1 step 4.
     return parseAnthropicSSE(body, signal);
   }

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-credentials.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-credentials.ts
@@ -11,11 +11,11 @@
  */
 
 import type { CatConfig } from '@cat-cafe/shared';
-import { resolveForClient } from '../../../../../../config/account-resolver.js';
 // `BuiltinAccountClient` is the resolver's narrow union (subset of ClientId).
 // Imported as a type-only re-export from account-resolver to avoid importing
 // from @cat-cafe/shared twice in this file.
 import type { BuiltinAccountClient } from '../../../../../../config/account-resolver.js';
+import { resolveForClient } from '../../../../../../config/account-resolver.js';
 import { resolveBoundAccountRefForCat } from '../../../../../../config/cat-account-binding.js';
 import { createModuleLogger } from '../../../../../../infrastructure/logger.js';
 
@@ -71,18 +71,15 @@ export function resolveApiCredentials(
   // `clientFamily='openai'` silently, making AC-G5 cosmetic and exposing
   // G2 to silent family routing failures when OpenAIChatAdapter lands.
   //
-  // Post-check: if the profile carries a builtin client identity
-  // (`profile.client` is set only for OAuth/builtin accounts per
-  // `accountToRuntimeProfile`), it MUST match the requested clientFamily.
-  // Mismatch → fail closed.
+  // Post-check: if the profile carries a client identity (`profile.client`),
+  // it MUST match the requested clientFamily. Mismatch → fail closed.
   //
-  // Scope note (deferred to G2 spec): api_key accounts today have no
-  // explicit family on schema (`accountToRuntimeProfile` only sets
-  // `profile.client` for OAuth builtins). The G2 spec must define how
-  // api_key accounts declare family so this guard becomes complete
-  // (not just OAuth/builtin half). For now api_key + missing family is
-  // best-effort and falls through — the runtime API call will fail if
-  // the proxy doesn't speak the requested protocol, surfacing the
+  // F159 G2 AC-G21/G22 (KD-22 resolved): `profile.client` is now set for both
+  // OAuth builtin accounts (via BUILTIN_ACCOUNT_MAP) AND api_key accounts that
+  // declare `account.clientFamily` in their schema. This guard fires on both
+  // paths — closing the half-coverage left by G1. Legacy api_key accounts
+  // without `clientFamily` still fall through with `profile.client=undefined`
+  // (best-effort backward compat); runtime API call surfaces protocol
   // mismatch at first invocation rather than silently routing.
   if (profile.client !== undefined && profile.client !== clientFamily) {
     log.warn(

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-protocol-adapter.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-protocol-adapter.ts
@@ -20,11 +20,7 @@
  * - Protocol id (used for audit + Hub UI label)
  */
 
-import type {
-  AdapterMessage,
-  CatAgentNeutralBlock,
-  CatAgentStreamEvent,
-} from './catagent-protocol-types.js';
+import type { AdapterMessage, CatAgentNeutralBlock, CatAgentStreamEvent } from './catagent-protocol-types.js';
 
 /** Credentials passed into the adapter at request build time (per-invocation). */
 export interface AdapterCredentials {
@@ -123,10 +119,7 @@ export interface CatAgentProtocolAdapter {
    * mapping (input usage, content block deltas, stop_reason) all stay inside
    * the adapter.
    */
-  parseStreamEvents(
-    body: ReadableStream<Uint8Array>,
-    signal?: AbortSignal,
-  ): AsyncIterable<CatAgentStreamEvent>;
+  parseStreamEvents(body: ReadableStream<Uint8Array>, signal?: AbortSignal): AsyncIterable<CatAgentStreamEvent>;
 
   // ── Transcript codec (KD-17 core: the half that was missing pre-iteration) ──
 

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-protocol-factory.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-protocol-factory.ts
@@ -1,29 +1,83 @@
 /**
- * CatAgent Protocol Factory — F159 Phase G Slice G1
+ * CatAgent Protocol Factory — F159 Phase G Slice G1 + G2
  *
  * Single entry point for service to obtain a configured
- * {@link CatAgentProtocolAdapter}. G1 currently only knows about
- * `AnthropicMessagesAdapter`; G2 (KD-16) will extend this with
- * `OpenAIChatAdapter`, gated on `CatConfig.catAgentProtocol` (selection
- * strategy A from the spec's Slice G2 options).
+ * {@link CatAgentProtocolAdapter}. G2 (KD-19/KD-20) dispatches based on
+ * `catConfig.catAgentProtocol`:
+ * - `undefined` / `'anthropic-messages'` → `AnthropicMessagesAdapter` (G1 default,
+ *   preserves G1 catagent member behavior — KD-25 first half byte-stable)
+ * - `'openai-chat'` → `OpenAIChatAdapter` (G2 Axis 5, implementation pending)
+ * - unknown value → **fail closed (throw)** — KD-20: no fallback, no
+ *   runtime protocol guessing, no silent vendor routing
  *
  * Service code never instantiates adapters directly — it calls this factory.
  * AC-G12 grep verifier asserts service contains no `new
  * AnthropicMessagesAdapter` (or any other adapter constructor).
  */
 
-import type { CatConfig } from '@cat-cafe/shared';
+import type { CatAgentProtocol, CatConfig } from '@cat-cafe/shared';
 import { AnthropicMessagesAdapter } from './anthropic-messages-adapter.js';
 import type { CatAgentProtocolAdapter } from './catagent-protocol-adapter.js';
 
 /**
  * Select and instantiate the protocol adapter for a CatAgent member.
  *
- * G1: always returns `AnthropicMessagesAdapter`. The `catConfig` parameter
- * is reserved for G2 — `catConfig.catAgentProtocol === 'openai-chat'` will
- * dispatch to `OpenAIChatAdapter` (and pick `clientFamily='openai'` for
- * account resolution downstream).
+ * Selection strategy = spec Slice G2 option A: explicit `catAgentProtocol`
+ * field on `CatConfig` (set via Hub UI / routes / catalog persistence,
+ * see G2 Axis 1 step 1a-1c). G2 KD-20 explicitly rejects option B
+ * (probing baseUrl shape) — that path is fragile, unauditable, and grows
+ * exponentially as protocols are added.
+ *
+ * Fail-closed contract:
+ * - Unknown protocol value → throw before any HTTP / credential resolution
+ * - Caller (invoke-single-cat host integration) surfaces the failure as
+ *   a normal credentials/init error to user; no silent fallback
  */
-export function createCatAgentProtocolAdapter(_catConfig: CatConfig | null): CatAgentProtocolAdapter {
-  return new AnthropicMessagesAdapter();
+export function createCatAgentProtocolAdapter(catConfig: CatConfig | null): CatAgentProtocolAdapter {
+  const protocol = catConfig?.catAgentProtocol;
+
+  // Default branch: G1 catagent members (no catAgentProtocol persisted) +
+  // explicit 'anthropic-messages' both land here. Byte-stable with G1
+  // (KD-25 AC-G31 verifies factory default branch unchanged).
+  if (protocol === undefined || protocol === 'anthropic-messages') {
+    return new AnthropicMessagesAdapter();
+  }
+
+  if (protocol === 'openai-chat') {
+    // G2 Axis 5 — OpenAIChatAdapter implementation is the next slice in this
+    // PR. Until it lands, this branch fail-closes with an actionable error
+    // so a user who Hub-configures 'openai-chat' early gets a clear signal
+    // instead of silently routing to Anthropic Messages (which would 404 on
+    // any OpenAI-only proxy — exactly the failure mode that triggered G2,
+    // KD-23).
+    throw new CatAgentProtocolNotImplementedError(protocol);
+  }
+
+  // KD-20 fail-closed: unrecognised protocol values throw. Service surfaces
+  // this as a credentials/init failure; no fallback to AnthropicMessagesAdapter.
+  throw new CatAgentProtocolUnknownError(protocol as string);
+}
+
+export class CatAgentProtocolUnknownError extends Error {
+  readonly protocol: string;
+  constructor(protocol: string) {
+    super(
+      `[catagent] Unknown catAgentProtocol "${protocol}" — fail-closed per KD-20 (no runtime protocol guessing). ` +
+        `Valid values: 'anthropic-messages' | 'openai-chat'.`,
+    );
+    this.name = 'CatAgentProtocolUnknownError';
+    this.protocol = protocol;
+  }
+}
+
+export class CatAgentProtocolNotImplementedError extends Error {
+  readonly protocol: CatAgentProtocol;
+  constructor(protocol: CatAgentProtocol) {
+    super(
+      `[catagent] catAgentProtocol "${protocol}" is recognised but its adapter is not yet implemented in this build. ` +
+        `Tracking: F159 Phase G G2 Axis 5 (OpenAIChatAdapter). Until then, use 'anthropic-messages' or leave catAgentProtocol unset.`,
+    );
+    this.name = 'CatAgentProtocolNotImplementedError';
+    this.protocol = protocol;
+  }
 }

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-protocol-factory.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-protocol-factory.ts
@@ -6,7 +6,7 @@
  * `catConfig.catAgentProtocol`:
  * - `undefined` / `'anthropic-messages'` → `AnthropicMessagesAdapter` (G1 default,
  *   preserves G1 catagent member behavior — KD-25 first half byte-stable)
- * - `'openai-chat'` → `OpenAIChatAdapter` (G2 Axis 5, implementation pending)
+ * - `'openai-chat'` → `OpenAIChatAdapter` (G2 Axis 5)
  * - unknown value → **fail closed (throw)** — KD-20: no fallback, no
  *   runtime protocol guessing, no silent vendor routing
  *
@@ -18,6 +18,7 @@
 import type { CatAgentProtocol, CatConfig } from '@cat-cafe/shared';
 import { AnthropicMessagesAdapter } from './anthropic-messages-adapter.js';
 import type { CatAgentProtocolAdapter } from './catagent-protocol-adapter.js';
+import { OpenAIChatAdapter } from './openai-chat-adapter.js';
 
 /**
  * Select and instantiate the protocol adapter for a CatAgent member.
@@ -44,13 +45,7 @@ export function createCatAgentProtocolAdapter(catConfig: CatConfig | null): CatA
   }
 
   if (protocol === 'openai-chat') {
-    // G2 Axis 5 — OpenAIChatAdapter implementation is the next slice in this
-    // PR. Until it lands, this branch fail-closes with an actionable error
-    // so a user who Hub-configures 'openai-chat' early gets a clear signal
-    // instead of silently routing to Anthropic Messages (which would 404 on
-    // any OpenAI-only proxy — exactly the failure mode that triggered G2,
-    // KD-23).
-    throw new CatAgentProtocolNotImplementedError(protocol);
+    return new OpenAIChatAdapter();
   }
 
   // KD-20 fail-closed: unrecognised protocol values throw. Service surfaces
@@ -66,18 +61,6 @@ export class CatAgentProtocolUnknownError extends Error {
         `Valid values: 'anthropic-messages' | 'openai-chat'.`,
     );
     this.name = 'CatAgentProtocolUnknownError';
-    this.protocol = protocol;
-  }
-}
-
-export class CatAgentProtocolNotImplementedError extends Error {
-  readonly protocol: CatAgentProtocol;
-  constructor(protocol: CatAgentProtocol) {
-    super(
-      `[catagent] catAgentProtocol "${protocol}" is recognised but its adapter is not yet implemented in this build. ` +
-        `Tracking: F159 Phase G G2 Axis 5 (OpenAIChatAdapter). Until then, use 'anthropic-messages' or leave catAgentProtocol unset.`,
-    );
-    this.name = 'CatAgentProtocolNotImplementedError';
     this.protocol = protocol;
   }
 }

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/openai-chat-adapter.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/openai-chat-adapter.ts
@@ -1,0 +1,346 @@
+/**
+ * OpenAI Chat Adapter — F159 Phase G Slice G2 Axis 5
+ *
+ * Concrete implementation of {@link CatAgentProtocolAdapter} for OpenAI-style
+ * Chat Completions streaming (`POST /v1/chat/completions`, Bearer auth, SSE
+ * `data:` frames ending with `[DONE]`).
+ *
+ * Mirrors the Anthropic adapter's contract layers:
+ * - URL / headers / request body
+ * - Streaming chunk → neutral events
+ * - Transcript codec for assistant turns + tool results
+ * - Truthful client family / protocol identifiers
+ */
+
+import type {
+  AdapterCredentials,
+  AdapterRequestInput,
+  AdapterToolDefinition,
+  AdapterToolResult,
+  CatAgentProtocolAdapter,
+} from './catagent-protocol-adapter.js';
+import type { AdapterMessage, CatAgentNeutralBlock, CatAgentStreamEvent } from './catagent-protocol-types.js';
+
+const DEFAULT_BASE_URL = 'https://api.openai.com';
+const DEFAULT_MAX_TOKENS = 4096;
+const MAX_TOOL_INPUT_BYTES = 65_536;
+const TERMINAL_STOP_REASONS = new Set(['stop', 'length', 'content_filter']);
+
+interface OpenAIChatToolCall {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
+interface OpenAIChatMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string | null;
+  tool_calls?: OpenAIChatToolCall[];
+  tool_call_id?: string;
+}
+
+interface OpenAIChoiceDeltaToolCall {
+  index?: number;
+  id?: string;
+  function?: {
+    name?: string;
+    arguments?: string;
+  };
+}
+
+interface OpenAIStreamContext {
+  text: string;
+  textSeen: boolean;
+  toolCalls: Map<number, OpenAIToolCallAccumulator>;
+  sawAnyEvent: boolean;
+  sawDone: boolean;
+}
+
+interface OpenAIToolCallAccumulator {
+  id: string;
+  name: string;
+  argumentsJson: string;
+  argumentBytes: number;
+}
+
+function buildOpenAIChatCompletionsUrl(baseURL?: string): string {
+  const rawBaseUrl = baseURL?.trim() || DEFAULT_BASE_URL;
+  const root = rawBaseUrl.replace(/\/+$/, '').replace(/\/v1$/i, '');
+  return `${root}/v1/chat/completions`;
+}
+
+function wrapMessages(payload: OpenAIChatMessage[]): AdapterMessage {
+  return { __adapterMessage: true, payload };
+}
+
+function unwrapMessages(message: AdapterMessage): OpenAIChatMessage[] {
+  return message.payload as OpenAIChatMessage[];
+}
+
+function buildToolDefinitions(tools: ReadonlyArray<AdapterToolDefinition>): unknown[] {
+  return tools.map((tool) => ({
+    type: 'function',
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.inputSchema,
+    },
+  }));
+}
+
+function neutralToolCallToOpenAI(block: Extract<CatAgentNeutralBlock, { type: 'tool_call' }>): OpenAIChatToolCall {
+  return {
+    id: block.id,
+    type: 'function',
+    function: {
+      name: block.name,
+      arguments: JSON.stringify(block.input),
+    },
+  };
+}
+
+function finaliseToolCallInput(acc: OpenAIToolCallAccumulator): Record<string, unknown> {
+  if (acc.argumentBytes > MAX_TOOL_INPUT_BYTES) return { _error: 'Tool input exceeded size limit' };
+  try {
+    return JSON.parse(acc.argumentsJson || '{}');
+  } catch {
+    return { _error: 'Invalid tool input JSON' };
+  }
+}
+
+async function* parseOpenAIChatStream(
+  body: ReadableStream<Uint8Array>,
+  signal?: AbortSignal,
+): AsyncIterable<CatAgentStreamEvent> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder('utf-8', { fatal: false });
+  let buffer = '';
+  let dataLines: string[] = [];
+  const ctx: OpenAIStreamContext = {
+    text: '',
+    textSeen: false,
+    toolCalls: new Map(),
+    sawAnyEvent: false,
+    sawDone: false,
+  };
+
+  try {
+    while (true) {
+      if (signal?.aborted) {
+        yield { type: 'stream_error', error: 'Request aborted' };
+        return;
+      }
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split(/\r?\n/);
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        const maybeEvent = flushDataLine(line, dataLines);
+        if (maybeEvent !== undefined) {
+          yield* handleOpenAIDataEvent(maybeEvent, ctx);
+        }
+      }
+    }
+
+    if (buffer.trim()) {
+      const maybeEvent = flushDataLine(buffer, dataLines);
+      if (maybeEvent !== undefined) yield* handleOpenAIDataEvent(maybeEvent, ctx);
+    }
+    if (dataLines.length > 0) yield* handleOpenAIDataEvent(dataLines.join('\n'), ctx);
+
+    yield* emitOpenAIContentBlocks(ctx);
+
+    if (ctx.sawAnyEvent && !ctx.sawDone) {
+      yield { type: 'stream_error', error: 'Stream ended without [DONE]' };
+    }
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    yield { type: 'stream_error', error: `Stream read error: ${msg}` };
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function flushDataLine(line: string, dataLines: string[]): string | undefined {
+  if (line === '') {
+    if (dataLines.length === 0) return undefined;
+    const event = dataLines.join('\n');
+    dataLines.length = 0;
+    return event;
+  }
+  if (line.startsWith(':')) return undefined;
+  if (line.startsWith('data:')) {
+    dataLines.push(line.slice(5).trimStart());
+  }
+  return undefined;
+}
+
+function* handleOpenAIDataEvent(eventData: string, ctx: OpenAIStreamContext): Iterable<CatAgentStreamEvent> {
+  if (!eventData) return;
+  if (eventData === '[DONE]') {
+    ctx.sawDone = true;
+    return;
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(eventData);
+  } catch {
+    return;
+  }
+
+  ctx.sawAnyEvent = true;
+
+  const usage = parsed.usage as Record<string, unknown> | undefined;
+  if (usage) {
+    const promptTokensDetails = usage.prompt_tokens_details as Record<string, unknown> | undefined;
+    yield {
+      type: 'usage_update',
+      usage: {
+        ...(typeof usage.prompt_tokens === 'number' ? { inputTokens: usage.prompt_tokens } : {}),
+        ...(typeof usage.completion_tokens === 'number' ? { outputTokens: usage.completion_tokens } : {}),
+        ...(typeof promptTokensDetails?.cached_tokens === 'number'
+          ? { cacheReadTokens: promptTokensDetails.cached_tokens as number }
+          : {}),
+      },
+    };
+  }
+
+  const choices = Array.isArray(parsed.choices) ? parsed.choices : [];
+  const choice = choices[0] as Record<string, unknown> | undefined;
+  if (!choice) return;
+
+  const delta = choice.delta as Record<string, unknown> | undefined;
+  if (delta && typeof delta.content === 'string' && delta.content.length > 0) {
+    ctx.textSeen = true;
+    ctx.text += delta.content;
+    yield { type: 'text_delta', text: delta.content, blockIndex: 0 };
+  }
+
+  if (delta && Array.isArray(delta.tool_calls)) {
+    for (const entry of delta.tool_calls) {
+      if (!entry || typeof entry !== 'object') continue;
+      const toolCall = entry as OpenAIChoiceDeltaToolCall;
+      const index = typeof toolCall.index === 'number' ? toolCall.index : 0;
+      const acc = ctx.toolCalls.get(index) ?? { id: '', name: '', argumentsJson: '', argumentBytes: 0 };
+      if (typeof toolCall.id === 'string' && toolCall.id.length > 0) acc.id ||= toolCall.id;
+      if (toolCall.function?.name) acc.name += toolCall.function.name;
+      if (typeof toolCall.function?.arguments === 'string') {
+        acc.argumentBytes += Buffer.byteLength(toolCall.function.arguments);
+        if (acc.argumentBytes <= MAX_TOOL_INPUT_BYTES) acc.argumentsJson += toolCall.function.arguments;
+      }
+      ctx.toolCalls.set(index, acc);
+    }
+  }
+
+  const finishReason = choice.finish_reason;
+  if (finishReason !== undefined && finishReason !== null) {
+    yield { type: 'stop', stopReason: String(finishReason) };
+  }
+}
+
+function* emitOpenAIContentBlocks(ctx: OpenAIStreamContext): Iterable<CatAgentStreamEvent> {
+  let nextIndex = 0;
+  if (ctx.textSeen) {
+    yield {
+      type: 'content_block_complete',
+      block: { type: 'text', text: ctx.text },
+      blockIndex: nextIndex,
+    };
+    nextIndex++;
+  }
+  for (const [index, acc] of [...ctx.toolCalls.entries()].sort((a, b) => a[0] - b[0])) {
+    yield {
+      type: 'content_block_complete',
+      block: {
+        type: 'tool_call',
+        id: acc.id || `call_${index}`,
+        name: acc.name || 'unknown_tool',
+        input: finaliseToolCallInput(acc),
+      },
+      blockIndex: nextIndex + index,
+    };
+  }
+}
+
+export class OpenAIChatAdapter implements CatAgentProtocolAdapter {
+  readonly clientFamily = 'openai' as const;
+  readonly protocolId = 'openai-chat-v1' as const;
+
+  buildRequestUrl(baseURL?: string): string {
+    return buildOpenAIChatCompletionsUrl(baseURL);
+  }
+
+  buildRequestHeaders(credentials: AdapterCredentials): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${credentials.apiKey}`,
+    };
+  }
+
+  buildRequestBody(input: AdapterRequestInput): unknown {
+    const messages = input.messages.flatMap((message) => unwrapMessages(message));
+    const body: Record<string, unknown> = {
+      model: input.model,
+      max_tokens: input.maxTokens ?? DEFAULT_MAX_TOKENS,
+      messages: input.systemPrompt
+        ? [{ role: 'system' as const, content: input.systemPrompt }, ...messages]
+        : messages,
+      stream: true,
+      stream_options: { include_usage: true },
+    };
+    if (input.tools.length > 0) body.tools = buildToolDefinitions(input.tools);
+    return body;
+  }
+
+  parseStreamEvents(body: ReadableStream<Uint8Array>, signal?: AbortSignal): AsyncIterable<CatAgentStreamEvent> {
+    return parseOpenAIChatStream(body, signal);
+  }
+
+  encodeUserPrompt(prompt: string): AdapterMessage {
+    return wrapMessages([{ role: 'user', content: prompt }]);
+  }
+
+  encodeAssistantTurn(blocks: ReadonlyArray<CatAgentNeutralBlock>): AdapterMessage {
+    const text = blocks
+      .filter((block): block is Extract<CatAgentNeutralBlock, { type: 'text' }> => block.type === 'text')
+      .map((block) => block.text)
+      .join('');
+    const toolCalls = blocks
+      .filter((block): block is Extract<CatAgentNeutralBlock, { type: 'tool_call' }> => block.type === 'tool_call')
+      .map((block) => neutralToolCallToOpenAI(block));
+    return wrapMessages([
+      {
+        role: 'assistant',
+        content: text.length > 0 ? text : null,
+        ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+      },
+    ]);
+  }
+
+  encodeToolResults(results: ReadonlyArray<AdapterToolResult>): AdapterMessage {
+    return wrapMessages(
+      results.map((result) => ({
+        role: 'tool' as const,
+        tool_call_id: result.id,
+        content: result.content,
+      })),
+    );
+  }
+
+  mapError(err: { status?: number; message?: string }): { errorText: string } {
+    const status = err.status ?? 0;
+    const msg = err.message ?? 'Unknown API error';
+    return { errorText: `OpenAI API error (${status}): ${msg}` };
+  }
+
+  isTerminalStopReason(stopReason: string | null): boolean {
+    return stopReason != null && TERMINAL_STOP_REASONS.has(stopReason);
+  }
+}

--- a/packages/api/src/routes/cats.ts
+++ b/packages/api/src/routes/cats.ts
@@ -758,9 +758,7 @@ export const catsRoutes: FastifyPluginAsync<CatsRoutesOptions> = async (app, opt
           cli: resolvedCli,
           ...(body.cliConfigArgs ? { cliConfigArgs: body.cliConfigArgs } : {}),
           ...(body.clientId === 'catagent' && body.nativeToolLevel ? { nativeToolLevel: body.nativeToolLevel } : {}),
-          ...(body.clientId === 'catagent' && body.catAgentProtocol
-            ? { catAgentProtocol: body.catAgentProtocol }
-            : {}),
+          ...(body.clientId === 'catagent' && body.catAgentProtocol ? { catAgentProtocol: body.catAgentProtocol } : {}),
           ...(body.clientId === 'catagent' && body.commandPolicy ? { commandPolicy: body.commandPolicy } : {}),
           ...(body.provider || providerNameForValidation
             ? { provider: body.provider ?? providerNameForValidation }

--- a/packages/api/src/routes/cats.ts
+++ b/packages/api/src/routes/cats.ts
@@ -185,6 +185,8 @@ const createNormalCatSchema = baseCatSchema.extend({
       }),
     )
     .optional(),
+  /** F159 Phase G G2 (AC-G15): CatAgent wire protocol — only valid when clientId === 'catagent'. */
+  catAgentProtocol: z.enum(['anthropic-messages', 'openai-chat']).optional(),
   provider: z.string().min(1).optional(),
   acp: acpConfigSchema.optional(), // F161: optional ACP transport for any client
 });
@@ -249,6 +251,8 @@ const updateCatSchema = z.object({
     )
     .nullable()
     .optional(),
+  /** F159 Phase G G2 (AC-G15): CatAgent wire protocol — nullable to allow clearing. */
+  catAgentProtocol: z.enum(['anthropic-messages', 'openai-chat']).nullable().optional(),
   provider: z.string().min(1).nullable().optional(),
   voiceConfig: voiceConfigSchema.nullable().optional(),
   acp: acpConfigSchema.nullable().optional(), // F161: nullable to allow removing ACP transport
@@ -256,19 +260,24 @@ const updateCatSchema = z.object({
 
 type UpdateCatRequestBody = z.infer<typeof updateCatSchema>;
 
-function hasNativeToolSettings(body: unknown): boolean {
+// F159 Phase G G2 step 1b: helpers gate catagent-only fields. Extended from
+// the pre-G2 nativeToolLevel/commandPolicy pair to also cover catAgentProtocol
+// — same persistence gating boundary at runtime-cat-catalog level.
+const CAT_AGENT_ONLY_FIELDS = ['nativeToolLevel', 'commandPolicy', 'catAgentProtocol'] as const;
+
+function hasCatAgentOnlySettings(body: unknown): boolean {
   if (!body || typeof body !== 'object') return false;
-  return Object.hasOwn(body, 'nativeToolLevel') || Object.hasOwn(body, 'commandPolicy');
+  return CAT_AGENT_ONLY_FIELDS.some((key) => Object.hasOwn(body, key));
 }
 
-function hasNonNullNativeToolSettings(body: unknown): boolean {
+function hasNonNullCatAgentOnlySettings(body: unknown): boolean {
   if (!body || typeof body !== 'object') return false;
   const record = body as Record<string, unknown>;
-  return record.nativeToolLevel != null || record.commandPolicy != null;
+  return CAT_AGENT_ONLY_FIELDS.some((key) => record[key] != null);
 }
 
-function catAgentNativeToolError(clientId: ClientId): string {
-  return `nativeToolLevel and commandPolicy are only supported for catagent clients (received ${clientId})`;
+function catAgentOnlySettingsError(clientId: ClientId): string {
+  return `${CAT_AGENT_ONLY_FIELDS.join(' / ')} are only supported for catagent clients (received ${clientId})`;
 }
 
 function resolveOperator(raw: unknown): string | null {
@@ -501,6 +510,7 @@ async function toCatResponse(
       ? {
           nativeToolLevel: cat.nativeToolLevel,
           commandPolicy: cat.commandPolicy,
+          catAgentProtocol: cat.catAgentProtocol,
         }
       : {}),
     provider: cat.provider,
@@ -624,9 +634,9 @@ export const catsRoutes: FastifyPluginAsync<CatsRoutesOptions> = async (app, opt
     const managedIdsBefore = getManagedCatalogIds(projectRoot);
     const body = parsed.data;
 
-    if (body.clientId !== 'catagent' && hasNativeToolSettings(body)) {
+    if (body.clientId !== 'catagent' && hasCatAgentOnlySettings(body)) {
       reply.status(400);
-      return { error: catAgentNativeToolError(body.clientId) };
+      return { error: catAgentOnlySettingsError(body.clientId) };
     }
 
     // Validate alias uniqueness across all existing members
@@ -748,6 +758,9 @@ export const catsRoutes: FastifyPluginAsync<CatsRoutesOptions> = async (app, opt
           cli: resolvedCli,
           ...(body.cliConfigArgs ? { cliConfigArgs: body.cliConfigArgs } : {}),
           ...(body.clientId === 'catagent' && body.nativeToolLevel ? { nativeToolLevel: body.nativeToolLevel } : {}),
+          ...(body.clientId === 'catagent' && body.catAgentProtocol
+            ? { catAgentProtocol: body.catAgentProtocol }
+            : {}),
           ...(body.clientId === 'catagent' && body.commandPolicy ? { commandPolicy: body.commandPolicy } : {}),
           ...(body.provider || providerNameForValidation
             ? { provider: body.provider ?? providerNameForValidation }
@@ -818,9 +831,9 @@ export const catsRoutes: FastifyPluginAsync<CatsRoutesOptions> = async (app, opt
       return { error: `Cat "${request.params.id}" not found` };
     }
     const effectiveClient = body.clientId ?? currentCat.clientId;
-    if (effectiveClient !== 'catagent' && hasNonNullNativeToolSettings(body)) {
+    if (effectiveClient !== 'catagent' && hasNonNullCatAgentOnlySettings(body)) {
       reply.status(400);
-      return { error: catAgentNativeToolError(effectiveClient) };
+      return { error: catAgentOnlySettingsError(effectiveClient) };
     }
     const currentEffectiveAccountRef = await resolveEffectiveAccountRef(currentCat);
     let targetAccountRef = resolveAccountRef(body);
@@ -917,14 +930,19 @@ export const catsRoutes: FastifyPluginAsync<CatsRoutesOptions> = async (app, opt
           ? {
               ...(body.nativeToolLevel !== undefined ? { nativeToolLevel: body.nativeToolLevel } : {}),
               ...(body.commandPolicy !== undefined ? { commandPolicy: body.commandPolicy } : {}),
+              // F159 Phase G G2 step 1b (AC-G15): catAgentProtocol透传 — only on catagent path.
+              ...(body.catAgentProtocol !== undefined ? { catAgentProtocol: body.catAgentProtocol } : {}),
             }
           : currentCat.nativeToolLevel !== undefined ||
               currentCat.commandPolicy !== undefined ||
+              currentCat.catAgentProtocol !== undefined ||
               body.nativeToolLevel === null ||
-              body.commandPolicy === null
+              body.commandPolicy === null ||
+              body.catAgentProtocol === null
             ? {
                 nativeToolLevel: null,
                 commandPolicy: null,
+                catAgentProtocol: null,
               }
             : {};
       updateRuntimeCat(projectRoot, request.params.id, {

--- a/packages/api/test/acp/acp-process-pool.test.js
+++ b/packages/api/test/acp/acp-process-pool.test.js
@@ -101,7 +101,7 @@ describe('AcpProcessPool', () => {
       );
       pool = new AcpProcessPool(defaultPoolConfig, defaultVariantConfig, createMockClient, 'spawn:v1');
       assert.equal(pool.spawnSignature, 'spawn:v1');
-      assert.equal(Object.prototype.hasOwnProperty.call(pool, '_spawnSignature'), false);
+      assert.equal(Object.hasOwn(pool, '_spawnSignature'), false);
     });
   });
 

--- a/packages/api/test/anthropic-messages-adapter-golden.test.js
+++ b/packages/api/test/anthropic-messages-adapter-golden.test.js
@@ -99,10 +99,7 @@ describe('AnthropicMessagesAdapter: buildRequestUrl', () => {
   });
 
   test('custom proxy without /v1 keeps full path', () => {
-    assert.equal(
-      a.buildRequestUrl('https://api.mycorp.com/anthropic'),
-      'https://api.mycorp.com/anthropic/v1/messages',
-    );
+    assert.equal(a.buildRequestUrl('https://api.mycorp.com/anthropic'), 'https://api.mycorp.com/anthropic/v1/messages');
   });
 });
 
@@ -146,9 +143,7 @@ describe('AnthropicMessagesAdapter: buildRequestBody', () => {
       tools: [{ name: 'read_file', description: 'reads a file', inputSchema: { type: 'object' } }],
     });
     const j = JSON.parse(JSON.stringify(body));
-    assert.deepEqual(j.tools, [
-      { name: 'read_file', description: 'reads a file', input_schema: { type: 'object' } },
-    ]);
+    assert.deepEqual(j.tools, [{ name: 'read_file', description: 'reads a file', input_schema: { type: 'object' } }]);
   });
 
   test('body with systemPrompt — placed as top-level "system" field', () => {
@@ -227,7 +222,13 @@ describe('AnthropicMessagesAdapter: parseStreamEvents — text + usage + stop', 
   test('message_start usage → neutral CatAgentUsageDelta with cache normalisation', async () => {
     const a = new AnthropicMessagesAdapter();
     const stream =
-      sse({ type: 'message_start', message: { id: 'm1', usage: { input_tokens: 100, cache_read_input_tokens: 50, cache_creation_input_tokens: 10 } } }) +
+      sse({
+        type: 'message_start',
+        message: {
+          id: 'm1',
+          usage: { input_tokens: 100, cache_read_input_tokens: 50, cache_creation_input_tokens: 10 },
+        },
+      }) +
       sse({ type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } }) +
       sse({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'hi' } }) +
       sse({ type: 'content_block_stop', index: 0 }) +
@@ -288,8 +289,16 @@ describe('AnthropicMessagesAdapter: parseStreamEvents — tool_call mapping', ()
     const a = new AnthropicMessagesAdapter();
     const stream =
       sse({ type: 'message_start', message: { id: 'm', usage: { input_tokens: 1 } } }) +
-      sse({ type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'tu1', name: 'read_file' } }) +
-      sse({ type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{"path":"x.txt"}' } }) +
+      sse({
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'tool_use', id: 'tu1', name: 'read_file' },
+      }) +
+      sse({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'input_json_delta', partial_json: '{"path":"x.txt"}' },
+      }) +
       sse({ type: 'content_block_stop', index: 0 }) +
       sse({ type: 'message_delta', delta: { stop_reason: 'tool_use' }, usage: { output_tokens: 1 } }) +
       sse({ type: 'message_stop' });
@@ -335,18 +344,9 @@ describe('AnthropicMessagesAdapter: parseStreamEvents — boundary cases', () =>
 describe('AnthropicMessagesAdapter: mapError', () => {
   test('byte-stable error text matches pre-G1 mapAnthropicError format', () => {
     const a = new AnthropicMessagesAdapter();
-    assert.equal(
-      a.mapError({ status: 404, message: 'Not Found' }).errorText,
-      'Anthropic API error (404): Not Found',
-    );
-    assert.equal(
-      a.mapError({ status: 500 }).errorText,
-      'Anthropic API error (500): Unknown API error',
-    );
-    assert.equal(
-      a.mapError({ message: 'Network failed' }).errorText,
-      'Anthropic API error (0): Network failed',
-    );
+    assert.equal(a.mapError({ status: 404, message: 'Not Found' }).errorText, 'Anthropic API error (404): Not Found');
+    assert.equal(a.mapError({ status: 500 }).errorText, 'Anthropic API error (500): Unknown API error');
+    assert.equal(a.mapError({ message: 'Network failed' }).errorText, 'Anthropic API error (0): Network failed');
   });
 });
 

--- a/packages/api/test/cat-catalog-store.test.js
+++ b/packages/api/test/cat-catalog-store.test.js
@@ -414,6 +414,121 @@ describe('cat-catalog-store', () => {
     });
   });
 
+  // F159 Phase G G2 step 1a (@gpt555 P2 coverage gap fix):
+  // mirror the nativeToolLevel/commandPolicy persistence test matrix for the
+  // new catAgentProtocol truth-source field — three behaviors that matter:
+  //   1. create persists when clientId === 'catagent'
+  //   2. patch updates / null clears existing catAgentProtocol
+  //   3. switching clientId away from 'catagent' clears catAgentProtocol
+  it('persists catAgentProtocol when creating a catagent member, clears for non-catagent', async () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'cat-catalog-store-'));
+    const templatePath = join(projectRoot, 'cat-template.json');
+    writeFileSync(templatePath, JSON.stringify(validConfig(), null, 2));
+    writeCatCatalog(projectRoot, validConfig());
+
+    // 1. catagent + catAgentProtocol → persisted
+    await createRuntimeCat(projectRoot, {
+      catId: 'protocol-cat',
+      breedId: 'protocol-cat',
+      name: '协议猫',
+      displayName: '协议猫',
+      avatar: '/avatars/protocol-cat.png',
+      color: { primary: '#0ea5e9', secondary: '#e0f2fe' },
+      mentionPatterns: ['@protocol-cat'],
+      roleDescription: '协议位测试',
+      clientId: 'catagent',
+      accountRef: 'claude',
+      defaultModel: 'claude-opus-4-6',
+      mcpSupport: false,
+      cli: { command: 'claude', outputFormat: 'stream-json' },
+      catAgentProtocol: 'openai-chat',
+    });
+
+    let catalog = readRuntimeCatCatalog(projectRoot);
+    let created = catalog.breeds.find((breed) => breed.catId === 'protocol-cat');
+    assert.ok(created, 'protocol-cat breed should be created');
+    assert.equal(created.variants[0]?.catAgentProtocol, 'openai-chat');
+
+    // 2. non-catagent clientId with catAgentProtocol → field NOT persisted
+    await createRuntimeCat(projectRoot, {
+      catId: 'non-catagent',
+      breedId: 'non-catagent',
+      name: '非原生猫',
+      displayName: '非原生猫',
+      avatar: '/avatars/non-catagent.png',
+      color: { primary: '#dc2626', secondary: '#fee2e2' },
+      mentionPatterns: ['@non-catagent'],
+      roleDescription: '非 catagent 隔离测试',
+      clientId: 'openai',
+      defaultModel: 'gpt-5.4',
+      mcpSupport: true,
+      cli: { command: 'codex', outputFormat: 'json' },
+      catAgentProtocol: 'openai-chat',
+    });
+
+    catalog = readRuntimeCatCatalog(projectRoot);
+    const nonCatagent = catalog.breeds.find((breed) => breed.catId === 'non-catagent');
+    assert.ok(nonCatagent, 'non-catagent breed should be created');
+    assert.equal(nonCatagent.variants[0]?.catAgentProtocol, undefined, 'catAgentProtocol must not persist on non-catagent variants');
+  });
+
+  it('updates and clears catAgentProtocol on existing catagent member, and clears on client switch away', async () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'cat-catalog-store-'));
+    const templatePath = join(projectRoot, 'cat-template.json');
+    writeFileSync(templatePath, JSON.stringify(validConfig(), null, 2));
+    writeCatCatalog(projectRoot, validConfig());
+
+    // Seed: create catagent member with catAgentProtocol='openai-chat'
+    await createRuntimeCat(projectRoot, {
+      catId: 'patch-protocol-cat',
+      breedId: 'patch-protocol-cat',
+      name: '更新协议猫',
+      displayName: '更新协议猫',
+      avatar: '/avatars/patch-protocol-cat.png',
+      color: { primary: '#7c3aed', secondary: '#ede9fe' },
+      mentionPatterns: ['@patch-protocol-cat'],
+      roleDescription: '协议位 patch 测试',
+      clientId: 'catagent',
+      accountRef: 'claude',
+      defaultModel: 'claude-opus-4-6',
+      mcpSupport: false,
+      cli: { command: 'claude', outputFormat: 'stream-json' },
+      catAgentProtocol: 'openai-chat',
+    });
+
+    // Patch: switch protocol to anthropic-messages
+    await updateRuntimeCat(projectRoot, 'patch-protocol-cat', {
+      catAgentProtocol: 'anthropic-messages',
+    });
+    let catalog = readRuntimeCatCatalog(projectRoot);
+    let updated = catalog.breeds.find((breed) => breed.catId === 'patch-protocol-cat');
+    assert.equal(updated.variants[0]?.catAgentProtocol, 'anthropic-messages');
+
+    // Patch null clears
+    await updateRuntimeCat(projectRoot, 'patch-protocol-cat', {
+      catAgentProtocol: null,
+    });
+    catalog = readRuntimeCatCatalog(projectRoot);
+    updated = catalog.breeds.find((breed) => breed.catId === 'patch-protocol-cat');
+    assert.equal(updated.variants[0]?.catAgentProtocol, undefined, 'patch null must clear catAgentProtocol');
+
+    // Re-seed catAgentProtocol then switch clientId away from catagent
+    await updateRuntimeCat(projectRoot, 'patch-protocol-cat', {
+      catAgentProtocol: 'openai-chat',
+    });
+    catalog = readRuntimeCatCatalog(projectRoot);
+    updated = catalog.breeds.find((breed) => breed.catId === 'patch-protocol-cat');
+    assert.equal(updated.variants[0]?.catAgentProtocol, 'openai-chat', 're-seed sanity check');
+
+    await updateRuntimeCat(projectRoot, 'patch-protocol-cat', {
+      clientId: 'openai',
+    });
+    catalog = readRuntimeCatCatalog(projectRoot);
+    updated = catalog.breeds.find((breed) => breed.catId === 'patch-protocol-cat');
+    assert.equal(updated.variants[0]?.catAgentProtocol, undefined, 'switching away from catagent must clear catAgentProtocol');
+    // nativeToolLevel / commandPolicy 同样路径已被既有测试 cover;此处只断言 protocol 字段被清
+  });
+
   it('updates an existing runtime member in place', async () => {
     const projectRoot = mkdtempSync(join(tmpdir(), 'cat-catalog-store-'));
     const templatePath = join(projectRoot, 'cat-template.json');

--- a/packages/api/test/cat-catalog-store.test.js
+++ b/packages/api/test/cat-catalog-store.test.js
@@ -445,7 +445,7 @@ describe('cat-catalog-store', () => {
     });
 
     let catalog = readRuntimeCatCatalog(projectRoot);
-    let created = catalog.breeds.find((breed) => breed.catId === 'protocol-cat');
+    const created = catalog.breeds.find((breed) => breed.catId === 'protocol-cat');
     assert.ok(created, 'protocol-cat breed should be created');
     assert.equal(created.variants[0]?.catAgentProtocol, 'openai-chat');
 
@@ -469,7 +469,11 @@ describe('cat-catalog-store', () => {
     catalog = readRuntimeCatCatalog(projectRoot);
     const nonCatagent = catalog.breeds.find((breed) => breed.catId === 'non-catagent');
     assert.ok(nonCatagent, 'non-catagent breed should be created');
-    assert.equal(nonCatagent.variants[0]?.catAgentProtocol, undefined, 'catAgentProtocol must not persist on non-catagent variants');
+    assert.equal(
+      nonCatagent.variants[0]?.catAgentProtocol,
+      undefined,
+      'catAgentProtocol must not persist on non-catagent variants',
+    );
   });
 
   it('updates and clears catAgentProtocol on existing catagent member, and clears on client switch away', async () => {
@@ -525,7 +529,11 @@ describe('cat-catalog-store', () => {
     });
     catalog = readRuntimeCatCatalog(projectRoot);
     updated = catalog.breeds.find((breed) => breed.catId === 'patch-protocol-cat');
-    assert.equal(updated.variants[0]?.catAgentProtocol, undefined, 'switching away from catagent must clear catAgentProtocol');
+    assert.equal(
+      updated.variants[0]?.catAgentProtocol,
+      undefined,
+      'switching away from catagent must clear catAgentProtocol',
+    );
     // nativeToolLevel / commandPolicy 同样路径已被既有测试 cover;此处只断言 protocol 字段被清
   });
 

--- a/packages/api/test/catagent-phase-d.test.js
+++ b/packages/api/test/catagent-phase-d.test.js
@@ -31,8 +31,11 @@ async function collect(iter) {
 
 let tmpDir;
 let catCafeDir;
+let prevCatOpusModel;
 
 before(() => {
+  prevCatOpusModel = process.env.CAT_OPUS_MODEL;
+  process.env.CAT_OPUS_MODEL = 'claude-opus-4-6';
   tmpDir = join(tmpdir(), `catagent-d-${Date.now()}`);
   mkdirSync(tmpDir, { recursive: true });
 
@@ -66,6 +69,8 @@ before(() => {
 });
 
 after(() => {
+  if (prevCatOpusModel !== undefined) process.env.CAT_OPUS_MODEL = prevCatOpusModel;
+  else delete process.env.CAT_OPUS_MODEL;
   try {
     rmSync(tmpDir, { recursive: true, force: true });
   } catch {

--- a/packages/api/test/catagent-phase-e.test.js
+++ b/packages/api/test/catagent-phase-e.test.js
@@ -49,6 +49,34 @@ function mockStreamingApi(responses) {
   };
 }
 
+function openAISseEvent(data) {
+  return `data: ${typeof data === 'string' ? data : JSON.stringify(data)}\n\n`;
+}
+
+function openAIStream(events) {
+  const text = events.map(openAISseEvent).join('');
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text));
+      controller.close();
+    },
+  });
+}
+
+function mockOpenAIStreamingApi(responses, captures) {
+  let callIndex = 0;
+  return async (url, init) => {
+    if (captures) captures.push({ url: String(url), body: JSON.parse(init.body) });
+    const events = responses[callIndex] ?? responses[responses.length - 1];
+    callIndex++;
+    return {
+      ok: true,
+      headers: new Headers({ 'content-type': 'text/event-stream' }),
+      body: openAIStream(events),
+    };
+  };
+}
+
 function textTurnEvents(text, stopReason = 'end_turn', inputTokens = 10, outputTokens = 5) {
   return [
     { type: 'message_start', message: { id: `msg${Date.now()}`, usage: { input_tokens: inputTokens } } },
@@ -69,6 +97,37 @@ function toolTurnEvents(toolName, toolInput, toolId = 'tu1') {
     { type: 'content_block_stop', index: 0 },
     { type: 'message_delta', delta: { stop_reason: 'tool_use' }, usage: { output_tokens: 15 } },
     { type: 'message_stop' },
+  ];
+}
+
+function openAITextTurnEvents(text, finishReason = 'stop', promptTokens = 10, completionTokens = 5) {
+  return [
+    {
+      id: `chatcmpl-${Date.now()}`,
+      choices: [{ index: 0, delta: { role: 'assistant', content: text }, finish_reason: finishReason }],
+    },
+    { id: `chatcmpl-${Date.now()}`, choices: [], usage: { prompt_tokens: promptTokens, completion_tokens: completionTokens } },
+    '[DONE]',
+  ];
+}
+
+function openAIToolTurnEvents(toolName, toolInput, toolId = 'call_1') {
+  const args = JSON.stringify(toolInput);
+  return [
+    {
+      id: `chatcmpl-${Date.now()}`,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            role: 'assistant',
+            tool_calls: [{ index: 0, id: toolId, function: { name: toolName, arguments: args } }],
+          },
+          finish_reason: 'tool_calls',
+        },
+      ],
+    },
+    '[DONE]',
   ];
 }
 
@@ -380,5 +439,95 @@ describe('E4: stream error handling', () => {
     await collect(svc.invoke('test'));
 
     assert.equal(capturedUrl, 'https://proxy.example/v1/messages');
+  });
+});
+
+describe('G2 Axis 5: OpenAI Chat protocol e2e', () => {
+  let prevFetch;
+  let prevEnv;
+
+  before(() => {
+    prevFetch = globalThis.fetch;
+    prevEnv = process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT;
+    process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = tmpDir;
+    resetMigrationState();
+    writeFileSync(
+      join(tmpDir, '.cat-cafe', 'accounts.json'),
+      JSON.stringify({
+        'test-ant': { authType: 'api_key' },
+        'test-ant-v1': { authType: 'api_key', baseUrl: 'https://proxy.example/v1' },
+        'test-openai': { authType: 'api_key', clientFamily: 'openai', baseUrl: 'https://proxy.example/v1' },
+      }),
+    );
+    writeFileSync(
+      join(tmpDir, '.cat-cafe', 'credentials.json'),
+      JSON.stringify({
+        'test-ant': { apiKey: 'sk-test-e' },
+        'test-ant-v1': { apiKey: 'sk-test-v1' },
+        'test-openai': { apiKey: 'sk-openai-e' },
+      }),
+    );
+  });
+
+  after(() => {
+    globalThis.fetch = prevFetch;
+    if (prevEnv !== undefined) process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = prevEnv;
+    else delete process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT;
+    resetMigrationState();
+  });
+
+  test('single-turn text path uses OpenAI URL/headers/body and ends cleanly', async () => {
+    const captures = [];
+    globalThis.fetch = mockOpenAIStreamingApi([openAITextTurnEvents('Hello from OpenAI')], captures);
+
+    const svc = new CatAgentService({
+      catId: 'opus',
+      projectRoot: tmpDir,
+      catConfig: { accountRef: 'test-openai', clientId: 'catagent', catAgentProtocol: 'openai-chat' },
+    });
+    const msgs = await collect(svc.invoke('hi'));
+
+    const text = msgs.filter((msg) => msg.type === 'text').map((msg) => msg.content).join('');
+    assert.equal(text, 'Hello from OpenAI');
+    assert.ok(msgs.some((msg) => msg.type === 'done'));
+    assert.equal(captures[0].url, 'https://proxy.example/v1/chat/completions');
+    assert.equal(captures[0].body.messages[0].role, 'user');
+    assert.equal(captures[0].body.stream_options.include_usage, true);
+  });
+
+  test('tool_call multi-turn path is lossless across assistant history + tool results', async () => {
+    const captures = [];
+    globalThis.fetch = mockOpenAIStreamingApi(
+      [
+        openAIToolTurnEvents('read_file', { path: 'hello.txt' }, 'call_read_1'),
+        openAITextTurnEvents('The file has 3 lines', 'stop', 50, 9),
+      ],
+      captures,
+    );
+
+    const svc = new CatAgentService({
+      catId: 'opus',
+      projectRoot: tmpDir,
+      catConfig: { accountRef: 'test-openai', clientId: 'catagent', catAgentProtocol: 'openai-chat' },
+    });
+    const msgs = await collect(svc.invoke('read hello.txt', { workingDirectory: tmpDir }));
+
+    assert.ok(msgs.some((msg) => msg.type === 'tool_use' && msg.toolName === 'read_file'));
+    assert.ok(msgs.some((msg) => msg.type === 'tool_result' && msg.toolUseId === 'call_read_1'));
+    assert.ok(msgs.some((msg) => msg.type === 'text' && msg.content.includes('3 lines')));
+
+    assert.ok(captures.length >= 2, 'must issue second turn');
+    const secondMessages = captures[1].body.messages;
+    const assistant = secondMessages.find((message) => message.role === 'assistant');
+    assert.deepEqual(assistant.tool_calls, [
+      {
+        id: 'call_read_1',
+        type: 'function',
+        function: { name: 'read_file', arguments: '{"path":"hello.txt"}' },
+      },
+    ]);
+    const toolMessage = secondMessages.find((message) => message.role === 'tool');
+    assert.equal(toolMessage.tool_call_id, 'call_read_1');
+    assert.match(toolMessage.content, /line1/);
   });
 });

--- a/packages/api/test/catagent-protocol-factory.test.js
+++ b/packages/api/test/catagent-protocol-factory.test.js
@@ -12,13 +12,8 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 
-const {
-  createCatAgentProtocolAdapter,
-  CatAgentProtocolUnknownError,
-  CatAgentProtocolNotImplementedError,
-} = await import(
-  '../dist/domains/cats/services/agents/providers/catagent/catagent-protocol-factory.js'
-);
+const { createCatAgentProtocolAdapter, CatAgentProtocolUnknownError, CatAgentProtocolNotImplementedError } =
+  await import('../dist/domains/cats/services/agents/providers/catagent/catagent-protocol-factory.js');
 
 const { AnthropicMessagesAdapter } = await import(
   '../dist/domains/cats/services/agents/providers/catagent/anthropic-messages-adapter.js'

--- a/packages/api/test/catagent-protocol-factory.test.js
+++ b/packages/api/test/catagent-protocol-factory.test.js
@@ -1,0 +1,121 @@
+/**
+ * CatAgent Protocol Factory dispatch tests — F159 Phase G G2 Axis 2 (AC-G17).
+ *
+ * Verifies fail-closed dispatch per KD-20:
+ * - undefined / 'anthropic-messages' → AnthropicMessagesAdapter (G1 default
+ *   byte-stable, KD-25 first half)
+ * - 'openai-chat' → throws CatAgentProtocolNotImplementedError (G2 Axis 5
+ *   adapter pending)
+ * - unknown string → throws CatAgentProtocolUnknownError (KD-20 strict)
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+const {
+  createCatAgentProtocolAdapter,
+  CatAgentProtocolUnknownError,
+  CatAgentProtocolNotImplementedError,
+} = await import(
+  '../dist/domains/cats/services/agents/providers/catagent/catagent-protocol-factory.js'
+);
+
+const { AnthropicMessagesAdapter } = await import(
+  '../dist/domains/cats/services/agents/providers/catagent/anthropic-messages-adapter.js'
+);
+
+describe('createCatAgentProtocolAdapter dispatch (AC-G17 / KD-20 fail-closed)', () => {
+  test('null catConfig → AnthropicMessagesAdapter (legacy/test path)', () => {
+    const adapter = createCatAgentProtocolAdapter(null);
+    assert.ok(adapter instanceof AnthropicMessagesAdapter);
+    assert.equal(adapter.clientFamily, 'anthropic');
+    assert.equal(adapter.protocolId, 'anthropic-messages-v1');
+  });
+
+  test('catConfig with no catAgentProtocol → AnthropicMessagesAdapter (G1 catagent member backward-compat)', () => {
+    const adapter = createCatAgentProtocolAdapter({ id: 'opus', clientId: 'catagent' });
+    assert.ok(adapter instanceof AnthropicMessagesAdapter);
+  });
+
+  test("catAgentProtocol='anthropic-messages' → AnthropicMessagesAdapter (explicit)", () => {
+    const adapter = createCatAgentProtocolAdapter({
+      id: 'opus',
+      clientId: 'catagent',
+      catAgentProtocol: 'anthropic-messages',
+    });
+    assert.ok(adapter instanceof AnthropicMessagesAdapter);
+  });
+
+  test("catAgentProtocol='openai-chat' → CatAgentProtocolNotImplementedError (Axis 5 pending)", () => {
+    assert.throws(
+      () =>
+        createCatAgentProtocolAdapter({
+          id: 'opus',
+          clientId: 'catagent',
+          catAgentProtocol: 'openai-chat',
+        }),
+      (err) => {
+        assert.ok(err instanceof CatAgentProtocolNotImplementedError);
+        assert.equal(err.protocol, 'openai-chat');
+        assert.match(err.message, /OpenAIChatAdapter|Axis 5/);
+        return true;
+      },
+    );
+  });
+
+  test('unknown protocol value → CatAgentProtocolUnknownError (KD-20 strict fail-closed)', () => {
+    assert.throws(
+      () =>
+        createCatAgentProtocolAdapter({
+          id: 'opus',
+          clientId: 'catagent',
+          catAgentProtocol: 'gemini-pro', // not in CatAgentProtocol union
+        }),
+      (err) => {
+        assert.ok(err instanceof CatAgentProtocolUnknownError);
+        assert.equal(err.protocol, 'gemini-pro');
+        assert.match(err.message, /fail-closed|KD-20/);
+        return true;
+      },
+    );
+  });
+
+  test('empty string protocol → CatAgentProtocolUnknownError (does NOT silently default)', () => {
+    assert.throws(
+      () =>
+        createCatAgentProtocolAdapter({
+          id: 'opus',
+          clientId: 'catagent',
+          catAgentProtocol: '',
+        }),
+      (err) => {
+        assert.ok(err instanceof CatAgentProtocolUnknownError);
+        return true;
+      },
+    );
+  });
+});
+
+// AC-G31 (KD-25 third pillar): default branch behavior is BYTE-stable with G1.
+// G1's AnthropicMessagesAdapter is what factory returned pre-G2; G2 step 1d
+// must not change that.
+describe('AC-G31 G1 catagent member default branch byte-stable', () => {
+  test('multiple invocations of default branch return AnthropicMessagesAdapter with identical identity', () => {
+    const a = createCatAgentProtocolAdapter(null);
+    const b = createCatAgentProtocolAdapter({ id: 'opus', clientId: 'catagent' });
+    const c = createCatAgentProtocolAdapter({
+      id: 'opus',
+      clientId: 'catagent',
+      catAgentProtocol: 'anthropic-messages',
+    });
+    for (const adapter of [a, b, c]) {
+      assert.equal(adapter.clientFamily, 'anthropic');
+      assert.equal(adapter.protocolId, 'anthropic-messages-v1');
+      assert.equal(typeof adapter.buildRequestUrl, 'function');
+      assert.equal(typeof adapter.parseStreamEvents, 'function');
+      assert.equal(typeof adapter.encodeAssistantTurn, 'function');
+      assert.equal(typeof adapter.mapError, 'function');
+      assert.equal(typeof adapter.isTerminalStopReason, 'function');
+    }
+  });
+});

--- a/packages/api/test/catagent-protocol-factory.test.js
+++ b/packages/api/test/catagent-protocol-factory.test.js
@@ -4,20 +4,20 @@
  * Verifies fail-closed dispatch per KD-20:
  * - undefined / 'anthropic-messages' → AnthropicMessagesAdapter (G1 default
  *   byte-stable, KD-25 first half)
- * - 'openai-chat' → throws CatAgentProtocolNotImplementedError (G2 Axis 5
- *   adapter pending)
+ * - 'openai-chat' → OpenAIChatAdapter
  * - unknown string → throws CatAgentProtocolUnknownError (KD-20 strict)
  */
 
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 
-const { createCatAgentProtocolAdapter, CatAgentProtocolUnknownError, CatAgentProtocolNotImplementedError } =
+const { createCatAgentProtocolAdapter, CatAgentProtocolUnknownError } =
   await import('../dist/domains/cats/services/agents/providers/catagent/catagent-protocol-factory.js');
 
 const { AnthropicMessagesAdapter } = await import(
   '../dist/domains/cats/services/agents/providers/catagent/anthropic-messages-adapter.js'
 );
+const { OpenAIChatAdapter } = await import('../dist/domains/cats/services/agents/providers/catagent/openai-chat-adapter.js');
 
 describe('createCatAgentProtocolAdapter dispatch (AC-G17 / KD-20 fail-closed)', () => {
   test('null catConfig → AnthropicMessagesAdapter (legacy/test path)', () => {
@@ -41,21 +41,15 @@ describe('createCatAgentProtocolAdapter dispatch (AC-G17 / KD-20 fail-closed)', 
     assert.ok(adapter instanceof AnthropicMessagesAdapter);
   });
 
-  test("catAgentProtocol='openai-chat' → CatAgentProtocolNotImplementedError (Axis 5 pending)", () => {
-    assert.throws(
-      () =>
-        createCatAgentProtocolAdapter({
-          id: 'opus',
-          clientId: 'catagent',
-          catAgentProtocol: 'openai-chat',
-        }),
-      (err) => {
-        assert.ok(err instanceof CatAgentProtocolNotImplementedError);
-        assert.equal(err.protocol, 'openai-chat');
-        assert.match(err.message, /OpenAIChatAdapter|Axis 5/);
-        return true;
-      },
-    );
+  test("catAgentProtocol='openai-chat' → OpenAIChatAdapter", () => {
+    const adapter = createCatAgentProtocolAdapter({
+      id: 'opus',
+      clientId: 'catagent',
+      catAgentProtocol: 'openai-chat',
+    });
+    assert.ok(adapter instanceof OpenAIChatAdapter);
+    assert.equal(adapter.clientFamily, 'openai');
+    assert.equal(adapter.protocolId, 'openai-chat-v1');
   });
 
   test('unknown protocol value → CatAgentProtocolUnknownError (KD-20 strict fail-closed)', () => {

--- a/packages/api/test/catagent-provider.test.js
+++ b/packages/api/test/catagent-provider.test.js
@@ -78,6 +78,17 @@ function mockFetchAbortable() {
 
 // Save original fetch
 const originalFetch = globalThis.fetch;
+let prevCatOpusModel;
+
+before(() => {
+  prevCatOpusModel = process.env.CAT_OPUS_MODEL;
+  process.env.CAT_OPUS_MODEL = 'claude-opus-4-6';
+});
+
+after(() => {
+  if (prevCatOpusModel !== undefined) process.env.CAT_OPUS_MODEL = prevCatOpusModel;
+  else delete process.env.CAT_OPUS_MODEL;
+});
 
 // Mock resolveApiCredentials by patching the module
 // Since CatAgentService imports resolveApiCredentials, we test via the service

--- a/packages/api/test/catagent-security-baseline.test.js
+++ b/packages/api/test/catagent-security-baseline.test.js
@@ -54,11 +54,9 @@ test('resolveApiCredentials fail-closes when OAuth builtin family mismatches req
   mkdirSync(configDir, { recursive: true });
   // `claude` is the Anthropic OAuth builtin per BUILTIN_ACCOUNT_MAP.
   writeFileSync(join(configDir, 'accounts.json'), JSON.stringify({ claude: { authType: 'oauth' } }));
-  writeFileSync(
-    join(configDir, 'credentials.json'),
-    JSON.stringify({ claude: { apiKey: 'sk-ant-test' } }),
-    { mode: 0o600 },
-  );
+  writeFileSync(join(configDir, 'credentials.json'), JSON.stringify({ claude: { apiKey: 'sk-ant-test' } }), {
+    mode: 0o600,
+  });
   try {
     // Sanity: same family resolves (anthropic adapter binding to claude).
     const ok = resolveApiCredentials(tmpDir, 'opus', { accountRef: 'claude' }, 'anthropic');
@@ -67,6 +65,75 @@ test('resolveApiCredentials fail-closes when OAuth builtin family mismatches req
     // Mismatch: anthropic builtin must not satisfy openai adapter.
     const mismatch = resolveApiCredentials(tmpDir, 'opus', { accountRef: 'claude' }, 'openai');
     assert.equal(mismatch, null, 'mismatched clientFamily must fail closed (anthropic builtin under openai adapter)');
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// F159 Phase G G2 AC-G20/G21/G22 (KD-22): completes G1 P2 fix's half coverage.
+// api_key accounts can now declare `clientFamily` in their schema. When set,
+// `accountToRuntimeProfile` propagates it to `profile.client`, which the G1
+// narrow guard already enforces — so api_key family mismatches now fail closed
+// the same way OAuth builtin mismatches do. Without `clientFamily` set, legacy
+// api_key accounts continue best-effort (backward compat preserved).
+test('resolveApiCredentials fail-closes when api_key clientFamily mismatches requested clientFamily', () => {
+  const tmpDir = realpathSync(mkdtempSync(join(tmpdir(), 'catagent-cred-apikey-fam-')));
+  const configDir = join(tmpDir, '.cat-cafe');
+  mkdirSync(configDir, { recursive: true });
+  // Custom api_key account explicitly declared as OpenAI family.
+  writeFileSync(
+    join(configDir, 'accounts.json'),
+    JSON.stringify({ 'my-openai-proxy': { authType: 'api_key', clientFamily: 'openai' } }),
+  );
+  writeFileSync(
+    join(configDir, 'credentials.json'),
+    JSON.stringify({ 'my-openai-proxy': { apiKey: 'sk-openai-proxy-test' } }),
+    { mode: 0o600 },
+  );
+  try {
+    // Sanity: matching family resolves.
+    const ok = resolveApiCredentials(tmpDir, 'opus', { accountRef: 'my-openai-proxy' }, 'openai');
+    assert.ok(ok && ok.apiKey === 'sk-openai-proxy-test', 'matching api_key clientFamily must resolve');
+
+    // Mismatch: openai api_key account must not satisfy anthropic adapter.
+    const mismatch = resolveApiCredentials(tmpDir, 'opus', { accountRef: 'my-openai-proxy' }, 'anthropic');
+    assert.equal(
+      mismatch,
+      null,
+      'mismatched api_key clientFamily must fail closed (openai api_key under anthropic adapter)',
+    );
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// F159 Phase G G2 backward-compat (KD-22): existing api_key accounts without
+// `clientFamily` continue to resolve best-effort. profile.client remains
+// undefined, so the family guard falls through and the bound credential is
+// returned regardless of requested clientFamily — runtime API call surfaces
+// any protocol mismatch at first invocation rather than silently routing.
+test('resolveApiCredentials resolves api_key account without clientFamily for any requested family (backward compat)', () => {
+  const tmpDir = realpathSync(mkdtempSync(join(tmpdir(), 'catagent-cred-apikey-legacy-')));
+  const configDir = join(tmpDir, '.cat-cafe');
+  mkdirSync(configDir, { recursive: true });
+  // Legacy api_key account without explicit clientFamily — pre-F159 G2 state.
+  writeFileSync(join(configDir, 'accounts.json'), JSON.stringify({ 'legacy-account': { authType: 'api_key' } }));
+  writeFileSync(
+    join(configDir, 'credentials.json'),
+    JSON.stringify({ 'legacy-account': { apiKey: 'sk-legacy-test' } }),
+    { mode: 0o600 },
+  );
+  try {
+    // Both adapter families resolve — guard falls through because
+    // profile.client is undefined for legacy api_key.
+    const asAnthropic = resolveApiCredentials(tmpDir, 'opus', { accountRef: 'legacy-account' }, 'anthropic');
+    assert.ok(
+      asAnthropic && asAnthropic.apiKey === 'sk-legacy-test',
+      'legacy api_key resolves under anthropic adapter',
+    );
+
+    const asOpenai = resolveApiCredentials(tmpDir, 'opus', { accountRef: 'legacy-account' }, 'openai');
+    assert.ok(asOpenai && asOpenai.apiKey === 'sk-legacy-test', 'legacy api_key resolves under openai adapter');
   } finally {
     rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/packages/api/test/catagent-vendor-neutrality.test.js
+++ b/packages/api/test/catagent-vendor-neutrality.test.js
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function stripCommentsAndStrings(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/\/\/.*$/gm, ' ')
+    .replace(/`(?:\\.|[^`])*`/g, ' ')
+    .replace(/'(?:\\.|[^'])*'/g, ' ')
+    .replace(/"(?:\\.|[^"])*"/g, ' ');
+}
+
+test('AC-G12/AC-G27: CatAgentService stays vendor-neutral in code identifiers', () => {
+  const source = readFileSync(
+    join(__dirname, '..', 'src', 'domains', 'cats', 'services', 'agents', 'providers', 'catagent', 'CatAgentService.ts'),
+    'utf-8',
+  );
+  const stripped = stripCommentsAndStrings(source);
+  for (const pattern of [
+    /\bAnthropic[A-Za-z0-9_]*\b/,
+    /\bmapAnthropicError\b/,
+    /\bparseAnthropicSSE\b/,
+    /\bOpenai[A-Za-z0-9_]*\b/,
+    /\bopenai[A-Za-z0-9_]*\b/,
+  ]) {
+    assert.equal(pattern.test(stripped), false, `CatAgentService must stay vendor-neutral: ${pattern}`);
+  }
+});

--- a/packages/api/test/cats-routes-runtime-crud.test.js
+++ b/packages/api/test/cats-routes-runtime-crud.test.js
@@ -488,6 +488,157 @@ describe('cats routes runtime CRUD', { concurrency: false }, () => {
     assert.match(JSON.parse(rejectedPatchRes.body).error, /only supported for catagent clients/i);
   });
 
+  // F159 Phase G G2 step 1b (AC-G15): mirror the nativeToolLevel/commandPolicy
+  // routes-level matrix for the new catAgentProtocol field — three behaviors:
+  //   1. catagent + catAgentProtocol → POST persists + GET returns
+  //   2. PATCH update / PATCH null clear on existing catagent member
+  //   3. non-catagent + catAgentProtocol → POST rejects (400)
+  //   4. PATCH clientId switch away from catagent → catAgentProtocol auto-cleared
+  it('persists catAgentProtocol via POST/PATCH for catagent members, GET exposes it', async () => {
+    const projectRoot = createProjectRoot();
+    process.env.CAT_TEMPLATE_PATH = join(projectRoot, 'cat-template.json');
+
+    const Fastify = (await import('fastify')).default;
+    const { catsRoutes } = await import('../dist/routes/cats.js');
+
+    const app = Fastify();
+    await app.register(catsRoutes);
+
+    const createRes = await app.inject({
+      method: 'POST',
+      url: '/api/cats',
+      headers: { 'content-type': 'application/json', 'x-cat-cafe-user': 'codex' },
+      body: JSON.stringify({
+        catId: 'runtime-protocol-cat',
+        name: '协议路由猫',
+        displayName: '协议路由猫',
+        avatar: '/avatars/catagent.png',
+        color: { primary: '#0ea5e9', secondary: '#e0f2fe' },
+        mentionPatterns: ['@runtime-protocol-cat'],
+        roleDescription: '协议位 routes 测试',
+        clientId: 'catagent',
+        accountRef: 'claude',
+        defaultModel: 'claude-opus-4-6',
+        mcpSupport: false,
+        catAgentProtocol: 'openai-chat',
+      }),
+    });
+    assert.equal(createRes.statusCode, 201);
+
+    const listRes = await app.inject({ method: 'GET', url: '/api/cats' });
+    assert.equal(listRes.statusCode, 200);
+    const cat = JSON.parse(listRes.body).cats.find((c) => c.id === 'runtime-protocol-cat');
+    assert.ok(cat, 'runtime-protocol-cat should appear in /api/cats');
+    assert.equal(cat.catAgentProtocol, 'openai-chat');
+
+    const patchRes = await app.inject({
+      method: 'PATCH',
+      url: '/api/cats/runtime-protocol-cat',
+      headers: { 'content-type': 'application/json', 'x-cat-cafe-user': 'codex' },
+      body: JSON.stringify({ catAgentProtocol: 'anthropic-messages' }),
+    });
+    assert.equal(patchRes.statusCode, 200);
+
+    const listAfterPatchRes = await app.inject({ method: 'GET', url: '/api/cats' });
+    const catAfterPatch = JSON.parse(listAfterPatchRes.body).cats.find((c) => c.id === 'runtime-protocol-cat');
+    assert.equal(catAfterPatch.catAgentProtocol, 'anthropic-messages');
+
+    const patchNullRes = await app.inject({
+      method: 'PATCH',
+      url: '/api/cats/runtime-protocol-cat',
+      headers: { 'content-type': 'application/json', 'x-cat-cafe-user': 'codex' },
+      body: JSON.stringify({ catAgentProtocol: null }),
+    });
+    assert.equal(patchNullRes.statusCode, 200);
+
+    const listAfterClearRes = await app.inject({ method: 'GET', url: '/api/cats' });
+    const catAfterClear = JSON.parse(listAfterClearRes.body).cats.find((c) => c.id === 'runtime-protocol-cat');
+    assert.equal(catAfterClear.catAgentProtocol, undefined, 'patch null must clear catAgentProtocol');
+  });
+
+  it('rejects catAgentProtocol for non-CatAgent members and clears it on client switch', async () => {
+    const projectRoot = createProjectRoot();
+    process.env.CAT_TEMPLATE_PATH = join(projectRoot, 'cat-template.json');
+
+    const Fastify = (await import('fastify')).default;
+    const { catsRoutes } = await import('../dist/routes/cats.js');
+
+    const app = Fastify();
+    await app.register(catsRoutes);
+
+    // 1. Non-catagent + catAgentProtocol → POST rejected
+    const rejectedCreateRes = await app.inject({
+      method: 'POST',
+      url: '/api/cats',
+      headers: { 'content-type': 'application/json', 'x-cat-cafe-user': 'codex' },
+      body: JSON.stringify({
+        catId: 'runtime-openai-protocol',
+        name: '错误协议猫',
+        displayName: '错误协议猫',
+        avatar: '/avatars/codex.png',
+        color: { primary: '#2563eb', secondary: '#bfdbfe' },
+        mentionPatterns: ['@runtime-openai-protocol'],
+        roleDescription: 'should reject catAgentProtocol',
+        clientId: 'openai',
+        accountRef: 'codex',
+        defaultModel: 'gpt-5.5',
+        catAgentProtocol: 'openai-chat',
+      }),
+    });
+    assert.equal(rejectedCreateRes.statusCode, 400);
+    assert.match(JSON.parse(rejectedCreateRes.body).error, /only supported for catagent clients/i);
+
+    // 2. catagent member with catAgentProtocol set, then switch clientId → cleared
+    const createCatAgentRes = await app.inject({
+      method: 'POST',
+      url: '/api/cats',
+      headers: { 'content-type': 'application/json', 'x-cat-cafe-user': 'codex' },
+      body: JSON.stringify({
+        catId: 'runtime-protocol-switch',
+        name: '协议切换猫',
+        displayName: '协议切换猫',
+        avatar: '/avatars/catagent.png',
+        color: { primary: '#16a34a', secondary: '#bbf7d0' },
+        mentionPatterns: ['@runtime-protocol-switch'],
+        roleDescription: 'switches client from catagent',
+        clientId: 'catagent',
+        accountRef: 'claude',
+        defaultModel: 'claude-opus-4-6',
+        catAgentProtocol: 'openai-chat',
+      }),
+    });
+    assert.equal(createCatAgentRes.statusCode, 201);
+
+    const switchClientRes = await app.inject({
+      method: 'PATCH',
+      url: '/api/cats/runtime-protocol-switch',
+      headers: { 'content-type': 'application/json', 'x-cat-cafe-user': 'codex' },
+      body: JSON.stringify({
+        clientId: 'openai',
+        accountRef: 'codex',
+        defaultModel: 'gpt-5.5',
+      }),
+    });
+    assert.equal(switchClientRes.statusCode, 200);
+
+    const listAfterSwitchRes = await app.inject({ method: 'GET', url: '/api/cats' });
+    const switchedCat = JSON.parse(listAfterSwitchRes.body).cats.find((c) => c.id === 'runtime-protocol-switch');
+    assert.ok(switchedCat, 'runtime-protocol-switch should still exist');
+    assert.equal(switchedCat.clientId, 'openai');
+    assert.equal(switchedCat.catAgentProtocol, undefined, 'switching away from catagent must clear catAgentProtocol');
+    assert.equal(switchedCat.nativeToolLevel, undefined, 'companion clearing still works (regression sanity)');
+
+    // 3. PATCH non-catagent member with catAgentProtocol → 400
+    const rejectedPatchRes = await app.inject({
+      method: 'PATCH',
+      url: '/api/cats/runtime-protocol-switch',
+      headers: { 'content-type': 'application/json', 'x-cat-cafe-user': 'codex' },
+      body: JSON.stringify({ catAgentProtocol: 'openai-chat' }),
+    });
+    assert.equal(rejectedPatchRes.statusCode, 400);
+    assert.match(JSON.parse(rejectedPatchRes.body).error, /only supported for catagent clients/i);
+  });
+
   it('POST /api/cats persists structured cli.effort for Codex members', async () => {
     const projectRoot = createProjectRoot();
     process.env.CAT_TEMPLATE_PATH = join(projectRoot, 'cat-template.json');

--- a/packages/api/test/openai-chat-adapter-golden.test.js
+++ b/packages/api/test/openai-chat-adapter-golden.test.js
@@ -1,0 +1,290 @@
+/**
+ * OpenAIChatAdapter Golden-Wire Contract Test — F159 Phase G G2 AC-G25
+ *
+ * Byte-stable lock on the OpenAI Chat Completions protocol shape:
+ * - URL / headers / body
+ * - stream_options.include_usage
+ * - transcript codec (assistant tool_calls + tool messages)
+ * - streaming chunk → neutral event mapping
+ * - error text + terminal stop classification
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { OpenAIChatAdapter } from '../dist/domains/cats/services/agents/providers/catagent/openai-chat-adapter.js';
+
+function toStream(chunks) {
+  let i = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (i < chunks.length) {
+        controller.enqueue(new TextEncoder().encode(chunks[i++]));
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+function sse(data) {
+  return `data: ${typeof data === 'string' ? data : JSON.stringify(data)}\n\n`;
+}
+
+async function collect(iter) {
+  const out = [];
+  for await (const event of iter) out.push(event);
+  return out;
+}
+
+describe('OpenAIChatAdapter: identity', () => {
+  test('clientFamily and protocolId are stable identifiers', () => {
+    const adapter = new OpenAIChatAdapter();
+    assert.equal(adapter.clientFamily, 'openai');
+    assert.equal(adapter.protocolId, 'openai-chat-v1');
+  });
+});
+
+describe('OpenAIChatAdapter: buildRequestUrl', () => {
+  const adapter = new OpenAIChatAdapter();
+
+  test('undefined baseURL uses default', () => {
+    assert.equal(adapter.buildRequestUrl(undefined), 'https://api.openai.com/v1/chat/completions');
+  });
+
+  test('empty string baseURL falls back to default', () => {
+    assert.equal(adapter.buildRequestUrl(''), 'https://api.openai.com/v1/chat/completions');
+  });
+
+  test('/v1 suffix not double-prefixed', () => {
+    assert.equal(adapter.buildRequestUrl('https://proxy.example/v1'), 'https://proxy.example/v1/chat/completions');
+  });
+
+  test('custom proxy without /v1 keeps full path', () => {
+    assert.equal(
+      adapter.buildRequestUrl('https://gateway.example/openai'),
+      'https://gateway.example/openai/v1/chat/completions',
+    );
+  });
+});
+
+describe('OpenAIChatAdapter: buildRequestHeaders', () => {
+  test('produces exact Bearer header set', () => {
+    const adapter = new OpenAIChatAdapter();
+    assert.deepEqual(adapter.buildRequestHeaders({ apiKey: 'sk-openai-test' }), {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer sk-openai-test',
+    });
+  });
+});
+
+describe('OpenAIChatAdapter: buildRequestBody', () => {
+  const adapter = new OpenAIChatAdapter();
+
+  test('minimal body uses stream + include_usage', () => {
+    const body = adapter.buildRequestBody({
+      model: 'gpt-5.5',
+      messages: [adapter.encodeUserPrompt('hi')],
+      tools: [],
+    });
+    const json = JSON.parse(JSON.stringify(body));
+    assert.deepEqual(json, {
+      model: 'gpt-5.5',
+      max_tokens: 4096,
+      messages: [{ role: 'user', content: 'hi' }],
+      stream: true,
+      stream_options: { include_usage: true },
+    });
+  });
+
+  test('system prompt is prepended as system message', () => {
+    const body = adapter.buildRequestBody({
+      model: 'gpt-5.5',
+      messages: [adapter.encodeUserPrompt('hi')],
+      tools: [],
+      systemPrompt: 'You are X.',
+    });
+    const json = JSON.parse(JSON.stringify(body));
+    assert.deepEqual(json.messages[0], { role: 'system', content: 'You are X.' });
+    assert.deepEqual(json.messages[1], { role: 'user', content: 'hi' });
+  });
+
+  test('tools map to OpenAI function tool schema', () => {
+    const body = adapter.buildRequestBody({
+      model: 'gpt-5.5',
+      messages: [adapter.encodeUserPrompt('read file')],
+      tools: [{ name: 'read_file', description: 'Read file', inputSchema: { type: 'object' } }],
+    });
+    const json = JSON.parse(JSON.stringify(body));
+    assert.deepEqual(json.tools, [
+      {
+        type: 'function',
+        function: {
+          name: 'read_file',
+          description: 'Read file',
+          parameters: { type: 'object' },
+        },
+      },
+    ]);
+  });
+});
+
+describe('OpenAIChatAdapter: transcript codec', () => {
+  const adapter = new OpenAIChatAdapter();
+
+  test('encodeAssistantTurn emits assistant content + tool_calls losslessly', () => {
+    const body = adapter.buildRequestBody({
+      model: 'gpt-5.5',
+      messages: [
+        adapter.encodeUserPrompt('go'),
+        adapter.encodeAssistantTurn([
+          { type: 'text', text: 'Thinking...' },
+          { type: 'tool_call', id: 'call_1', name: 'read_file', input: { path: 'a.txt' } },
+        ]),
+      ],
+      tools: [],
+    });
+    const json = JSON.parse(JSON.stringify(body));
+    assert.deepEqual(json.messages[1], {
+      role: 'assistant',
+      content: 'Thinking...',
+      tool_calls: [
+        {
+          id: 'call_1',
+          type: 'function',
+          function: {
+            name: 'read_file',
+            arguments: '{"path":"a.txt"}',
+          },
+        },
+      ],
+    });
+  });
+
+  test('encodeToolResults emits role=tool messages keyed by tool_call_id', () => {
+    const body = adapter.buildRequestBody({
+      model: 'gpt-5.5',
+      messages: [
+        adapter.encodeUserPrompt('go'),
+        adapter.encodeToolResults([
+          { id: 'call_1', content: 'file body', status: 'ok' },
+          { id: 'call_2', content: 'Error: nope', status: 'error' },
+        ]),
+      ],
+      tools: [],
+    });
+    const json = JSON.parse(JSON.stringify(body));
+    assert.deepEqual(json.messages.slice(1), [
+      { role: 'tool', tool_call_id: 'call_1', content: 'file body' },
+      { role: 'tool', tool_call_id: 'call_2', content: 'Error: nope' },
+    ]);
+  });
+});
+
+describe('OpenAIChatAdapter: parseStreamEvents', () => {
+  test('text deltas + final usage + stop are normalised', async () => {
+    const adapter = new OpenAIChatAdapter();
+    const stream = [
+      sse({
+        id: 'chatcmpl-1',
+        choices: [{ index: 0, delta: { role: 'assistant', content: 'Hel' }, finish_reason: null }],
+      }),
+      sse({
+        id: 'chatcmpl-1',
+        choices: [{ index: 0, delta: { content: 'lo' }, finish_reason: 'stop' }],
+      }),
+      sse({
+        id: 'chatcmpl-1',
+        choices: [],
+        usage: { prompt_tokens: 12, completion_tokens: 4, prompt_tokens_details: { cached_tokens: 3 } },
+      }),
+      sse('[DONE]'),
+    ].join('');
+    const events = await collect(adapter.parseStreamEvents(toStream([stream])));
+    assert.deepEqual(
+      events.filter((event) => event.type === 'text_delta').map((event) => event.text),
+      ['Hel', 'lo'],
+    );
+    const stop = events.find((event) => event.type === 'stop');
+    assert.equal(stop?.stopReason, 'stop');
+    const usage = events.find((event) => event.type === 'usage_update');
+    assert.deepEqual(usage?.usage, { inputTokens: 12, outputTokens: 4, cacheReadTokens: 3 });
+    const complete = events.find((event) => event.type === 'content_block_complete');
+    assert.deepEqual(complete?.block, { type: 'text', text: 'Hello' });
+  });
+
+  test('tool_calls delta is reassembled into neutral tool_call block', async () => {
+    const adapter = new OpenAIChatAdapter();
+    const stream = [
+      sse({
+        id: 'chatcmpl-2',
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call_abc',
+                  function: { name: 'read_file', arguments: '{"path":"a' },
+                },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      }),
+      sse({
+        id: 'chatcmpl-2',
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [{ index: 0, function: { arguments: '.txt"}' } }],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      }),
+      sse('[DONE]'),
+    ].join('');
+    const events = await collect(adapter.parseStreamEvents(toStream([stream])));
+    const complete = events.find((event) => event.type === 'content_block_complete');
+    assert.equal(complete?.block.type, 'tool_call');
+    assert.equal(complete?.block.id, 'call_abc');
+    assert.equal(complete?.block.name, 'read_file');
+    assert.deepEqual(complete?.block.input, { path: 'a.txt' });
+    const stop = events.find((event) => event.type === 'stop');
+    assert.equal(stop?.stopReason, 'tool_calls');
+  });
+
+  test('missing [DONE] yields stream_error', async () => {
+    const adapter = new OpenAIChatAdapter();
+    const stream = sse({
+      id: 'chatcmpl-3',
+      choices: [{ index: 0, delta: { content: 'partial' }, finish_reason: 'stop' }],
+    });
+    const events = await collect(adapter.parseStreamEvents(toStream([stream])));
+    const error = events.find((event) => event.type === 'stream_error');
+    assert.match(error?.error ?? '', /\[DONE\]/);
+  });
+});
+
+describe('OpenAIChatAdapter: mapError + terminal stop reasons', () => {
+  test('mapError emits OpenAI-shaped error text', () => {
+    const adapter = new OpenAIChatAdapter();
+    assert.deepEqual(adapter.mapError({ status: 429, message: 'rate limited' }), {
+      errorText: 'OpenAI API error (429): rate limited',
+    });
+  });
+
+  test('terminal stop reasons match Chat Completions semantics', () => {
+    const adapter = new OpenAIChatAdapter();
+    for (const reason of ['stop', 'length', 'content_filter']) {
+      assert.equal(adapter.isTerminalStopReason(reason), true);
+    }
+    for (const reason of ['tool_calls', 'function_call', null, undefined, 'future_reason', '']) {
+      assert.equal(adapter.isTerminalStopReason(reason ?? null), false);
+    }
+  });
+});

--- a/packages/shared/src/types/cat-breed.ts
+++ b/packages/shared/src/types/cat-breed.ts
@@ -7,7 +7,14 @@
  * Phase 4-F: 支持多 Variant（多版本猫召唤）
  */
 
-import type { AgyProfileConfig, CatColor, ClientId, CommandPolicyEntry, NativeToolLevel } from './cat.js';
+import type {
+  AgyProfileConfig,
+  CatAgentProtocol,
+  CatColor,
+  ClientId,
+  CommandPolicyEntry,
+  NativeToolLevel,
+} from './cat.js';
 import type { CatId } from './ids.js';
 import type { VoiceConfig } from './tts.js';
 
@@ -89,6 +96,10 @@ export interface CatVariant {
   readonly nativeToolLevel?: NativeToolLevel;
   /** F159 Phase F: allowlist-first command policy for L2 run_command. */
   readonly commandPolicy?: readonly CommandPolicyEntry[];
+  /** F159 Phase G G2 (AC-G13): CatAgent wire protocol selection. Only
+   *  meaningful when `clientId === 'catagent'`; omitted defaults to
+   *  `'anthropic-messages'` (G1 catagent behavior preserved). */
+  readonly catAgentProtocol?: CatAgentProtocol;
   /** Optional per-variant override for sessionChain; falls back to breed.features.sessionChain. */
   readonly sessionChain?: boolean;
   /** F34: Per-cat TTS voice (optional, falls back to defaults in cat-voices.ts) */

--- a/packages/shared/src/types/cat-breed.ts
+++ b/packages/shared/src/types/cat-breed.ts
@@ -231,8 +231,18 @@ export type AccountProtocol = 'anthropic' | 'openai' | 'openai-responses' | 'goo
  */
 export interface AccountConfig {
   readonly authType: 'oauth' | 'api_key';
-  /** F171: Explicit client identity for API key accounts (e.g. 'anthropic', 'openai'). */
+  /** F171 (legacy display): freeform client identity surfaced in Hub UI.
+   *  Do NOT use for routing/security decisions — prefer `clientFamily`,
+   *  which is typed and drives `profile.client` in `accountToRuntimeProfile`.
+   *  TODO(F159 G3+): sunset once Hub UI migrates fully to `clientFamily`. */
   readonly clientId?: string;
+  /** F159 G2 (AC-G20): typed client family for api_key accounts.
+   *  Authoritative source for adapter routing. When set on api_key accounts,
+   *  drives `profile.client` in `accountToRuntimeProfile`, which enables the
+   *  family fail-closed guard in `catagent-credentials.ts` (AC-G22).
+   *  Optional: existing api_key accounts without `clientFamily` continue to
+   *  resolve best-effort (no `profile.client` set → guard falls through). */
+  readonly clientFamily?: 'anthropic' | 'openai' | 'google' | 'kimi' | 'dare' | 'opencode';
   readonly baseUrl?: string;
   readonly models?: readonly string[];
   readonly displayName?: string;

--- a/packages/shared/src/types/cat.ts
+++ b/packages/shared/src/types/cat.ts
@@ -29,6 +29,24 @@ export type CatProvider = ClientId;
 /** F159 Phase F: native CatAgent tool capability tier. */
 export type NativeToolLevel = 'L0' | 'L1' | 'L2';
 
+/**
+ * F159 Phase G G2: CatAgent wire protocol selection.
+ *
+ * Selects which `CatAgentProtocolAdapter` the factory dispatches for a
+ * `clientId='catagent'` member:
+ * - `anthropic-messages` → `AnthropicMessagesAdapter` (G1 default, Anthropic
+ *   Messages API `POST /v1/messages` + `x-api-key` + `anthropic-version`)
+ * - `openai-chat` → `OpenAIChatAdapter` (G2 new, OpenAI Chat Completions
+ *   `POST /v1/chat/completions` + `Authorization: Bearer`)
+ *
+ * Omitted defaults to `'anthropic-messages'` to preserve G1 catagent members'
+ * behavior across the G2 rollout. Only meaningful when `clientId === 'catagent'`;
+ * persistence is gated to catagent-only at runtime catalog / route / Hub layers.
+ *
+ * See AC-G13 + KD-20 (fail-closed dispatch, no runtime protocol guessing).
+ */
+export type CatAgentProtocol = 'anthropic-messages' | 'openai-chat';
+
 /** F159 Phase F: allowlist-first command policy for CatAgent run_command. */
 export interface CommandPolicyEntry {
   readonly binary: string;
@@ -90,6 +108,10 @@ export interface CatConfig {
   readonly nativeToolLevel?: NativeToolLevel;
   /** F159 Phase F: allowlist-first command policy for L2 run_command. */
   readonly commandPolicy?: readonly CommandPolicyEntry[];
+  /** F159 Phase G G2 (AC-G13): CatAgent wire protocol selection. Only
+   *  meaningful when `clientId === 'catagent'`; omitted defaults to
+   *  `'anthropic-messages'` (G1 catagent behavior preserved). */
+  readonly catAgentProtocol?: CatAgentProtocol;
   readonly roleDescription: string;
   readonly personality: string;
   /** F32-b: Which breed this cat belongs to (for frontend grouping) */

--- a/packages/shared/src/types/client-routing.ts
+++ b/packages/shared/src/types/client-routing.ts
@@ -1,4 +1,4 @@
-import type { ClientId } from './cat.js';
+import type { CatConfig, ClientId } from './cat.js';
 import type { AccountProtocol } from './cat-breed.js';
 
 export type BuiltinAccountClient = Extract<ClientId, 'anthropic' | 'openai' | 'google' | 'kimi' | 'dare' | 'opencode'>;
@@ -52,4 +52,64 @@ export function protocolForClient(client: ClientId): BuiltinAccountProtocol | nu
     default:
       return null;
   }
+}
+
+// ── F159 Phase G G2 Axis 3 (KD-24): member-level protocol-aware helpers ──
+//
+// `protocolForClient` / `builtinAccountFamilyForClient` above are kept as
+// pure `clientId → default family/protocol` mappings (client-level default),
+// matching the @gpt555 G2 design gate P2 decision: changing those to accept
+// `catConfig` would pollute shared routing semantics and force every
+// downstream call site to thread `catConfig` through. The G2 effective*
+// helpers below take per-member catConfig and surface the protocol-aware
+// answer when `clientId === 'catagent'` (where `catAgentProtocol` overrides
+// the client-level default), falling through to the client-level helpers
+// otherwise.
+//
+// Migration audit (G2 follow-up): downstream call sites for protocolForClient
+// / builtinAccountFamilyForClient should each be evaluated individually for
+// whether they want the client-level default (keep) or the member-level
+// effective answer (migrate to effective* variant).
+
+/**
+ * Resolve the effective wire protocol for a CatAgent member, honoring the
+ * `catAgentProtocol` selection bit persisted on `CatConfig`.
+ *
+ * - non-catagent clients → falls through to `protocolForClient(clientId)`
+ *   so existing behavior is unchanged
+ * - catagent + `catAgentProtocol === 'openai-chat'` → `'openai'`
+ * - catagent + `catAgentProtocol === 'anthropic-messages'` → `'anthropic'`
+ * - catagent + undefined / unknown → `'anthropic'` (G1 catagent backward-
+ *   compat default; matches `catagent-protocol-factory.ts` default branch)
+ *
+ * Returns `null` only when the underlying client has no protocol mapping
+ * (e.g. 'antigravity' / 'acp').
+ */
+export function effectiveProtocolForCat(catConfig: CatConfig): BuiltinAccountProtocol | null {
+  if (catConfig.clientId === 'catagent') {
+    if (catConfig.catAgentProtocol === 'openai-chat') return 'openai';
+    // 'anthropic-messages' or undefined / unrecognised → anthropic default.
+    // (Factory still fail-closes on unknown values at adapter dispatch
+    // time — this helper is for routing/account-binding decisions where
+    // a sensible default is more useful than throwing.)
+    return 'anthropic';
+  }
+  return protocolForClient(catConfig.clientId);
+}
+
+/**
+ * Resolve the effective builtin account family for a CatAgent member,
+ * honoring the `catAgentProtocol` selection bit on `CatConfig`.
+ *
+ * - non-catagent clients → falls through to `builtinAccountFamilyForClient(clientId)`
+ * - catagent + `'openai-chat'` → `'openai'`
+ * - catagent + `'anthropic-messages'` / undefined → `'anthropic'` (G1
+ *   backward-compat default)
+ */
+export function effectiveClientFamilyForCat(catConfig: CatConfig): BuiltinAccountClient | null {
+  if (catConfig.clientId === 'catagent') {
+    if (catConfig.catAgentProtocol === 'openai-chat') return 'openai';
+    return 'anthropic';
+  }
+  return builtinAccountFamilyForClient(catConfig.clientId);
 }

--- a/packages/shared/src/types/client-routing.ts
+++ b/packages/shared/src/types/client-routing.ts
@@ -66,10 +66,26 @@ export function protocolForClient(client: ClientId): BuiltinAccountProtocol | nu
 // the client-level default), falling through to the client-level helpers
 // otherwise.
 //
-// Migration audit (G2 follow-up): downstream call sites for protocolForClient
-// / builtinAccountFamilyForClient should each be evaluated individually for
-// whether they want the client-level default (keep) or the member-level
-// effective answer (migrate to effective* variant).
+// ── AC-G19 Migration Audit (completed 2026-06-24 per @gpt555 G2 Axis 3 P2) ──
+//
+// Audit of every existing `protocolForClient('catagent')` /
+// `builtinAccountFamilyForClient('catagent')` call site with per-site decision:
+//
+// | Call site                                         | Decision  | Rationale                                                                                                                                                |
+// | ------------------------------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+// | account-resolver.ts:45  resolveBuiltinClientForProvider(provider: ClientId) | KEEP   | Helper accepts only ClientId; caller has no catConfig context. Catagent-aware credential resolution flows through `catagent-credentials.ts` w/ `adapter.clientFamily` (Axis 2 already wires this end-to-end). |
+// | account-resolver.ts:131 builtinProtocol from BUILTIN_ACCOUNT_MAP ref           | KEEP   | Profile-shape derivation from synthetic builtin ref (OAuth fallback); catAgentProtocol does not apply at the account-profile layer.                                                              |
+// | account-resolver.ts:165 same as :131 in preferred-ref branch                   | KEEP   | Same — synthetic builtin profile shape; not member-level.                                                                                                                                       |
+// | account-resolver.ts:202 same as :131 in walk-discovery-chain branch           | KEEP   | Same.                                                                                                                                                                                            |
+// | account-resolver.ts:241 same as :131 in synthetic-fallback branch             | KEEP   | Same.                                                                                                                                                                                            |
+// | first-run-quest.ts:437  buildProbeEnv(clientId, ...)                          | KEEP   | First-run credential probe runs BEFORE any cat is persisted — there is no CatConfig at this point, only the operator's chosen clientId for probing. Catagent-specific protocol is decided post-creation.       |
+// | hub-cat-editor.model.ts:381 resolveBuiltinClientFamily → filterAccounts       | DEFERRED | Hub UI account-picker filter; for catagent + 'openai-chat' the picker should arguably show OpenAI accounts. Migration requires threading `form.catAgentProtocol` through `filterAccounts`. Tracked as Axis 6 cross-cutting UX polish — does NOT block G2 merge gate (credentials path still fails-closed at adapter level via Axis 2). |
+//
+// Outcome: 6 sites KEEP client-level default (correct semantics — they
+// operate on ClientId / profile shape, not member-level routing). 1 site
+// DEFERRED with explicit follow-up tracker. Zero sites required immediate
+// migration to satisfy AC-G19; the client-level / member-level split is
+// honored everywhere a catConfig is actually in scope.
 
 /**
  * Resolve the effective wire protocol for a CatAgent member, honoring the

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -213,6 +213,8 @@ export type { BuiltinAccountClient } from './client-routing.js';
 export {
   builtinAccountFamilyForClient,
   builtinAccountIdForClient,
+  effectiveClientFamilyForCat,
+  effectiveProtocolForCat,
   protocolForClient,
 } from './client-routing.js';
 // Command types (F142 Phase B — slash command framework)

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -172,6 +172,7 @@ export type {
 // Cat types
 export type {
   AgyProfileConfig,
+  CatAgentProtocol,
   CatColor,
   CatConfig,
   /** @deprecated clowder-ai#340: Use ClientId instead. */

--- a/packages/shared/test/client-routing.test.js
+++ b/packages/shared/test/client-routing.test.js
@@ -54,10 +54,7 @@ test('effectiveProtocolForCat: non-catagent ignores catAgentProtocol (only meani
   // Even if catAgentProtocol leaks onto a non-catagent CatConfig (it shouldn't
   // per truth-source gating, but defense-in-depth at the routing helper), it
   // does NOT change the protocol — that's strictly a catagent-only switch.
-  assert.equal(
-    effectiveProtocolForCat({ id: 'codex', clientId: 'openai', catAgentProtocol: 'openai-chat' }),
-    'openai',
-  );
+  assert.equal(effectiveProtocolForCat({ id: 'codex', clientId: 'openai', catAgentProtocol: 'openai-chat' }), 'openai');
   assert.equal(
     effectiveProtocolForCat({ id: 'opus', clientId: 'anthropic', catAgentProtocol: 'openai-chat' }),
     'anthropic',

--- a/packages/shared/test/client-routing.test.js
+++ b/packages/shared/test/client-routing.test.js
@@ -1,6 +1,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { builtinAccountFamilyForClient, builtinAccountIdForClient, protocolForClient } from '../dist/index.js';
+import {
+  builtinAccountFamilyForClient,
+  builtinAccountIdForClient,
+  effectiveClientFamilyForCat,
+  effectiveProtocolForCat,
+  protocolForClient,
+} from '../dist/index.js';
+
+// ── Client-level default mapping (KD-24: PRESERVED unchanged, no catConfig) ──
 
 test('catagent shares anthropic builtin account family', () => {
   assert.equal(builtinAccountFamilyForClient('catagent'), 'anthropic');
@@ -8,8 +16,65 @@ test('catagent shares anthropic builtin account family', () => {
 });
 
 test('protocolForClient normalizes provider family routing', () => {
+  // F159 Phase G G2 KD-24: this assertion is intentionally preserved AS-IS.
+  // protocolForClient is the pure client-level default; the G2 catagent
+  // protocol-aware answer lives on effectiveProtocolForCat below.
   assert.equal(protocolForClient('catagent'), 'anthropic');
   assert.equal(protocolForClient('opencode'), 'anthropic');
   assert.equal(protocolForClient('dare'), 'openai');
   assert.equal(protocolForClient('antigravity'), null);
+});
+
+// ── F159 Phase G G2 Axis 3 (AC-G18 / KD-24): member-level effective helpers ──
+
+function catagentConfig(catAgentProtocol) {
+  return { id: 'opus', clientId: 'catagent', catAgentProtocol };
+}
+
+test('effectiveProtocolForCat: catagent + no catAgentProtocol → anthropic (G1 backward-compat)', () => {
+  assert.equal(effectiveProtocolForCat({ id: 'opus', clientId: 'catagent' }), 'anthropic');
+});
+
+test('effectiveProtocolForCat: catagent + anthropic-messages → anthropic', () => {
+  assert.equal(effectiveProtocolForCat(catagentConfig('anthropic-messages')), 'anthropic');
+});
+
+test('effectiveProtocolForCat: catagent + openai-chat → openai (G2 wire protocol override)', () => {
+  assert.equal(effectiveProtocolForCat(catagentConfig('openai-chat')), 'openai');
+});
+
+test('effectiveProtocolForCat: non-catagent falls through to protocolForClient', () => {
+  assert.equal(effectiveProtocolForCat({ id: 'codex', clientId: 'openai' }), 'openai');
+  assert.equal(effectiveProtocolForCat({ id: 'opus', clientId: 'anthropic' }), 'anthropic');
+  assert.equal(effectiveProtocolForCat({ id: 'gemini', clientId: 'google' }), 'google');
+  assert.equal(effectiveProtocolForCat({ id: 'agy', clientId: 'antigravity' }), null);
+});
+
+test('effectiveProtocolForCat: non-catagent ignores catAgentProtocol (only meaningful for catagent)', () => {
+  // Even if catAgentProtocol leaks onto a non-catagent CatConfig (it shouldn't
+  // per truth-source gating, but defense-in-depth at the routing helper), it
+  // does NOT change the protocol — that's strictly a catagent-only switch.
+  assert.equal(
+    effectiveProtocolForCat({ id: 'codex', clientId: 'openai', catAgentProtocol: 'openai-chat' }),
+    'openai',
+  );
+  assert.equal(
+    effectiveProtocolForCat({ id: 'opus', clientId: 'anthropic', catAgentProtocol: 'openai-chat' }),
+    'anthropic',
+  );
+});
+
+test('effectiveClientFamilyForCat: catagent + openai-chat → openai (account family override)', () => {
+  assert.equal(effectiveClientFamilyForCat(catagentConfig('openai-chat')), 'openai');
+});
+
+test('effectiveClientFamilyForCat: catagent default (no catAgentProtocol) → anthropic', () => {
+  assert.equal(effectiveClientFamilyForCat({ id: 'opus', clientId: 'catagent' }), 'anthropic');
+  assert.equal(effectiveClientFamilyForCat(catagentConfig('anthropic-messages')), 'anthropic');
+});
+
+test('effectiveClientFamilyForCat: non-catagent falls through to builtinAccountFamilyForClient', () => {
+  assert.equal(effectiveClientFamilyForCat({ id: 'codex', clientId: 'openai' }), 'openai');
+  assert.equal(effectiveClientFamilyForCat({ id: 'opus', clientId: 'anthropic' }), 'anthropic');
+  assert.equal(effectiveClientFamilyForCat({ id: 'agy', clientId: 'antigravity' }), null);
 });

--- a/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
+++ b/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
@@ -698,10 +698,10 @@ describe('HubCatEditor', () => {
     expect(createPayload.catAgentProtocol).toBe('openai-chat');
 
     // 2. catagent + catAgentProtocol '' (backend default) → field omitted (no patch)
-    const defaultPayload = buildCatPayload(
-      { ...formCatAgentOpenAI, catAgentProtocol: '' },
-      null,
-    ) as Record<string, unknown>;
+    const defaultPayload = buildCatPayload({ ...formCatAgentOpenAI, catAgentProtocol: '' }, null) as Record<
+      string,
+      unknown
+    >;
     expect(Object.hasOwn(defaultPayload, 'catAgentProtocol')).toBe(false);
 
     // 3. Switching away from catagent + existing cat had catAgentProtocol → null clears

--- a/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
+++ b/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
@@ -584,6 +584,78 @@ describe('HubCatEditor', () => {
     expect(clearPayload.commandPolicy).toBeNull();
   });
 
+  // F159 Phase G G2 (AC-G16, @gpt555 P2 UI State Drift fix):
+  // Verify that AccountSection's Client switch onChange explicitly resets
+  // catAgentProtocol when switching away from catagent — without this,
+  // users can silently carry over an incompatible protocol selection.
+  it('AccountSection Client switch clears catAgentProtocol form state when leaving catagent', async () => {
+    const { AccountSection } = await import('../hub-cat-editor.sections');
+    const onChange = vi.fn();
+    const form: HubCatEditorFormState = {
+      catId: 'switch-protocol',
+      name: '协议切换猫',
+      displayName: '协议切换猫',
+      variantLabel: '',
+      nickname: '',
+      avatar: '/avatars/catagent.png',
+      colorPrimary: '#16a34a',
+      colorSecondary: '#bbf7d0',
+      mentionPatterns: '@switch-protocol',
+      roleDescription: '协议切换验证',
+      personality: '',
+      teamStrengths: '',
+      caution: '',
+      strengths: '',
+      clientId: 'catagent',
+      accountRef: 'codex-for-me',
+      defaultModel: 'gpt-5.5',
+      commandArgs: '',
+      cliConfigArgs: [],
+      nativeToolLevel: '',
+      commandPolicyPreset: '',
+      catAgentProtocol: 'openai-chat',
+      cliEffort: '',
+      provider: '',
+      sessionChain: 'true',
+      maxPromptTokens: '',
+      maxContextTokens: '',
+      maxMessages: '',
+      maxContentLengthPerMsg: '',
+      ...emptyVoiceFields,
+      ...emptyAcpFields,
+    };
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(
+        React.createElement(AccountSection, {
+          form,
+          modelOptions: [],
+          availableProfiles: [],
+          loadingProfiles: false,
+          onChange,
+        }),
+      );
+    });
+
+    // Switch Client away from catagent → onChange must include catAgentProtocol: ''
+    await changeField(queryField(container, 'select[aria-label="Client"]'), 'openai', 'change');
+    const calls = (onChange as ReturnType<typeof vi.fn>).mock.calls;
+    const lastCall = calls[calls.length - 1]?.[0] as Partial<HubCatEditorFormState>;
+    expect(lastCall.clientId).toBe('openai');
+    expect(lastCall.catAgentProtocol).toBe('');
+
+    // Sanity: switching to another catagent (idempotent) does NOT clear it
+    // (the spread is gated on nextClient !== 'catagent').
+    onChange.mockClear();
+    await changeField(queryField(container, 'select[aria-label="Client"]'), 'catagent', 'change');
+    const catagentCall = (onChange as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as Partial<HubCatEditorFormState>;
+    expect(catagentCall.clientId).toBe('catagent');
+    expect(catagentCall.catAgentProtocol).toBeUndefined();
+  });
+
   // F159 Phase G G2 (AC-G16): catAgentProtocol round-trip — mirror the
   // nativeToolLevel persist/clear matrix at the Hub payload boundary.
   it('buildCatPayload emits catAgentProtocol on catagent member and clears on non-catagent', () => {

--- a/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
+++ b/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
@@ -56,6 +56,10 @@ const emptyAcpFields = {
 const emptyNativeToolFields = {
   nativeToolLevel: '' as const,
   commandPolicyPreset: '' as const,
+  // F159 Phase G G2 (AC-G16): all form fixtures default catAgentProtocol to ''
+  // (backend default = 'anthropic-messages'). Tests that need explicit values
+  // override locally.
+  catAgentProtocol: '' as const,
 };
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -154,6 +158,7 @@ describe('HubCatEditor', () => {
       cliConfigArgs: [],
       nativeToolLevel: '',
       commandPolicyPreset: '',
+      catAgentProtocol: '',
       cliEffort: '',
       provider: '',
       sessionChain: 'true',
@@ -205,6 +210,7 @@ describe('HubCatEditor', () => {
     await renderAdvancedRuntimeSection('catagent', {
       nativeToolLevel: 'L2',
       commandPolicyPreset: 'git-readonly',
+      catAgentProtocol: '',
     });
     expect(document.body.textContent).toContain('Git 只读：status / diff');
     expect(document.body.textContent).not.toContain('保留现有自定义策略');
@@ -212,6 +218,7 @@ describe('HubCatEditor', () => {
     await renderAdvancedRuntimeSection('catagent', {
       nativeToolLevel: 'L2',
       commandPolicyPreset: 'custom',
+      catAgentProtocol: '',
     });
     expect(document.body.textContent).toContain('保留现有自定义策略');
   });
@@ -220,6 +227,7 @@ describe('HubCatEditor', () => {
     const firstRender = await renderAdvancedRuntimeSection('catagent', {
       nativeToolLevel: 'L2',
       commandPolicyPreset: 'custom',
+      catAgentProtocol: '',
     });
 
     await changeField(queryField(container, 'select[aria-label="工具级别 (CatAgent)"]'), 'L1', 'change');
@@ -231,6 +239,7 @@ describe('HubCatEditor', () => {
     const secondRender = await renderAdvancedRuntimeSection('catagent', {
       nativeToolLevel: 'L1',
       commandPolicyPreset: 'custom',
+      catAgentProtocol: '',
     });
 
     await changeField(queryField(container, 'select[aria-label="工具级别 (CatAgent)"]'), 'L2', 'change');
@@ -263,6 +272,7 @@ describe('HubCatEditor', () => {
       cliConfigArgs: [],
       nativeToolLevel: '',
       commandPolicyPreset: '',
+      catAgentProtocol: '',
       cliEffort: '',
       provider: '',
       sessionChain: 'true',
@@ -313,6 +323,7 @@ describe('HubCatEditor', () => {
       cliConfigArgs: [],
       nativeToolLevel: '',
       commandPolicyPreset: '',
+      catAgentProtocol: '',
       cliEffort: '',
       provider: '',
       sessionChain: 'true',
@@ -362,6 +373,7 @@ describe('HubCatEditor', () => {
       cliConfigArgs: [],
       nativeToolLevel: '',
       commandPolicyPreset: '',
+      catAgentProtocol: '',
       cliEffort: '',
       provider: '',
       sessionChain: 'true',
@@ -405,6 +417,7 @@ describe('HubCatEditor', () => {
       cliConfigArgs: ['--config model_provider="custom"'],
       nativeToolLevel: '',
       commandPolicyPreset: '',
+      catAgentProtocol: '',
       cliEffort: 'xhigh',
       provider: '',
       sessionChain: 'true',
@@ -444,6 +457,7 @@ describe('HubCatEditor', () => {
       cliConfigArgs: [],
       nativeToolLevel: 'L2',
       commandPolicyPreset: 'git-readonly',
+      catAgentProtocol: '',
       cliEffort: '',
       provider: '',
       sessionChain: 'true',
@@ -483,6 +497,7 @@ describe('HubCatEditor', () => {
       cliConfigArgs: [],
       nativeToolLevel: 'L2',
       commandPolicyPreset: 'git-readonly',
+      catAgentProtocol: '',
       cliEffort: '',
       provider: '',
       sessionChain: 'true',
@@ -536,6 +551,7 @@ describe('HubCatEditor', () => {
       cliConfigArgs: [],
       nativeToolLevel: 'L2',
       commandPolicyPreset: 'custom',
+      catAgentProtocol: '',
       cliEffort: '',
       provider: '',
       sessionChain: 'true',
@@ -566,6 +582,75 @@ describe('HubCatEditor', () => {
 
     const clearPayload = buildCatPayload({ ...form, commandPolicyPreset: '' }, existingCat) as Record<string, unknown>;
     expect(clearPayload.commandPolicy).toBeNull();
+  });
+
+  // F159 Phase G G2 (AC-G16): catAgentProtocol round-trip — mirror the
+  // nativeToolLevel persist/clear matrix at the Hub payload boundary.
+  it('buildCatPayload emits catAgentProtocol on catagent member and clears on non-catagent', () => {
+    const formCatAgentOpenAI: HubCatEditorFormState = {
+      catId: 'runtime-catagent',
+      name: '运行时原生猫',
+      displayName: '运行时原生猫',
+      variantLabel: '',
+      nickname: '',
+      avatar: '/avatars/catagent.png',
+      colorPrimary: '#16a34a',
+      colorSecondary: '#bbf7d0',
+      mentionPatterns: '@runtime-catagent',
+      roleDescription: '原生工具体验',
+      personality: '谨慎',
+      teamStrengths: '',
+      caution: '',
+      strengths: '',
+      clientId: 'catagent',
+      accountRef: 'codex-for-me',
+      defaultModel: 'gpt-5.5',
+      commandArgs: '',
+      cliConfigArgs: [],
+      nativeToolLevel: '',
+      commandPolicyPreset: '',
+      catAgentProtocol: 'openai-chat',
+      cliEffort: '',
+      provider: '',
+      sessionChain: 'true',
+      maxPromptTokens: '',
+      maxContextTokens: '',
+      maxMessages: '',
+      maxContentLengthPerMsg: '',
+      ...emptyVoiceFields,
+      ...emptyAcpFields,
+    };
+
+    // 1. catagent + catAgentProtocol set → emitted on payload
+    const createPayload = buildCatPayload(formCatAgentOpenAI, null) as Record<string, unknown>;
+    expect(createPayload.catAgentProtocol).toBe('openai-chat');
+
+    // 2. catagent + catAgentProtocol '' (backend default) → field omitted (no patch)
+    const defaultPayload = buildCatPayload(
+      { ...formCatAgentOpenAI, catAgentProtocol: '' },
+      null,
+    ) as Record<string, unknown>;
+    expect(Object.hasOwn(defaultPayload, 'catAgentProtocol')).toBe(false);
+
+    // 3. Switching away from catagent + existing cat had catAgentProtocol → null clears
+    const existingCatagent = {
+      id: 'runtime-catagent',
+      name: 'runtime-catagent',
+      displayName: '运行时原生猫',
+      clientId: 'catagent',
+      defaultModel: 'gpt-5.5',
+      color: { primary: '#16a34a', secondary: '#bbf7d0' },
+      mentionPatterns: ['@runtime-catagent'],
+      avatar: '/avatars/catagent.png',
+      roleDescription: '原生工具体验',
+      personality: '谨慎',
+      catAgentProtocol: 'openai-chat',
+    } as CatData;
+    const switchAwayPayload = buildCatPayload(
+      { ...formCatAgentOpenAI, clientId: 'openai', catAgentProtocol: '' },
+      existingCatagent,
+    ) as Record<string, unknown>;
+    expect(switchAwayPayload.catAgentProtocol).toBeNull();
   });
 
   it('splitCommandArgs preserves quoted segments', () => {

--- a/packages/web/src/components/hub-cat-editor-advanced.tsx
+++ b/packages/web/src/components/hub-cat-editor-advanced.tsx
@@ -10,6 +10,7 @@ import {
   type CodexRuntimeSettings,
   getCliEffortOptionsForClient,
   type HubCatEditorFormState,
+  CAT_AGENT_PROTOCOL_OPTIONS,
   NATIVE_TOOL_LEVEL_OPTIONS,
   SESSION_CHAIN_OPTIONS,
   SESSION_STRATEGY_OPTIONS,
@@ -185,6 +186,20 @@ export function AdvancedRuntimeSection({
                 当前成员已有自定义策略；此处只保留或切换到内置预设，不编辑自定义 JSON。
               </p>
             ) : null}
+            {/* F159 Phase G G2 (AC-G16): wire protocol selector for CatAgent. */}
+            <SelectField
+              label="协议 (CatAgent)"
+              value={form.catAgentProtocol}
+              options={CAT_AGENT_PROTOCOL_OPTIONS}
+              onChange={(value) =>
+                onChange({ catAgentProtocol: value as HubCatEditorFormState['catAgentProtocol'] })
+              }
+              tone="success"
+            />
+            <p className="text-label leading-4 text-cafe-muted">
+              选择 catagent 调用的 wire protocol。默认 Anthropic Messages，需要绑 Anthropic 兼容账号；
+              OpenAI Chat 走 `/v1/chat/completions`，需要绑 OpenAI 兼容账号——切换协议后请确认账号 family 匹配。
+            </p>
           </div>
         ) : null}
       </div>

--- a/packages/web/src/components/hub-cat-editor-advanced.tsx
+++ b/packages/web/src/components/hub-cat-editor-advanced.tsx
@@ -2,6 +2,7 @@
 
 import type { CatData } from '@/hooks/useCatData';
 import {
+  CAT_AGENT_PROTOCOL_OPTIONS,
   CATAGENT_COMMAND_POLICY_PRESET_OPTIONS,
   CATAGENT_CUSTOM_COMMAND_POLICY_PRESET_OPTION,
   CODEX_APPROVAL_OPTIONS,
@@ -10,7 +11,6 @@ import {
   type CodexRuntimeSettings,
   getCliEffortOptionsForClient,
   type HubCatEditorFormState,
-  CAT_AGENT_PROTOCOL_OPTIONS,
   NATIVE_TOOL_LEVEL_OPTIONS,
   SESSION_CHAIN_OPTIONS,
   SESSION_STRATEGY_OPTIONS,
@@ -191,14 +191,12 @@ export function AdvancedRuntimeSection({
               label="协议 (CatAgent)"
               value={form.catAgentProtocol}
               options={CAT_AGENT_PROTOCOL_OPTIONS}
-              onChange={(value) =>
-                onChange({ catAgentProtocol: value as HubCatEditorFormState['catAgentProtocol'] })
-              }
+              onChange={(value) => onChange({ catAgentProtocol: value as HubCatEditorFormState['catAgentProtocol'] })}
               tone="success"
             />
             <p className="text-label leading-4 text-cafe-muted">
-              选择 catagent 调用的 wire protocol。默认 Anthropic Messages，需要绑 Anthropic 兼容账号；
-              OpenAI Chat 走 `/v1/chat/completions`，需要绑 OpenAI 兼容账号——切换协议后请确认账号 family 匹配。
+              选择 catagent 调用的 wire protocol。默认 Anthropic Messages，需要绑 Anthropic 兼容账号； OpenAI Chat 走
+              `/v1/chat/completions`，需要绑 OpenAI 兼容账号——切换协议后请确认账号 family 匹配。
             </p>
           </div>
         ) : null}

--- a/packages/web/src/components/hub-cat-editor.model.ts
+++ b/packages/web/src/components/hub-cat-editor.model.ts
@@ -4,6 +4,7 @@ import {
   type CliEffortValue,
   type CommandPolicyEntry,
   getCliEffortOptionsForProvider,
+  type CatAgentProtocol,
   type NativeToolLevel,
   builtinAccountIdForClient as sharedBuiltinAccountIdForClient,
 } from '@cat-cafe/shared';
@@ -55,6 +56,10 @@ export interface HubCatEditorFormState {
   nativeToolLevel: NativeToolLevel | '';
   /** F159 Phase F: safe command policy preset for CatAgent L2. */
   commandPolicyPreset: CatAgentCommandPolicyPreset;
+  /** F159 Phase G G2 (AC-G16): CatAgent wire protocol selection.
+   *  '' = backend default ('anthropic-messages'); switching catagent → catagent
+   *  preserves whatever value was loaded. Cleared when clientId !== 'catagent'. */
+  catAgentProtocol: CatAgentProtocol | '';
   cliEffort: CliEffortValue | '';
   provider: string;
   acpEnabled: boolean;
@@ -130,6 +135,14 @@ export const NATIVE_TOOL_LEVEL_OPTIONS: Array<{ value: NativeToolLevel | ''; lab
   { value: '', label: 'L0 · 只读（默认）' },
   { value: 'L1', label: 'L1 · 读 + 写文件' },
   { value: 'L2', label: 'L2 · 读 + 写 + 执行命令' },
+];
+
+/** F159 Phase G G2 (AC-G16): CatAgent wire protocol options.
+ *  '' renders the backend default (Anthropic Messages, G1 catagent baseline). */
+export const CAT_AGENT_PROTOCOL_OPTIONS: Array<{ value: CatAgentProtocol | ''; label: string }> = [
+  { value: '', label: 'Anthropic Messages（默认）' },
+  { value: 'anthropic-messages', label: 'Anthropic Messages · /v1/messages + x-api-key' },
+  { value: 'openai-chat', label: 'OpenAI Chat · /v1/chat/completions + Bearer' },
 ];
 
 export const CATAGENT_GIT_READONLY_COMMAND_POLICY: readonly CommandPolicyEntry[] = [
@@ -448,6 +461,10 @@ export function initialState(cat?: CatData | null, draft?: HubCatEditorDraft | n
     cliConfigArgs: [...(cat?.cliConfigArgs ?? [])],
     nativeToolLevel: cat?.nativeToolLevel && cat.nativeToolLevel !== 'L0' ? cat.nativeToolLevel : '',
     commandPolicyPreset: detectCatAgentCommandPolicyPreset(cat?.commandPolicy),
+    // F159 Phase G G2 (AC-G16): preserve loaded value verbatim; '' means
+    // "use backend default" (Anthropic Messages). Hub UI dropdown surfaces
+    // the explicit option for visibility.
+    catAgentProtocol: cat?.catAgentProtocol ?? '',
     cliEffort: isCliEffortValue(persistedCliEffort) ? persistedCliEffort : '',
     provider: cat?.provider ?? '',
     acpEnabled:

--- a/packages/web/src/components/hub-cat-editor.model.ts
+++ b/packages/web/src/components/hub-cat-editor.model.ts
@@ -378,6 +378,12 @@ function isAllowedGoogleGatewayProfile(profile: ProfileItem): boolean {
   return hostname !== null && !isOfficialGoogleHostname(hostname);
 }
 
+// F159 Phase G G2 AC-G19 audit (see @cat-cafe/shared client-routing.ts audit
+// table): DEFERRED to Axis 6 cross-cutting UX polish. Hub UI account-picker
+// filter for catagent + 'openai-chat' should arguably show OpenAI accounts;
+// migration requires threading form.catAgentProtocol through filterAccounts.
+// Does NOT block G2 merge gate (credentials path still fails-closed at adapter
+// level via Axis 2 factory dispatch).
 function resolveBuiltinClientFamily(client: ClientId): BuiltinAccountClient | null {
   if (typeof builtinAccountFamilyForClient === 'function') {
     const family = builtinAccountFamilyForClient(client);

--- a/packages/web/src/components/hub-cat-editor.model.ts
+++ b/packages/web/src/components/hub-cat-editor.model.ts
@@ -1,10 +1,10 @@
 import {
   builtinAccountFamilyForClient,
+  type CatAgentProtocol,
   CLI_EFFORT_VALUES,
   type CliEffortValue,
   type CommandPolicyEntry,
   getCliEffortOptionsForProvider,
-  type CatAgentProtocol,
   type NativeToolLevel,
   builtinAccountIdForClient as sharedBuiltinAccountIdForClient,
 } from '@cat-cafe/shared';

--- a/packages/web/src/components/hub-cat-editor.payload.ts
+++ b/packages/web/src/components/hub-cat-editor.payload.ts
@@ -194,6 +194,15 @@ export function buildCatPayload(form: HubCatEditorFormState, cat?: CatData | nul
           ? { commandPolicy: null }
           : {}
         : {};
+  // F159 Phase G G2 (AC-G16): catAgentProtocol patch — only emit on catagent
+  // members; clear when switching away from catagent (mirrors nativeToolLevel
+  // pattern). '' on the form means "backend default", not "no value to send".
+  const catAgentProtocolPatch: Record<string, unknown> =
+    isCatAgent && form.catAgentProtocol
+      ? { catAgentProtocol: form.catAgentProtocol }
+      : cat?.catAgentProtocol
+        ? { catAgentProtocol: null }
+        : {};
   const common = {
     displayName,
     variantLabel: trimText(form.variantLabel),
@@ -241,6 +250,7 @@ export function buildCatPayload(form: HubCatEditorFormState, cat?: CatData | nul
     cliConfigArgs: (form.cliConfigArgs ?? []).filter((arg) => arg.trim().length > 0),
     ...nativeToolLevelPatch,
     ...commandPolicyPatch,
+    ...catAgentProtocolPatch,
     ...buildProviderPatch(form, cat),
   };
 }

--- a/packages/web/src/components/hub-cat-editor.sections.tsx
+++ b/packages/web/src/components/hub-cat-editor.sections.tsx
@@ -405,6 +405,12 @@ export function AccountSection({
               cliEffort: '',
               acpEnabled: nextAcpEnabled,
               ...(nextAcpEnabled ? acpDefaultsForClientSwitch(form, nextClient) : {}),
+              // F159 Phase G G2 (AC-G16, @gpt555 P2 UI State Drift fix):
+              // model注释 + AC-G16 都承诺 clientId !== 'catagent' 时清空
+              // catAgentProtocol。否则用户先选 'openai-chat'，切到非 catagent，
+              // 再切回 catagent 时旧协议会悄悄留在 form state 里，可能让
+              // payload 提交一个跟新账号 family 不匹配的协议选择。
+              ...(nextClient !== 'catagent' ? { catAgentProtocol: '' as const } : {}),
             });
           }}
           required

--- a/packages/web/src/hooks/useCatData.ts
+++ b/packages/web/src/hooks/useCatData.ts
@@ -5,7 +5,7 @@
  * Fetches once per session, caches module-level. All consumers share same data.
  */
 
-import type { CommandPolicyEntry } from '@cat-cafe/shared';
+import type { CatAgentProtocol, CommandPolicyEntry } from '@cat-cafe/shared';
 import { useEffect, useMemo, useState } from 'react';
 import { UNKNOWN_CAT_COLOR } from '@/lib/color-defaults';
 import { refreshMentionData } from '@/lib/mention-highlight';
@@ -37,6 +37,8 @@ export interface CatData {
   nativeToolLevel?: 'L0' | 'L1' | 'L2';
   /** F159 Phase F: CatAgent L2 command allowlist. */
   commandPolicy?: CommandPolicyEntry[];
+  /** F159 Phase G G2 (AC-G15): CatAgent wire protocol — surfaces from /api/cats GET. */
+  catAgentProtocol?: CatAgentProtocol;
   /** clowder-ai#340 P5: Model provider name (renamed from ocProviderName). */
   provider?: string;
   /** F161: ACP transport config. Presence means this member runs through ACP instead of legacy CLI. */


### PR DESCRIPTION
## Summary
- **Axis 1-2 (协议选择位 + factory dispatch)**: `CatConfig.catAgentProtocol?: 'anthropic-messages' | 'openai-chat'` 写入真相源；factory 基于显式字段 dispatch，未识别值 fail-closed throw（KD-20）
- **Axis 3 (shared routing contract)**: 新增 `effectiveProtocolForCat` / `effectiveClientFamilyForCat`（KD-24），保留 `protocolForClient` / `builtinAccountFamilyForClient` 作 client-level default 不变
- **Axis 4 (api_key clientFamily)**: `AccountConfig` 新增 typed `clientFamily?: 'anthropic'|'openai'|'google'|'kimi'|'dare'|'opencode'`；`accountToRuntimeProfile` 对 api_key 设 `profile.client` → 完整 family fail-closed
- **Axis 5 (OpenAIChatAdapter)**: 实现 `CatAgentProtocolAdapter` 全部 7 method + Bearer auth + POST /v1/chat/completions + SSE 解析 ([DONE] sentinel) + tool_calls lossless 映射 + `stream_options.include_usage:true`

修这个 dogfood 痛点（KD-23）：co-creator 在 develop 上跑 catagent + openai 模型撞 \`Anthropic API error (403): "This group does not allow /v1/messages dispatch"\`——根因是 develop 上的 factory 永远返回 `AnthropicMessagesAdapter`，强制 OpenAI-only 代理走 \`/v1/messages\`。本 PR 落地 G2 后，catagent 可显式选 `openai-chat` 协议走 \`/v1/chat/completions\` + Bearer。

## Merge Gate Status

| Gate | Status |
|---|---|
| AC-G13~G22 (Axes 1-4) | ✅ all marked done in spec |
| AC-G23 (OpenAIChatAdapter 7 methods) | ✅ implemented (`openai-chat-adapter.ts`, 346 lines) |
| AC-G24 (tool_calls lossless 映射) | ✅ golden test 跨 chunk 拼接验证 |
| AC-G25 (openai-chat-adapter-golden) | ✅ 22 suites byte-stable |
| AC-G26 (e2e 行为测试) | ✅ catagent-phase-e 末段二例 |
| AC-G27 (vendor-neutrality verifier 扩展) | ✅ \`Openai*\`/\`openai*\` 加入黑名单 |
| **AC-G28 part 1**: 跨 family code review | ✅ Ragdoll @opus 复审 Maine Coon @gpt52 实现（见 thread） |
| **AC-G28 part 2**: Hub UI 暹罗猫审美 review | ⚠️ codex 代审了 64/64 功能测试，**审美 review 未真正走 Siamese** — 由 co-creator 决定是否接受代审或等 Gemini |
| AC-G29 (G1 Anthropic broad suite 135 tests) | ✅ 135/135 unchanged |
| AC-G30 (G1 Anthropic golden 35 tests) | ✅ byte-stable |
| AC-G31 (factory 默认分支 verifier) | ✅ pass |
| **Total verified** | ✅ **194/194 (59 G2 new + 135 G1 broad regression)** |

## Test plan
- [x] \`pnpm run build\` 干净通过
- [x] G2 new tests: \`openai-chat-adapter-golden\` (22) + \`catagent-vendor-neutrality\` (1) + \`catagent-protocol-factory\` updated (4 incl OpenAI dispatch) + \`anthropic-messages-adapter-golden\` regression (35) — total 59 pass
- [x] G1 Anthropic broad suite: phase-b/d/e/f + provider + security-baseline + stream-parser — 135 pass
- [ ] Post-merge dogfood sanity: co-creator 在 Hub 把 littlecat 协议下拉切到 \`openai-chat\`，prompt 跑通验证 \`/v1/chat/completions\` 路径 200

## Outstanding
- AC-G28 part 2 (Siamese 审美 review) 是 spec letter 未严格 met 的唯一 gate；codex 已做功能 review。co-creator 在 merge 时决定是否接受代审。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: 缅因猫-GPT5.4 (Maine Coon, implementer of Axis 5)
Co-Authored-By: 布偶猫-Opus47 (Ragdoll, cross-family code reviewer)
Co-Authored-By: 缅因猫-Codex/GPT5.5 (Maine Coon, Hub UI functional review)