### PR TITLE
feat(F159 G2 follow-up): 幼仔(catagent) breed 模板 — 默认 openai-chat

### DIFF
--- a/cat-template.json
+++ b/cat-template.json
@@ -78,6 +78,19 @@
       "roleDescription": "开源多模型编码 agent，自带多专家编排 + LSP + 主题生态",
       "personality": "沉稳可靠，什么 provider 都能接，什么任务都能扛",
       "teamStrengths": "多专家内部编排、LSP 集成、开源生态、provider-agnostic"
+    },
+    {
+      "id": "kitten",
+      "name": "幼猫",
+      "nickname": "幼仔",
+      "avatar": "/avatars/catagent.png",
+      "color": {
+        "primary": "#9B7EBD",
+        "secondary": "#E8DFF5"
+      },
+      "roleDescription": "灵巧的轻装猫——短任务、快回合、不绕弯",
+      "personality": "直爽好奇守边界，任务越具体越高效；不确定先查真相源不硬猜",
+      "teamStrengths": "状态查询、日志定位、命令输出解读、文本提取、简短问答、简单脚本片段、lint & test smoke、多轮工具循环"
     }
   ],
   "clientDefaults": {
@@ -179,6 +192,13 @@
       "lead": false,
       "available": true,
       "evaluation": "claude-fable-5 新布偶猫，Opus x2 猫粮，能力画像待校准"
+    },
+    "catagent": {
+      "family": "kitten",
+      "roles": ["executor", "scout"],
+      "lead": true,
+      "available": true,
+      "evaluation": "灵巧轻装猫，跑 catagent+openai-chat 原生路径；短任务/日志定位/命令输出/工具循环最高效，不擅长长链推理"
     }
   },
   "reviewPolicy": {
@@ -909,6 +929,57 @@
             "temperature": 0.3
           },
           "accountRef": "claude"
+        }
+      ]
+    },
+    {
+      "id": "kitten",
+      "catId": "catagent",
+      "name": "幼猫",
+      "displayName": "幼猫",
+      "nickname": "幼仔",
+      "avatar": "/avatars/catagent.png",
+      "color": {
+        "primary": "#9B7EBD",
+        "secondary": "#E8DFF5"
+      },
+      "mentionPatterns": ["@catagent", "@littlecat", "@幼仔", "@幼", "@kitten"],
+      "roleDescription": "灵巧的轻装猫——短任务、快回合、不绕弯",
+      "teamStrengths": "状态查询 / 日志定位 / 命令输出解读 / 文本提取 / 简短问答 / 简单脚本片段 / lint & test smoke / 多轮工具循环",
+      "caution": null,
+      "defaultVariantId": "catagent-default",
+      "features": {
+        "sessionChain": true
+      },
+      "variants": [
+        {
+          "id": "catagent-default",
+          "clientId": "catagent",
+          "catAgentProtocol": "openai-chat",
+          "defaultModel": "gpt-5.5",
+          "mcpSupport": true,
+          "cli": {
+            "command": "catagent",
+            "outputFormat": "json"
+          },
+          "nativeToolLevel": "L1",
+          "personality": "直爽 + 好奇 + 守边界 + 谦虚。任务越具体越高效；不确定时先查真相源不硬猜；做不了直接退回，不假装懂",
+          "strengths": ["status-query", "log-grep", "command-output", "text-extraction", "short-answer", "tool-loop"],
+          "contextBudget": {
+            "maxPromptTokens": 120000,
+            "maxContextTokens": 100000,
+            "maxMessages": 120,
+            "maxContentLengthPerMsg": 50000
+          },
+          "voiceConfig": {
+            "voice": "zm_yunjian",
+            "langCode": "zh",
+            "speed": 1,
+            "refAudio": "honkai-starrail/帕姆/chapter0_7_pompom_104.wav",
+            "refText": "既然选择了上车，就得遵守这里的规矩。特殊的并不只你一个，这点你可给我记好了。",
+            "instruct": "用一个好奇直爽的小动物语气说话，简短利落",
+            "temperature": 0.3
+          }
         }
       ]
     }

--- a/packages/api/src/routes/cats.ts
+++ b/packages/api/src/routes/cats.ts
@@ -559,7 +559,11 @@ interface CatsRoutesOptions {
 }
 
 export const catsRoutes: FastifyPluginAsync<CatsRoutesOptions> = async (app, opts) => {
-  // GET /api/cat-templates - 获取角色模板（纯灵魂层，不含 client/model 绑定）
+  // GET /api/cat-templates - 获取角色模板（灵魂层 + 可选 runtimeDefaults）
+  // F159 G2 follow-up: 单纯"灵魂层"模板（F171 首次配置遗留）让 catagent 类猫选完
+  // 模板后 form 留默认 clientId=anthropic 创建出来根本不是 catagent。把
+  // breeds[].defaultVariant 的运行时身份字段作为可选 runtimeDefaults 一并返回，
+  // 让前端 handleTemplateSelect 把它们 patch 进 form，实现 "点模板=可用猫"。
   app.get('/api/cat-templates', async () => {
     try {
       const projectRoot = resolveProjectRoot();
@@ -575,26 +579,66 @@ export const catsRoutes: FastifyPluginAsync<CatsRoutesOptions> = async (app, opt
           personality: string;
           teamStrengths?: string;
         }[];
+        breeds?: {
+          id: string;
+          defaultVariantId: string;
+          variants?: {
+            id: string;
+            clientId?: string;
+            defaultModel?: string;
+            catAgentProtocol?: string;
+            nativeToolLevel?: string;
+          }[];
+        }[];
         clientDefaults?: Record<string, { defaultModel: string; models: string[] }>;
       };
+
+      // Build breed.id → runtimeDefaults map from default variant (sole source of "body" defaults).
+      // accountRef intentionally not carried — it's environment-specific (per-user account binding).
+      const runtimeDefaultsByBreedId = new Map<
+        string,
+        { clientId: string; defaultModel: string; catAgentProtocol?: string; nativeToolLevel?: string }
+      >();
+      for (const breed of raw.breeds ?? []) {
+        const variant = breed.variants?.find((v) => v.id === breed.defaultVariantId);
+        if (!variant?.clientId || !variant.defaultModel) continue;
+        runtimeDefaultsByBreedId.set(breed.id, {
+          clientId: variant.clientId,
+          defaultModel: variant.defaultModel,
+          ...(variant.catAgentProtocol ? { catAgentProtocol: variant.catAgentProtocol } : {}),
+          ...(variant.nativeToolLevel ? { nativeToolLevel: variant.nativeToolLevel } : {}),
+        });
+      }
+
       if (raw.roleTemplates && raw.roleTemplates.length > 0) {
-        return { templates: raw.roleTemplates, clientDefaults: raw.clientDefaults ?? {} };
+        return {
+          templates: raw.roleTemplates.map((t) => ({
+            ...t,
+            ...(runtimeDefaultsByBreedId.has(t.id) ? { runtimeDefaults: runtimeDefaultsByBreedId.get(t.id) } : {}),
+          })),
+          clientDefaults: raw.clientDefaults ?? {},
+        };
       }
       // Fallback: extract from breeds (legacy)
       const templateConfig = loadCatConfig(templatePath);
       const allCats = Object.values(toAllCatConfigs(templateConfig));
       const templateCats = allCats.filter((c) => c.isDefaultVariant);
       return {
-        templates: templateCats.map((cat) => ({
-          id: cat.breedId ?? cat.id,
-          name: cat.breedDisplayName ?? cat.displayName ?? cat.name,
-          nickname: cat.nickname,
-          avatar: cat.avatar,
-          color: cat.color,
-          roleDescription: cat.roleDescription,
-          personality: cat.personality,
-          teamStrengths: cat.teamStrengths,
-        })),
+        templates: templateCats.map((cat) => {
+          const breedId = cat.breedId ?? cat.id;
+          const runtimeDefaults = runtimeDefaultsByBreedId.get(breedId);
+          return {
+            id: breedId,
+            name: cat.breedDisplayName ?? cat.displayName ?? cat.name,
+            nickname: cat.nickname,
+            avatar: cat.avatar,
+            color: cat.color,
+            roleDescription: cat.roleDescription,
+            personality: cat.personality,
+            teamStrengths: cat.teamStrengths,
+            ...(runtimeDefaults ? { runtimeDefaults } : {}),
+          };
+        }),
         clientDefaults: {},
       };
     } catch (err) {

--- a/packages/api/test/cats-routes-runtime-crud.test.js
+++ b/packages/api/test/cats-routes-runtime-crud.test.js
@@ -3173,4 +3173,44 @@ describe('cats routes runtime CRUD', { concurrency: false }, () => {
     const listed = JSON.parse(listRes.body).cats.find((cat) => cat.id === 'migrate-oc-to-acp');
     assert.equal(listed.provider, undefined, 'GET should confirm no stale provider remains after migration');
   });
+
+  // F159 G2 follow-up: AC for runtimeDefaults extension of /api/cat-templates.
+  // Without this, picking a catagent template leaves form.clientId='anthropic' and
+  // catAgentProtocol='' → created member silently falls back to anthropic-messages → /v1/messages 403.
+  it('GET /api/cat-templates exposes breed defaultVariant runtimeDefaults (kitten → catagent + openai-chat)', async () => {
+    createProjectRootFromRepoTemplate();
+
+    const Fastify = (await import('fastify')).default;
+    const { catsRoutes } = await import('../dist/routes/cats.js');
+    const app = Fastify();
+    await app.register(catsRoutes);
+
+    const res = await app.inject({ method: 'GET', url: '/api/cat-templates' });
+    assert.equal(res.statusCode, 200);
+    const { templates } = JSON.parse(res.body);
+    assert.ok(Array.isArray(templates) && templates.length > 0, 'templates non-empty');
+
+    const kitten = templates.find((t) => t.id === 'kitten');
+    assert.ok(kitten, 'kitten template present in /api/cat-templates response');
+    assert.deepEqual(kitten.runtimeDefaults, {
+      clientId: 'catagent',
+      defaultModel: 'gpt-5.5',
+      catAgentProtocol: 'openai-chat',
+      nativeToolLevel: 'L1',
+    });
+
+    // ragdoll family: regular anthropic-style template, no catAgentProtocol field surfaces.
+    const ragdoll = templates.find((t) => t.id === 'ragdoll');
+    assert.ok(ragdoll, 'ragdoll template present');
+    assert.equal(ragdoll.runtimeDefaults?.clientId, 'anthropic');
+    assert.equal(ragdoll.runtimeDefaults?.defaultModel, 'claude-opus-4-6');
+    assert.equal(ragdoll.runtimeDefaults?.catAgentProtocol, undefined);
+    assert.equal(ragdoll.runtimeDefaults?.nativeToolLevel, undefined);
+
+    // maine-coon family: openai client, no catAgentProtocol (it's not a catagent member).
+    const maineCoon = templates.find((t) => t.id === 'maine-coon');
+    assert.ok(maineCoon, 'maine-coon template present');
+    assert.equal(maineCoon.runtimeDefaults?.clientId, 'openai');
+    assert.equal(maineCoon.runtimeDefaults?.catAgentProtocol, undefined);
+  });
 });

--- a/packages/api/test/system-prompt-builder.test.js
+++ b/packages/api/test/system-prompt-builder.test.js
@@ -12,7 +12,7 @@ import { catRegistry } from '@cat-cafe/shared';
 
 const REPO_ROOT_TEMPLATE = resolve(dirname(fileURLToPath(import.meta.url)), '../../..', 'cat-template.json');
 const CAT_TEMPLATE_PATH = REPO_ROOT_TEMPLATE;
-const FULL_RUNTIME_PROMPT_CHAR_BUDGET = 6700; // 6500→6700: gemini35 standalone breed adds ~78 chars to roster
+const FULL_RUNTIME_PROMPT_CHAR_BUDGET = 6900; // 6700→6900: kitten/catagent breed adds ~94 chars to roster (F159 G2 follow-up)
 
 function assertWithinFullRuntimePromptBudget(prompt) {
   assert.ok(
@@ -1713,8 +1713,8 @@ describe('SystemPromptBuilder', () => {
         featureId: 'F073',
       },
     });
-    // 6200→6500→6700: decision funnel §17 + gemini35 standalone breed roster growth
-    assert.ok(prompt.length < 6700, `Prompt with SOP hint is ${prompt.length} chars, expected < 6700`);
+    // 6200→6500→6700→6900: decision funnel §17 + gemini35 standalone breed + kitten/catagent breed roster growth
+    assert.ok(prompt.length < 6900, `Prompt with SOP hint is ${prompt.length} chars, expected < 6900`);
   });
 
   // --- F092: Voice Mode prompt injection ---
@@ -1761,8 +1761,8 @@ describe('SystemPromptBuilder', () => {
       },
       voiceMode: true,
     });
-    // 6200→6500→6700: decision funnel §17 + gemini35 standalone breed roster growth
-    assert.ok(prompt.length < 6700, `Prompt with voice mode + SOP hint is ${prompt.length} chars, expected < 6700`);
+    // 6200→6500→6700→6900: decision funnel §17 + gemini35 standalone breed + kitten/catagent breed roster growth
+    assert.ok(prompt.length < 6900, `Prompt with voice mode + SOP hint is ${prompt.length} chars, expected < 6900`);
   });
 
   test('buildInvocationContext injects bootcamp mode when bootcampState provided', async () => {

--- a/packages/web/src/components/FirstRunQuestWizard.tsx
+++ b/packages/web/src/components/FirstRunQuestWizard.tsx
@@ -29,6 +29,27 @@ function effectiveAccountFamily(template: TemplateCard | null, fallbackClientId:
   return tplDefaults.clientId;
 }
 
+/**
+ * F159 G2 follow-up: ConfigStep also passes `client` (CLI binary name like 'claude'/'codex')
+ * to connectivity-test, which uses it to pick the actual CLI probe at runtime
+ * (first-run-quest.ts:~396). If `client` and `clientId` come from different families,
+ * the probe runs the wrong CLI binary against the right account → testResult.ok fails →
+ * create button disabled → legitimate kitten path blocked. Sync `client` to the same
+ * effective family as `clientId`.
+ */
+function effectiveClientName(template: TemplateCard | null, fallbackClient: string): string {
+  const family = effectiveAccountFamily(template, '');
+  if (!family) return fallbackClient;
+  const familyToCli: Record<string, string> = {
+    anthropic: 'claude',
+    openai: 'codex',
+    google: 'gemini',
+    kimi: 'kimi',
+    opencode: 'opencode',
+  };
+  return familyToCli[family] ?? fallbackClient;
+}
+
 interface FirstRunQuestWizardProps {
   open: boolean;
   onClose: () => void;
@@ -232,7 +253,7 @@ export function FirstRunQuestWizard({ open, onClose, onCreated }: FirstRunQuestW
           {step === 'client' && <ClientStep onSelect={handleClientSelect} />}
           {step === 'config' && selectedClient && (
             <ConfigStep
-              client={selectedClient.client}
+              client={effectiveClientName(selectedTemplate, selectedClient.client)}
               clientId={effectiveAccountFamily(selectedTemplate, selectedClient.provider)}
               onComplete={handleConfigComplete}
             />

--- a/packages/web/src/components/FirstRunQuestWizard.tsx
+++ b/packages/web/src/components/FirstRunQuestWizard.tsx
@@ -85,6 +85,13 @@ export function FirstRunQuestWizard({ open, onClose, onCreated }: FirstRunQuestW
           const catId = `${selectedTemplate.id}-${suffix}`;
           const catName = selectedTemplate.nickname ?? selectedTemplate.name;
 
+          // F159 G2 follow-up: template runtimeDefaults > user's selectedClient pick.
+          // The template is the source of truth for "what kind of cat this is" — selectedClient
+          // only fills in user environment (which actual CLI binary they have installed). For
+          // catagent native-path templates (kitten), runtimeDefaults carries clientId='catagent'
+          // + catAgentProtocol='openai-chat' + nativeToolLevel; without this override the wizard
+          // creates a普通 anthropic/openai 成员 instead of the catagent that was selected.
+          const tplDefaults = selectedTemplate.runtimeDefaults;
           const createRes = await apiFetch('/api/cats', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -102,8 +109,12 @@ export function FirstRunQuestWizard({ open, onClose, onCreated }: FirstRunQuestW
               roleDescription: selectedTemplate.roleDescription,
               personality: selectedTemplate.personality,
               teamStrengths: selectedTemplate.teamStrengths,
-              clientId: selectedClient.provider,
+              clientId: tplDefaults?.clientId ?? selectedClient.provider,
+              ...(tplDefaults?.catAgentProtocol ? { catAgentProtocol: tplDefaults.catAgentProtocol } : {}),
+              ...(tplDefaults?.nativeToolLevel ? { nativeToolLevel: tplDefaults.nativeToolLevel } : {}),
               accountRef: config.accountRef,
+              // model 尊重 user 在 ConfigStep 的选择（用户基于实际 selectedClient.models 列表挑的）；
+              // template.runtimeDefaults.defaultModel 只是 suggestion，不强制 override。
               defaultModel: config.model,
             }),
           });

--- a/packages/web/src/components/FirstRunQuestWizard.tsx
+++ b/packages/web/src/components/FirstRunQuestWizard.tsx
@@ -10,6 +10,25 @@ import { type TemplateCard, TemplateStep } from './first-run-quest/TemplateStep'
 
 type WizardStep = 'template' | 'client' | 'config' | 'creating' | 'done';
 
+/**
+ * F159 G2 follow-up: ConfigStep filters accounts/models by `clientId` (account family).
+ * For catagent-native templates the wire-protocol determines the *account family* the
+ * runtime adapter expects — anthropic-messages → 'anthropic'; openai-chat → 'openai'.
+ * Passing `selectedClient.provider` (the CLI binary the user has installed, e.g. 'anthropic'
+ * for Claude CLI) would let the user bind a Claude account to a `catagent + openai-chat`
+ * cat → at invoke time `OpenAIChatAdapter.clientFamily='openai'` fail-closes via
+ * `catagent-credentials.ts` family guard (created but uncallable cat). Derive the
+ * effective account family from the template's runtimeDefaults instead.
+ */
+function effectiveAccountFamily(template: TemplateCard | null, fallbackClientId: string): string {
+  const tplDefaults = template?.runtimeDefaults;
+  if (!tplDefaults) return fallbackClientId;
+  if (tplDefaults.clientId === 'catagent') {
+    return tplDefaults.catAgentProtocol === 'openai-chat' ? 'openai' : 'anthropic';
+  }
+  return tplDefaults.clientId;
+}
+
 interface FirstRunQuestWizardProps {
   open: boolean;
   onClose: () => void;
@@ -214,7 +233,7 @@ export function FirstRunQuestWizard({ open, onClose, onCreated }: FirstRunQuestW
           {step === 'config' && selectedClient && (
             <ConfigStep
               client={selectedClient.client}
-              clientId={selectedClient.provider}
+              clientId={effectiveAccountFamily(selectedTemplate, selectedClient.provider)}
               onComplete={handleConfigComplete}
             />
           )}

--- a/packages/web/src/components/HubCatEditor.tsx
+++ b/packages/web/src/components/HubCatEditor.tsx
@@ -337,6 +337,20 @@ export function HubCatEditor({ cat, draft, existingCats, open, onClose, onSaved 
       teamStrengths: t.teamStrengths ?? '',
       catId,
       mentionPatterns: joinTags(deduped),
+      // F159 G2 follow-up: apply runtime身份 defaults if the template carries them.
+      // Without this, picking 幼仔 leaves clientId='anthropic' + 空 catAgentProtocol → 创建出来不是 catagent。
+      ...(t.runtimeDefaults
+        ? {
+            clientId: t.runtimeDefaults.clientId,
+            defaultModel: t.runtimeDefaults.defaultModel,
+            ...(t.runtimeDefaults.catAgentProtocol
+              ? { catAgentProtocol: t.runtimeDefaults.catAgentProtocol }
+              : {}),
+            ...(t.runtimeDefaults.nativeToolLevel
+              ? { nativeToolLevel: t.runtimeDefaults.nativeToolLevel }
+              : {}),
+          }
+        : {}),
     });
   };
 

--- a/packages/web/src/components/__tests__/first-run-quest-wizard.test.tsx
+++ b/packages/web/src/components/__tests__/first-run-quest-wizard.test.tsx
@@ -275,17 +275,20 @@ describe('FirstRunQuestWizard', () => {
           ],
         });
       }
-      // user still picks an installed CLI client (e.g. anthropic) — template runtimeDefaults must override.
+      // user picks an installed CLI client. We mock both anthropic and openai available;
+      // the test exercises picking codex/openai (matches template runtimeDefaults family).
+      // Picking anthropic CLI here would be a degenerate case — ConfigStep would filter to
+      // openai accounts (effective family from template) regardless of selectedClient.provider.
       if (url.includes('/api/first-run/available-clients')) {
         return jsonResponse({
           clients: [
             {
-              client: 'claude',
-              provider: 'anthropic',
-              label: 'Claude',
-              cli: 'claude',
+              client: 'codex',
+              provider: 'openai',
+              label: 'Codex',
+              cli: 'codex',
               installed: true,
-              hasApiKey: false,
+              hasApiKey: true,
             },
           ],
         });
@@ -294,12 +297,14 @@ describe('FirstRunQuestWizard', () => {
         return jsonResponse({
           providers: [
             {
-              id: 'claude',
-              displayName: 'Claude (OAuth)',
-              name: 'Claude (OAuth)',
+              id: 'codex',
+              provider: 'codex',
+              displayName: 'OpenAI (Codex)',
+              name: 'OpenAI (Codex)',
               authType: 'oauth',
               mode: 'subscription',
-              models: ['claude-opus-4-6'],
+              clientId: 'openai',
+              models: ['gpt-5.5'],
               hasApiKey: false,
               createdAt: '2026-01-01',
               updatedAt: '2026-01-01',
@@ -338,8 +343,8 @@ describe('FirstRunQuestWizard', () => {
     });
     await flushEffects();
 
-    // Step 2: select client (user picks Claude, but template should override)
-    const clientButton = Array.from(document.querySelectorAll('button')).find((b) => b.textContent?.includes('Claude'));
+    // Step 2: select client (user picks Codex/OpenAI — matches template's openai-chat family).
+    const clientButton = Array.from(document.querySelectorAll('button')).find((b) => b.textContent?.includes('Codex'));
     expect(clientButton).toBeTruthy();
     await act(async () => {
       clientButton!.click();
@@ -365,10 +370,13 @@ describe('FirstRunQuestWizard', () => {
       await flushEffects();
     }
 
-    // Assert: template runtimeDefaults overrode user's anthropic pick.
+    // Assert: template runtimeDefaults override.
     expect(catsPayload).not.toBeNull();
     expect(catsPayload!.clientId).toBe('catagent');
     expect(catsPayload!.catAgentProtocol).toBe('openai-chat');
     expect(catsPayload!.nativeToolLevel).toBe('L1');
+    // Family consistency: accountRef is from openai-family ConfigStep, not anthropic.
+    // OpenAIChatAdapter.clientFamily='openai' will match account.clientFamily='openai' at invoke time.
+    expect(catsPayload!.accountRef).toBe('codex');
   });
 });

--- a/packages/web/src/components/__tests__/first-run-quest-wizard.test.tsx
+++ b/packages/web/src/components/__tests__/first-run-quest-wizard.test.tsx
@@ -245,4 +245,130 @@ describe('FirstRunQuestWizard', () => {
     expect(catsPayload!.clientId).toBe('anthropic');
     expect(catsPayload!.client).toBeUndefined();
   });
+
+  // F159 G2 follow-up: kitten/catagent template must POST with clientId=catagent
+  // + catAgentProtocol=openai-chat + nativeToolLevel=L1 from template.runtimeDefaults,
+  // overriding whichever client the user picked in step 2. Without this, picking 幼仔
+  // in first-run still creates a 普通 anthropic/openai 成员 → /v1/messages 403.
+  it('catagent template runtimeDefaults override selectedClient in POST payload', async () => {
+    let catsPayload: Record<string, unknown> | null = null;
+
+    mockApiFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.includes('/api/cat-templates')) {
+        return jsonResponse({
+          templates: [
+            {
+              id: 'kitten',
+              name: '幼猫',
+              nickname: '幼仔',
+              avatar: '/avatars/catagent.png',
+              color: { primary: '#9B7EBD', secondary: '#E8DFF5' },
+              roleDescription: '灵巧的轻装猫',
+              personality: '直爽好奇',
+              runtimeDefaults: {
+                clientId: 'catagent',
+                defaultModel: 'gpt-5.5',
+                catAgentProtocol: 'openai-chat',
+                nativeToolLevel: 'L1',
+              },
+            },
+          ],
+        });
+      }
+      // user still picks an installed CLI client (e.g. anthropic) — template runtimeDefaults must override.
+      if (url.includes('/api/first-run/available-clients')) {
+        return jsonResponse({
+          clients: [
+            {
+              client: 'claude',
+              provider: 'anthropic',
+              label: 'Claude',
+              cli: 'claude',
+              installed: true,
+              hasApiKey: false,
+            },
+          ],
+        });
+      }
+      if (url.includes('/api/accounts')) {
+        return jsonResponse({
+          providers: [
+            {
+              id: 'claude',
+              displayName: 'Claude (OAuth)',
+              name: 'Claude (OAuth)',
+              authType: 'oauth',
+              mode: 'subscription',
+              models: ['claude-opus-4-6'],
+              hasApiKey: false,
+              createdAt: '2026-01-01',
+              updatedAt: '2026-01-01',
+            },
+          ],
+        });
+      }
+      if (url.includes('/api/first-run/connectivity-test')) {
+        return jsonResponse({ ok: true, message: '连接成功' });
+      }
+      if (url === '/api/cats' && init?.method === 'POST') {
+        catsPayload = JSON.parse(String(init.body)) as Record<string, unknown>;
+        return jsonResponse({ cat: { id: 'kitten-abcd', displayName: '幼猫' } });
+      }
+      if (url === '/api/threads' && init?.method === 'POST') {
+        return jsonResponse({ id: 'thread-test-kitten' });
+      }
+      if (url === '/api/threads') {
+        return jsonResponse({ threads: [] });
+      }
+      return jsonResponse({});
+    });
+
+    await act(async () => {
+      root.render(<WizardHost />);
+    });
+    await flushEffects();
+
+    // Step 1: select 幼仔 template
+    const templateButton = Array.from(document.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('幼猫'),
+    );
+    expect(templateButton).toBeTruthy();
+    await act(async () => {
+      templateButton!.click();
+    });
+    await flushEffects();
+
+    // Step 2: select client (user picks Claude, but template should override)
+    const clientButton = Array.from(document.querySelectorAll('button')).find((b) => b.textContent?.includes('Claude'));
+    expect(clientButton).toBeTruthy();
+    await act(async () => {
+      clientButton!.click();
+    });
+    await flushEffects();
+
+    // Step 3: connectivity test + create
+    const testButton = Array.from(document.querySelectorAll('button')).find((b) => b.textContent?.includes('测试连接'));
+    if (testButton) {
+      await act(async () => {
+        testButton.click();
+      });
+      await flushEffects();
+    }
+
+    const createButton = Array.from(document.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('创建猫猫'),
+    );
+    if (createButton && !createButton.disabled) {
+      await act(async () => {
+        createButton.click();
+      });
+      await flushEffects();
+    }
+
+    // Assert: template runtimeDefaults overrode user's anthropic pick.
+    expect(catsPayload).not.toBeNull();
+    expect(catsPayload!.clientId).toBe('catagent');
+    expect(catsPayload!.catAgentProtocol).toBe('openai-chat');
+    expect(catsPayload!.nativeToolLevel).toBe('L1');
+  });
 });

--- a/packages/web/src/components/__tests__/first-run-quest-wizard.test.tsx
+++ b/packages/web/src/components/__tests__/first-run-quest-wizard.test.tsx
@@ -252,6 +252,7 @@ describe('FirstRunQuestWizard', () => {
   // in first-run still creates a 普通 anthropic/openai 成员 → /v1/messages 403.
   it('catagent template runtimeDefaults override selectedClient in POST payload', async () => {
     let catsPayload: Record<string, unknown> | null = null;
+    let connectivityPayload: Record<string, unknown> | null = null;
 
     mockApiFetch.mockImplementation(async (url: string, init?: RequestInit) => {
       if (url.includes('/api/cat-templates')) {
@@ -275,20 +276,20 @@ describe('FirstRunQuestWizard', () => {
           ],
         });
       }
-      // user picks an installed CLI client. We mock both anthropic and openai available;
-      // the test exercises picking codex/openai (matches template runtimeDefaults family).
-      // Picking anthropic CLI here would be a degenerate case — ConfigStep would filter to
-      // openai accounts (effective family from template) regardless of selectedClient.provider.
+      // user picks an installed CLI client — for this test we want the *degenerate* case:
+      // user has only Claude CLI installed but picked kitten/openai-chat template. The
+      // FirstRunQuestWizard must override BOTH clientId (account family) AND client (CLI
+      // probe binary) so connectivity-test runs the right CLI against the right account.
       if (url.includes('/api/first-run/available-clients')) {
         return jsonResponse({
           clients: [
             {
-              client: 'codex',
-              provider: 'openai',
-              label: 'Codex',
-              cli: 'codex',
+              client: 'claude',
+              provider: 'anthropic',
+              label: 'Claude',
+              cli: 'claude',
               installed: true,
-              hasApiKey: true,
+              hasApiKey: false,
             },
           ],
         });
@@ -313,6 +314,7 @@ describe('FirstRunQuestWizard', () => {
         });
       }
       if (url.includes('/api/first-run/connectivity-test')) {
+        connectivityPayload = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>;
         return jsonResponse({ ok: true, message: '连接成功' });
       }
       if (url === '/api/cats' && init?.method === 'POST') {
@@ -343,8 +345,9 @@ describe('FirstRunQuestWizard', () => {
     });
     await flushEffects();
 
-    // Step 2: select client (user picks Codex/OpenAI — matches template's openai-chat family).
-    const clientButton = Array.from(document.querySelectorAll('button')).find((b) => b.textContent?.includes('Codex'));
+    // Step 2: select client. User picks Claude (the only CLI installed) — but the wizard
+    // must remap to codex/openai because the template is kitten/openai-chat.
+    const clientButton = Array.from(document.querySelectorAll('button')).find((b) => b.textContent?.includes('Claude'));
     expect(clientButton).toBeTruthy();
     await act(async () => {
       clientButton!.click();
@@ -375,8 +378,16 @@ describe('FirstRunQuestWizard', () => {
     expect(catsPayload!.clientId).toBe('catagent');
     expect(catsPayload!.catAgentProtocol).toBe('openai-chat');
     expect(catsPayload!.nativeToolLevel).toBe('L1');
-    // Family consistency: accountRef is from openai-family ConfigStep, not anthropic.
+    // Family consistency: accountRef from openai-family ConfigStep filter.
     // OpenAIChatAdapter.clientFamily='openai' will match account.clientFamily='openai' at invoke time.
     expect(catsPayload!.accountRef).toBe('codex');
+    // connectivity-test must use the codex CLI probe (template's effective family),
+    // NOT the claude probe that user picked in ClientStep. Without this, probe runs
+    // wrong CLI binary against right account → testResult.ok fails → create blocked.
+    expect(connectivityPayload).not.toBeNull();
+    expect(connectivityPayload!.client).toBe('codex');
+    // clientId comes from selectedProfile.provider (account-binding), which is 'codex'
+    // for the OAuth builtin; what matters is it's openai-family (not 'claude'/'anthropic').
+    expect(connectivityPayload!.clientId).toBe('codex');
   });
 });

--- a/packages/web/src/components/first-run-quest/TemplateStep.tsx
+++ b/packages/web/src/components/first-run-quest/TemplateStep.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import type { CatAgentProtocol, NativeToolLevel } from '@cat-cafe/shared';
 import { apiFetch } from '@/utils/api-client';
+import type { ClientId } from '../hub-cat-editor.model';
 
 export interface TemplateCard {
   id: string;
@@ -12,6 +14,17 @@ export interface TemplateCard {
   roleDescription: string;
   personality: string;
   teamStrengths?: string;
+  /**
+   * F159 G2 follow-up: runtime身份字段（clientId / model / catAgentProtocol / nativeToolLevel），
+   * 由 /api/cat-templates 从 breeds[].defaultVariant 提取。HubCatEditor.handleTemplateSelect
+   * 会把这些 patch 进 form，让"点模板=可用猫"。accountRef 不在此——它是 user environment-specific。
+   */
+  runtimeDefaults?: {
+    clientId: ClientId;
+    defaultModel: string;
+    catAgentProtocol?: CatAgentProtocol;
+    nativeToolLevel?: NativeToolLevel;
+  };
 }
 
 interface TemplateStepProps {


### PR DESCRIPTION
## Summary
F159 G2 (PR #27) 已 ship OpenAIChatAdapter，但 `cat-template.json` 里没有 catagent breed entry——新建 catagent 猫只能靠 runtime overlay 手动配，且 variant 默认缺 `catAgentProtocol` 字段，落到 anthropic-messages 默认路径 → dogfood 撞 \`Anthropic API error (403): /v1/messages dispatch\`（KD-23 痛点没真正闭环）。

把幼仔做成 breed 模板，让新建走 G2 openai-chat 路径默认正确。

## Why now
co-creator 今天在 thread 里发现：
1. 现有 runtime overlay 里的 catagent variant **缺 `catAgentProtocol` 字段** → 即便 G2 代码已 active 也走默认 anthropic-messages → /v1/messages 403
2. catagent 自我介绍 schema-driven（直接读 cat-breed.ts dump 字段），是因为 persona 是个空壳（roster 仅 "轻量级任务执行者"一行）

模板把两个都补了：默认协议正确 + persona 立体。

## Changes
- **`cat-template.json`**:
  - `roleTemplates` 新增 `kitten` 家族条目
  - `roster` 新增 `catagent` 条目（family=kitten, lead=true, available=true）
  - `breeds` 新增 `kitten` breed + `catagent-default` variant
    - \`clientId: 'catagent'\`
    - **\`catAgentProtocol: 'openai-chat'\`** ← 默认走 G2 路径，修 KD-23 闭环
    - \`nativeToolLevel: 'L1'\`（轻量起步）
    - mentionPatterns: \`@catagent / @littlecat / @幼仔 / @幼 / @kitten\`
    - personality / strengths / teamStrengths 来自父母版 review 汇总（@opus + @codex 独立给出后融合，见 thread）
    - \`caution: null\`（co-creator 明示去掉"注意事项"字段）
- **`packages/api/test/system-prompt-builder.test.js`**:
  - \`FULL_RUNTIME_PROMPT_CHAR_BUDGET\`: 6700 → 6900（新 breed 加 ~94 chars 到 roster，常规 budget 调整，跟 gemini35 加入时同模式）

## Test plan
- [x] system-prompt-builder + cat-catalog-store + cats-routes-runtime-crud: **193/193**
- [x] G2 + G1 broad regression（factory + vendor-neutrality + openai-chat-golden + anthropic-golden + phase-e）: **70/70**
- [x] 合计 **263/263** 全过
- [x] JSON syntax valid (\`python3 -m json.tool\`)
- [x] \`pnpm build\` 干净通过
- [ ] Post-merge dogfood 验证：co-creator 重启 develop runtime，新建一只 catagent 猫 → 检查 \`catAgentProtocol\` 默认 \`openai-chat\` → 发 prompt → 应直接 200，不再 403

## Known follow-ups
- 🎨 \`avatar: /avatars/catagent.png\` 文件未创建——runtime 会 fallback default.png（非阻塞，待 Siamese 出图）
- ⚙️ L1 vs L2 选择：模板默认 L1（保守），runtime overlay 当前是 L2 + 完整 commandPolicy；overlay 优先，老配置不变；新建走 L1
- 📝 LL backlog：catagent persona enrichment 方法论 + 导航指令场景化（应该让元任务/闲聊不强制注入"真相源 + 下一步"）

🤖 Generated with [Claude Code](https://claude.com/claude-code)