### PR TITLE
fix: suppress stale PR tracking instructions

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -66,7 +66,6 @@ created: 2026-02-26
 | F203 | Native System Prompt L0 — 压缩免疫核心规则注入 | in-progress | Ragdoll Opus 4.7 | internal | [F203](features/F203-native-system-prompt-l0.md) |
 | F204 | Weixin MP Publisher Plugin — 微信公众号文章发布插件 | review | community @mindfn + maintainers | community [#688](https://github.com/zts212653/clowder-ai/pull/688) | [F204](features/F204-weixin-mp-publisher-plugin.md) |
 | F205 | MediaHub Video Provider Plugins — 视频生成/分析插件 | spec | community @mindfn + maintainers | community [#689](https://github.com/zts212653/clowder-ai/pull/689) | [F205](features/F205-video-provider-plugins.md) |
-| F207 | AI Family Office — 个人投资学习基建（画像/知识/数据/分析/决策五层） | spec | Ragdoll | internal | [F207](features/F207-personal-finance-infra.md) |
 | F208 | Capability Profile Routing — 能力画像档案 + 认知路由 | spec | Ragdoll | internal | [F208](features/F208-capability-profile-routing.md) |
 | F193 | Cross-Thread Communication Unification (Phase E: 发现即投递) | in-progress | Ragdoll (Opus 4.6) | internal | [F193](features/F193-cross-thread-comm-unification.md) |
 | F210 | Gemini CLI to Antigravity CLI Migration | in-progress | Maine Coon/Maine Coon | internal | [F210](features/F210-antigravity-cli-migration.md) |

--- a/packages/api/src/infrastructure/email/CiCdRouter.ts
+++ b/packages/api/src/infrastructure/email/CiCdRouter.ts
@@ -161,12 +161,16 @@ export class CiCdRouter {
       threadId: string;
       ownerCatId: string | null;
       userId?: string;
-      automationState?: { trackingInstructions?: string };
+      automationState?: { trackingInstructions?: string; trackingInstructionsHeadSha?: string };
     },
     fingerprint: string,
   ): Promise<CiRouteResult> {
     const { taskStore, log } = this.opts;
-    const content = buildCiMessageContent(poll, task.automationState?.trackingInstructions);
+    const content = buildCiMessageContent(
+      poll,
+      task.automationState?.trackingInstructions,
+      task.automationState?.trackingInstructionsHeadSha,
+    );
 
     const source: ConnectorSource = {
       connector: 'github-ci',
@@ -208,7 +212,11 @@ export class CiCdRouter {
   }
 }
 
-export function buildCiMessageContent(poll: CiPollResult, trackingInstructions?: string): string {
+export function buildCiMessageContent(
+  poll: CiPollResult,
+  trackingInstructions?: string,
+  trackingInstructionsHeadSha?: string,
+): string {
   const bucketEmoji = poll.aggregateBucket === 'pass' ? '✅' : '❌';
   const bucketLabel = poll.aggregateBucket === 'pass' ? 'CI 通过' : 'CI 失败';
 
@@ -234,9 +242,20 @@ export function buildCiMessageContent(poll: CiPollResult, trackingInstructions?:
   }
 
   // F202 Phase 2C (AC-C2): append user-provided tracking instructions
-  if (trackingInstructions) {
+  if (shouldAppendTrackingInstructions(trackingInstructions, poll.headSha, trackingInstructionsHeadSha)) {
     lines.push('', '📌 **Tracking Instructions**', trackingInstructions);
   }
 
   return lines.join('\n');
+}
+
+function shouldAppendTrackingInstructions(
+  trackingInstructions: string | undefined,
+  currentHeadSha: string | undefined,
+  instructionsHeadSha: string | undefined,
+): trackingInstructions is string {
+  if (!trackingInstructions) return false;
+  if (!instructionsHeadSha) return true;
+  if (!currentHeadSha) return true;
+  return instructionsHeadSha === currentHeadSha;
 }

--- a/packages/api/src/infrastructure/email/CiCdRouter.ts
+++ b/packages/api/src/infrastructure/email/CiCdRouter.ts
@@ -256,6 +256,6 @@ function shouldAppendTrackingInstructions(
 ): trackingInstructions is string {
   if (!trackingInstructions) return false;
   if (!instructionsHeadSha) return true;
-  if (!currentHeadSha) return true;
+  if (!currentHeadSha) return false;
   return instructionsHeadSha === currentHeadSha;
 }

--- a/packages/api/src/infrastructure/email/ReviewFeedbackRouter.ts
+++ b/packages/api/src/infrastructure/email/ReviewFeedbackRouter.ts
@@ -42,6 +42,7 @@ export interface PrReviewDecision {
 export interface ReviewFeedbackSignal {
   readonly repoFullName: string;
   readonly prNumber: number;
+  readonly headSha?: string;
   readonly newComments: readonly PrFeedbackComment[];
   readonly newDecisions: readonly PrReviewDecision[];
 }
@@ -66,13 +67,23 @@ export class ReviewFeedbackRouter {
 
   async route(
     signal: ReviewFeedbackSignal,
-    tracking: { threadId: string; catId: string; userId: string; trackingInstructions?: string },
+    tracking: {
+      threadId: string;
+      catId: string;
+      userId: string;
+      trackingInstructions?: string;
+      trackingInstructionsHeadSha?: string;
+    },
   ): Promise<ReviewFeedbackRouteResult> {
     if (signal.newComments.length === 0 && signal.newDecisions.length === 0) {
       return { kind: 'skipped', reason: 'no new feedback' };
     }
 
-    const content = buildReviewFeedbackContent(signal, tracking.trackingInstructions);
+    const content = buildReviewFeedbackContent(
+      signal,
+      tracking.trackingInstructions,
+      tracking.trackingInstructionsHeadSha,
+    );
 
     const source: ConnectorSource = {
       connector: 'github-review-feedback',
@@ -106,7 +117,11 @@ export class ReviewFeedbackRouter {
 
 // ── Message Formatting (OQ-2: three-section aggregation) ───────────
 
-export function buildReviewFeedbackContent(signal: ReviewFeedbackSignal, trackingInstructions?: string): string {
+export function buildReviewFeedbackContent(
+  signal: ReviewFeedbackSignal,
+  trackingInstructions?: string,
+  trackingInstructionsHeadSha?: string,
+): string {
   const lines: string[] = [];
 
   // F140 Phase E.1: prepend severity header when comments/decisions contain
@@ -170,11 +185,22 @@ export function buildReviewFeedbackContent(signal: ReviewFeedbackSignal, trackin
   }
 
   // F202 Phase 2C (AC-C2): append user-provided tracking instructions
-  if (trackingInstructions) {
+  if (shouldAppendTrackingInstructions(trackingInstructions, signal.headSha, trackingInstructionsHeadSha)) {
     lines.push('', '📌 **Tracking Instructions**', trackingInstructions);
   }
 
   return lines.join('\n');
+}
+
+function shouldAppendTrackingInstructions(
+  trackingInstructions: string | undefined,
+  currentHeadSha: string | undefined,
+  instructionsHeadSha: string | undefined,
+): trackingInstructions is string {
+  if (!trackingInstructions) return false;
+  if (!instructionsHeadSha) return true;
+  if (!currentHeadSha) return true;
+  return instructionsHeadSha === currentHeadSha;
 }
 
 function decisionEmoji(state: PrReviewDecision['state']): string {

--- a/packages/api/src/infrastructure/email/ReviewFeedbackRouter.ts
+++ b/packages/api/src/infrastructure/email/ReviewFeedbackRouter.ts
@@ -199,7 +199,7 @@ function shouldAppendTrackingInstructions(
 ): trackingInstructions is string {
   if (!trackingInstructions) return false;
   if (!instructionsHeadSha) return true;
-  if (!currentHeadSha) return true;
+  if (!currentHeadSha) return false;
   return instructionsHeadSha === currentHeadSha;
 }
 

--- a/packages/api/src/infrastructure/email/ReviewFeedbackTaskSpec.ts
+++ b/packages/api/src/infrastructure/email/ReviewFeedbackTaskSpec.ts
@@ -22,6 +22,7 @@ export interface ReviewFeedbackSignal {
   task: TaskItem;
   repoFullName: string;
   prNumber: number;
+  headSha?: string;
   newComments: PrFeedbackComment[];
   newDecisions: PrReviewDecision[];
   commitCursor: () => Promise<void>;
@@ -388,6 +389,7 @@ export function createReviewFeedbackTaskSpec(opts: ReviewFeedbackTaskSpecOptions
                 task,
                 repoFullName,
                 prNumber,
+                headSha: prMetadata?.headSha,
                 newComments,
                 newDecisions,
                 commitCursor: () =>
@@ -449,6 +451,7 @@ export function createReviewFeedbackTaskSpec(opts: ReviewFeedbackTaskSpecOptions
           {
             repoFullName: signal.repoFullName,
             prNumber: signal.prNumber,
+            headSha: signal.headSha,
             newComments: signal.newComments,
             newDecisions: signal.newDecisions,
           },
@@ -457,6 +460,7 @@ export function createReviewFeedbackTaskSpec(opts: ReviewFeedbackTaskSpecOptions
             catId: task.ownerCatId ?? '',
             userId: task.userId ?? '',
             trackingInstructions: task.automationState?.trackingInstructions,
+            trackingInstructionsHeadSha: task.automationState?.trackingInstructionsHeadSha,
           },
         );
 

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -2302,6 +2302,7 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
       const intent = parsed.data.intent ?? existing?.automationState?.intent ?? 'review';
       const shouldSeedPrBoundary = !existing || existing.status === 'done';
       let seededPrBoundary: Pick<AutomationState, 'review' | 'ci'> | undefined;
+      let instructionsPrBoundary: Pick<AutomationState, 'review' | 'ci'> | undefined;
       if (shouldSeedPrBoundary) {
         if (!fetchPrTrackingBoundary) {
           reply.status(503);
@@ -2317,11 +2318,20 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
           reply.status(503);
           return { error: 'PR tracking boundary unavailable — try again later' };
         }
+      } else if (instructions !== undefined && instructions !== '' && fetchPrTrackingBoundary) {
+        try {
+          instructionsPrBoundary = await fetchPrTrackingBoundary(repoFullName, prNumber);
+        } catch {
+          reply.status(503);
+          return { error: 'PR tracking boundary unavailable — try again later' };
+        }
       }
 
       const trackingInstructionsHeadSha =
         instructions !== undefined && instructions !== ''
-          ? (seededPrBoundary?.ci?.headSha ?? existing?.automationState?.ci?.headSha)
+          ? (seededPrBoundary?.ci?.headSha ??
+            instructionsPrBoundary?.ci?.headSha ??
+            existing?.automationState?.ci?.headSha)
           : instructions === ''
             ? ''
             : undefined;

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -2319,8 +2319,19 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
         }
       }
 
+      const trackingInstructionsHeadSha =
+        instructions !== undefined && instructions !== ''
+          ? (seededPrBoundary?.ci?.headSha ?? existing?.automationState?.ci?.headSha)
+          : instructions === ''
+            ? ''
+            : undefined;
       const automationState = {
-        ...(instructions !== undefined ? { trackingInstructions: instructions } : {}),
+        ...(instructions !== undefined
+          ? {
+              trackingInstructions: instructions,
+              ...(trackingInstructionsHeadSha !== undefined ? { trackingInstructionsHeadSha } : {}),
+            }
+          : {}),
         ...(seededPrBoundary ?? {}),
       };
 

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -2301,6 +2301,7 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
       const existing = await taskStore.getBySubject(subjectKey);
       const intent = parsed.data.intent ?? existing?.automationState?.intent ?? 'review';
       const shouldSeedPrBoundary = !existing || existing.status === 'done';
+      const shouldBindInstructionsHead = instructions !== undefined && instructions !== '';
       let seededPrBoundary: Pick<AutomationState, 'review' | 'ci'> | undefined;
       let instructionsPrBoundary: Pick<AutomationState, 'review' | 'ci'> | undefined;
       if (shouldSeedPrBoundary) {
@@ -2318,10 +2319,18 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
           reply.status(503);
           return { error: 'PR tracking boundary unavailable — try again later' };
         }
-      } else if (instructions !== undefined && instructions !== '' && fetchPrTrackingBoundary) {
+      } else if (shouldBindInstructionsHead) {
+        if (!fetchPrTrackingBoundary) {
+          reply.status(503);
+          return { error: 'PR tracking boundary fetcher not configured' };
+        }
         try {
           instructionsPrBoundary = await fetchPrTrackingBoundary(repoFullName, prNumber);
         } catch {
+          reply.status(503);
+          return { error: 'PR tracking boundary unavailable — try again later' };
+        }
+        if (!instructionsPrBoundary.ci?.headSha) {
           reply.status(503);
           return { error: 'PR tracking boundary unavailable — try again later' };
         }
@@ -2329,9 +2338,7 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
 
       const trackingInstructionsHeadSha =
         instructions !== undefined && instructions !== ''
-          ? (seededPrBoundary?.ci?.headSha ??
-            instructionsPrBoundary?.ci?.headSha ??
-            existing?.automationState?.ci?.headSha)
+          ? (seededPrBoundary?.ci?.headSha ?? instructionsPrBoundary?.ci?.headSha)
           : instructions === ''
             ? ''
             : undefined;

--- a/packages/api/test/callback-routes.test.js
+++ b/packages/api/test/callback-routes.test.js
@@ -3042,6 +3042,71 @@ describe('Callback Routes', () => {
     assert.equal(body.task.automationState.trackingInstructionsHeadSha, 'test-head');
   });
 
+  test('POST register-pr-tracking rebinds updated instructions to the current active PR head', async () => {
+    const { callbacksRoutes } = await import('../dist/routes/callbacks.js');
+    const app = Fastify();
+    const boundaryCalls = [];
+    const boundaries = [
+      {
+        review: { lastCommentCursor: 10, lastDecisionCursor: 20 },
+        ci: { headSha: 'sha-old', lastFingerprint: 'sha-old:pass', lastBucket: 'pass' },
+      },
+      {
+        review: { lastCommentCursor: 110, lastDecisionCursor: 220 },
+        ci: { headSha: 'sha-current', lastFingerprint: 'sha-current:pending', lastBucket: 'pending' },
+      },
+    ];
+    await app.register(callbacksRoutes, {
+      registry,
+      messageStore,
+      socketManager,
+      taskStore,
+      threadStore,
+      evidenceStore,
+      reflectionService,
+      markerQueue,
+      fetchPrTrackingBoundary: async (repoFullName, prNumber) => {
+        boundaryCalls.push({ repoFullName, prNumber });
+        return boundaries.shift();
+      },
+    });
+
+    const { invocationId, callbackToken } = await registry.create('user-1', 'opus', 'thread-pr');
+    const headers = { 'x-invocation-id': invocationId, 'x-callback-token': callbackToken };
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/callbacks/register-pr-tracking',
+      headers,
+      payload: {
+        repoFullName: 'zts212653/cat-cafe',
+        prNumber: 106,
+        instructions: 'Handle old head.',
+      },
+    });
+    assert.equal(first.statusCode, 200);
+    assert.equal(JSON.parse(first.body).task.automationState.trackingInstructionsHeadSha, 'sha-old');
+
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/callbacks/register-pr-tracking',
+      headers,
+      payload: {
+        repoFullName: 'zts212653/cat-cafe',
+        prNumber: 106,
+        instructions: 'Handle current head.',
+      },
+    });
+    assert.equal(second.statusCode, 200);
+    const updated = JSON.parse(second.body).task.automationState;
+    assert.equal(updated.trackingInstructions, 'Handle current head.');
+    assert.equal(updated.trackingInstructionsHeadSha, 'sha-current');
+    assert.deepEqual(boundaryCalls, [
+      { repoFullName: 'zts212653/cat-cafe', prNumber: 106 },
+      { repoFullName: 'zts212653/cat-cafe', prNumber: 106 },
+    ]);
+  });
+
   test('POST register-pr-tracking seeds PR feedback and CI boundaries after unregister/re-register', async () => {
     const { callbacksRoutes } = await import('../dist/routes/callbacks.js');
     const app = Fastify();

--- a/packages/api/test/callback-routes.test.js
+++ b/packages/api/test/callback-routes.test.js
@@ -3107,6 +3107,63 @@ describe('Callback Routes', () => {
     ]);
   });
 
+  test('POST register-pr-tracking rejects active instruction updates when current PR head is unavailable', async () => {
+    const { callbacksRoutes } = await import('../dist/routes/callbacks.js');
+    const app = Fastify();
+    const boundaries = [
+      {
+        review: { lastCommentCursor: 10, lastDecisionCursor: 20 },
+        ci: { headSha: 'sha-old', lastFingerprint: 'sha-old:pass', lastBucket: 'pass' },
+      },
+      {
+        review: { lastCommentCursor: 110, lastDecisionCursor: 220 },
+      },
+    ];
+    await app.register(callbacksRoutes, {
+      registry,
+      messageStore,
+      socketManager,
+      taskStore,
+      threadStore,
+      evidenceStore,
+      reflectionService,
+      markerQueue,
+      fetchPrTrackingBoundary: async () => boundaries.shift(),
+    });
+
+    const { invocationId, callbackToken } = await registry.create('user-1', 'opus', 'thread-pr');
+    const headers = { 'x-invocation-id': invocationId, 'x-callback-token': callbackToken };
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/callbacks/register-pr-tracking',
+      headers,
+      payload: {
+        repoFullName: 'zts212653/cat-cafe',
+        prNumber: 107,
+        instructions: 'Handle old head.',
+      },
+    });
+    assert.equal(first.statusCode, 200);
+
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/callbacks/register-pr-tracking',
+      headers,
+      payload: {
+        repoFullName: 'zts212653/cat-cafe',
+        prNumber: 107,
+        instructions: 'Handle current head.',
+      },
+    });
+    assert.equal(second.statusCode, 503);
+    assert.deepEqual(JSON.parse(second.body), { error: 'PR tracking boundary unavailable — try again later' });
+
+    const stored = taskStore.getBySubject('pr:zts212653/cat-cafe#107');
+    assert.equal(stored.automationState.trackingInstructions, 'Handle old head.');
+    assert.equal(stored.automationState.trackingInstructionsHeadSha, 'sha-old');
+  });
+
   test('POST register-pr-tracking seeds PR feedback and CI boundaries after unregister/re-register', async () => {
     const { callbacksRoutes } = await import('../dist/routes/callbacks.js');
     const app = Fastify();

--- a/packages/api/test/callback-routes.test.js
+++ b/packages/api/test/callback-routes.test.js
@@ -3021,6 +3021,27 @@ describe('Callback Routes', () => {
     assert.equal(stored.automationState.trackingInstructions, '');
   });
 
+  test('POST register-pr-tracking binds instructions to the seeded PR head', async () => {
+    const app = await createApp();
+    const { invocationId, callbackToken } = await registry.create('user-1', 'opus', 'thread-pr');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/callbacks/register-pr-tracking',
+      headers: { 'x-invocation-id': invocationId, 'x-callback-token': callbackToken },
+      payload: {
+        repoFullName: 'zts212653/cat-cafe',
+        prNumber: 105,
+        instructions: 'Handle this head before merge.',
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = JSON.parse(response.body);
+    assert.equal(body.task.automationState.trackingInstructions, 'Handle this head before merge.');
+    assert.equal(body.task.automationState.trackingInstructionsHeadSha, 'test-head');
+  });
+
   test('POST register-pr-tracking seeds PR feedback and CI boundaries after unregister/re-register', async () => {
     const { callbacksRoutes } = await import('../dist/routes/callbacks.js');
     const app = Fastify();

--- a/packages/api/test/cicd-router.test.js
+++ b/packages/api/test/cicd-router.test.js
@@ -95,6 +95,30 @@ describe('CiCdRouter', () => {
     socketMock = mockSocketManager();
   });
 
+  describe('tracking instructions head binding', () => {
+    it('keeps instructions when they describe the current CI head', () => {
+      const content = buildCiMessageContent(
+        makePollResult({ headSha: 'abc1234567890' }),
+        'Proceed to merge readiness.',
+        'abc1234567890',
+      );
+
+      assert.ok(content.includes('📌 **Tracking Instructions**'));
+      assert.ok(content.includes('Proceed to merge readiness.'));
+    });
+
+    it('omits stale instructions when CI reports a newer head', () => {
+      const content = buildCiMessageContent(
+        makePollResult({ headSha: 'newhead1234567890' }),
+        'Handle old head review finding before merge.',
+        'oldhead1234567890',
+      );
+
+      assert.ok(!content.includes('📌 **Tracking Instructions**'));
+      assert.ok(!content.includes('Handle old head review finding before merge.'));
+    });
+  });
+
   // ── AC-A6: Unregistered PR skipped ──────────────────────────────
 
   describe('unregistered PR', () => {

--- a/packages/api/test/review-feedback-router.test.js
+++ b/packages/api/test/review-feedback-router.test.js
@@ -102,6 +102,22 @@ describe('ReviewFeedbackRouter', () => {
       assert.ok(!content.includes('📌 **Tracking Instructions**'));
       assert.ok(!content.includes('Handle old head review finding before merge.'));
     });
+
+    it('omits head-bound instructions when the current review head is unknown', () => {
+      const content = buildReviewFeedbackContent(
+        {
+          repoFullName: 'owner/repo',
+          prNumber: 42,
+          newComments: [{ id: 1, author: 'bot', body: 'LGTM', createdAt: '2026-06-26', commentType: 'conversation' }],
+          newDecisions: [],
+        },
+        'Handle old head review finding before merge.',
+        'oldhead1234567890',
+      );
+
+      assert.ok(!content.includes('📌 **Tracking Instructions**'));
+      assert.ok(!content.includes('Handle old head review finding before merge.'));
+    });
   });
 
   it('delivers review feedback with correct connector (AC-A3/A4)', async () => {

--- a/packages/api/test/review-feedback-router.test.js
+++ b/packages/api/test/review-feedback-router.test.js
@@ -68,6 +68,42 @@ describe('ReviewFeedbackRouter', () => {
     socketMock = mockSocketManager();
   });
 
+  describe('tracking instructions head binding', () => {
+    it('keeps instructions when they describe the current review head', () => {
+      const content = buildReviewFeedbackContent(
+        {
+          repoFullName: 'owner/repo',
+          prNumber: 42,
+          headSha: 'abc1234567890',
+          newComments: [{ id: 1, author: 'bot', body: 'LGTM', createdAt: '2026-06-26', commentType: 'conversation' }],
+          newDecisions: [],
+        },
+        'Proceed to merge readiness.',
+        'abc1234567890',
+      );
+
+      assert.ok(content.includes('📌 **Tracking Instructions**'));
+      assert.ok(content.includes('Proceed to merge readiness.'));
+    });
+
+    it('omits stale instructions when review feedback is for a newer head', () => {
+      const content = buildReviewFeedbackContent(
+        {
+          repoFullName: 'owner/repo',
+          prNumber: 42,
+          headSha: 'newhead1234567890',
+          newComments: [{ id: 1, author: 'bot', body: 'LGTM', createdAt: '2026-06-26', commentType: 'conversation' }],
+          newDecisions: [],
+        },
+        'Handle old head review finding before merge.',
+        'oldhead1234567890',
+      );
+
+      assert.ok(!content.includes('📌 **Tracking Instructions**'));
+      assert.ok(!content.includes('Handle old head review finding before merge.'));
+    });
+  });
+
   it('delivers review feedback with correct connector (AC-A3/A4)', async () => {
     const router = createRouter();
     const result = await router.route(

--- a/packages/shared/src/types/task.ts
+++ b/packages/shared/src/types/task.ts
@@ -97,6 +97,8 @@ export interface AutomationState {
   readonly intent?: PrTrackingIntent;
   /** F202 Phase 2C: user-provided instructions appended to trigger messages. Task preference, not system override. */
   readonly trackingInstructions?: string;
+  /** PR head that trackingInstructions were written for; stale-head callbacks suppress the instructions. */
+  readonly trackingInstructionsHeadSha?: string;
 }
 
 export interface TaskItem {

--- a/review-notes/2026-06-26-pr-tracking-instructions-review-request.md
+++ b/review-notes/2026-06-26-pr-tracking-instructions-review-request.md
@@ -1,0 +1,104 @@
+# Review Request: suppress stale PR tracking instructions
+
+Review-Target-ID: fix-pr-tracking-instruction-head-scope
+Branch: fix/pr-tracking-instruction-head-scope
+
+## What
+
+PR #29 binds PR tracking instructions to the PR head observed when
+`/api/callbacks/register-pr-tracking` stores them, then suppresses those
+instructions from CI/review-feedback callbacks when later callbacks report a
+different head.
+
+## Why
+
+Daily patrol found PR #187 callbacks replaying old head-specific instructions
+after newer commits. A current-head CI/review callback should not keep telling
+the receiver to handle stale findings from an earlier head.
+
+## Original Requirements
+
+> 每轮必须先查真相源和证据，再给风险/价值判断与下一步动作。
+> 发现可执行事项后主导闭环：按家规走 feature lifecycle（定位真相源、立项、实现/协调、质量门禁、review、完成记录）。
+
+- Source: patrol thread `thread_mqcj45byxoka2z7u`, scheduled wake `2026-06-26 00:00 Asia/Shanghai`.
+- Please check that the implementation solves the observed PR-tracking callback problem, not just the narrow tests.
+
+## Tradeoff
+
+This keeps backward compatibility by still appending instructions for older
+tasks that have no stored `trackingInstructionsHeadSha`, and it fails open when
+a callback has no current head SHA. That avoids silently dropping instructions
+from legacy/manual tracking records while fixing the stale-head replay path.
+
+## Architecture Ownership
+
+Architecture cell: callback-routing / PR-tracking automation state
+Map delta: none
+Why: This extends existing callback router/task automation metadata without
+adding a new Store, Router, Adapter, Dispatcher, or ownership boundary.
+
+Please check:
+- diff matches `Map delta: none`
+- no parallel Store/Queue/Router/Adapter/Dispatcher/Binding was introduced
+- no architecture ownership docs should have changed
+
+## Open Questions
+
+### Technical OQ
+
+- Is the fail-open behavior for legacy tasks without `trackingInstructionsHeadSha` the right compatibility boundary?
+- Is the chosen head source during registration correct for both fresh and active re-registration paths?
+
+### Value OQ
+
+None.
+
+## Next Action
+
+Please do a non-author current-SHA review of PR #29 at
+`3ed5438210baf32491bfff847583bd62fca66096`. If there are P1/P2 findings, route
+back to receive-review. If clean, approve and include the focused validation you ran.
+
+## Review Sandbox
+
+- Path: `/tmp/cat-cafe-review/fix-pr-tracking-instruction-head-scope/gpt555`
+- Start Command: `pnpm review:start` or equivalent read-only checkout/test commands
+- Ports: not used; no frontend/runtime server needed for this review
+
+## Self-Check Evidence
+
+### Spec Compliance
+
+- Found truth source in `CiCdRouter`, `ReviewFeedbackRouter`, `ReviewFeedbackTaskSpec`, and `register-pr-tracking`.
+- Created task `[Patrol P2] PR tracking callbacks should not replay stale head-specific instructions`.
+- Implemented in isolated worktree with dev/test `.env` pointing Redis to `6398`.
+- Registered PR tracking for PR #29.
+
+### Test Results
+
+Red tests first:
+- `cicd-router.test.js`: stale-head CI instructions assertion failed before implementation.
+- `review-feedback-router.test.js`: stale-head review feedback instructions assertion failed before implementation.
+- `callback-routes.test.js`: expected `trackingInstructionsHeadSha === "test-head"`, got `undefined` before implementation.
+
+Green / focused:
+- `pnpm --dir packages/api run build`: passed
+- `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import ./packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 packages/api/test/cicd-router.test.js packages/api/test/review-feedback-router.test.js`: 41 tests / 17 suites passed
+- `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import ./packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 --test-name-pattern "binds instructions" packages/api/test/callback-routes.test.js`: 1 test passed
+- `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import ./packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 packages/api/test/f202-phase2-c.test.js packages/api/test/task-store-instructions.test.js`: 30 tests / 11 suites passed
+- `pnpm --dir packages/api run lint`: passed
+- `git diff --check`: passed
+
+Dogfood:
+- Built `buildCiMessageContent()` with a current head plus old-head instructions; output omitted the stale Tracking Instructions block.
+
+Known unrelated checks:
+- `pnpm check` passed Biome and then failed `check-feature-truth` on an existing `ROADMAP` reference to missing `F207`.
+- An accidental broad API test run hit an unrelated `capabilities-route.test.js` timeout; the targeted suites above passed.
+
+### Related Documents
+
+- `docs/features/F133-cicd-tracking.md`
+- `docs/features/F140-github-pr-automation.md`
+- PR: https://github.com/clowder-labs/clowder-ai/pull/29

--- a/review-notes/2026-06-26-pr-tracking-instructions-review-request.md
+++ b/review-notes/2026-06-26-pr-tracking-instructions-review-request.md
@@ -97,6 +97,26 @@ Known unrelated checks:
 - `pnpm check` passed Biome and then failed `check-feature-truth` on an existing `ROADMAP` reference to missing `F207`.
 - An accidental broad API test run hit an unrelated `capabilities-route.test.js` timeout; the targeted suites above passed.
 
+### Receive-Review Update
+
+Reviewer found one P2 on active re-register: updating instructions on an already
+tracked PR could reuse old `automationState.ci.headSha`. Fixed by fetching the
+current PR boundary for non-empty active instruction updates and using that
+head only for `trackingInstructionsHeadSha`, without reseeding review/CI cursors.
+
+Red→Green:
+- `POST register-pr-tracking rebinds updated instructions to the current active PR head`: failed with `sha-old`, now passes with `sha-current`.
+
+Additional verification after the fix:
+- `pnpm --dir packages/api run build`: passed
+- `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import ./packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 --test-name-pattern "rebinds updated instructions" packages/api/test/callback-routes.test.js`: 1 test passed
+- `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import ./packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 packages/api/test/cicd-router.test.js packages/api/test/review-feedback-router.test.js`: 41 tests / 17 suites passed
+- `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import ./packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 --test-name-pattern "binds instructions|rebinds updated instructions|allows empty instructions" packages/api/test/callback-routes.test.js`: 4 tests passed
+- `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import ./packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 packages/api/test/f202-phase2-c.test.js packages/api/test/task-store-instructions.test.js`: 30 tests / 11 suites passed
+- `pnpm --dir packages/api run lint`: passed
+- `git diff --check`: passed
+- `pnpm check`: Biome passed, then hit the existing unrelated `ROADMAP`/missing `F207` feature-truth issue
+
 ### Related Documents
 
 - `docs/features/F133-cicd-tracking.md`

--- a/review-notes/2026-06-26-pr-tracking-instructions-review-request.md
+++ b/review-notes/2026-06-26-pr-tracking-instructions-review-request.md
@@ -56,9 +56,9 @@ None.
 
 ## Next Action
 
-Please do a non-author current-SHA review of PR #29 at
-`3ed5438210baf32491bfff847583bd62fca66096`. If there are P1/P2 findings, route
-back to receive-review. If clean, approve and include the focused validation you ran.
+Please do a non-author current-SHA review of PR #29. If there are P1/P2
+findings, route back to receive-review. If clean, approve and include the
+focused validation you ran.
 
 ## Review Sandbox
 

--- a/review-notes/2026-06-26-pr-tracking-instructions-review-request.md
+++ b/review-notes/2026-06-26-pr-tracking-instructions-review-request.md
@@ -27,9 +27,10 @@ the receiver to handle stale findings from an earlier head.
 ## Tradeoff
 
 This keeps backward compatibility by still appending instructions for older
-tasks that have no stored `trackingInstructionsHeadSha`, and it fails open when
-a callback has no current head SHA. That avoids silently dropping instructions
-from legacy/manual tracking records while fixing the stale-head replay path.
+tasks that have no stored `trackingInstructionsHeadSha`. Head-bound
+instructions now fail closed when the callback cannot prove the current head,
+which avoids replaying stale head-specific actions during transient metadata
+failures.
 
 ## Architecture Ownership
 
@@ -94,7 +95,6 @@ Dogfood:
 - Built `buildCiMessageContent()` with a current head plus old-head instructions; output omitted the stale Tracking Instructions block.
 
 Known unrelated checks:
-- `pnpm check` passed Biome and then failed `check-feature-truth` on an existing `ROADMAP` reference to missing `F207`.
 - An accidental broad API test run hit an unrelated `capabilities-route.test.js` timeout; the targeted suites above passed.
 
 ### Receive-Review Update
@@ -115,7 +115,40 @@ Additional verification after the fix:
 - `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import ./packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 packages/api/test/f202-phase2-c.test.js packages/api/test/task-store-instructions.test.js`: 30 tests / 11 suites passed
 - `pnpm --dir packages/api run lint`: passed
 - `git diff --check`: passed
-- `pnpm check`: Biome passed, then hit the existing unrelated `ROADMAP`/missing `F207` feature-truth issue
+- `pnpm check`: initially hit an unrelated `ROADMAP`/missing `F207` feature-truth issue; the PR now removes that stale ROADMAP row and `pnpm check` passes.
+
+### Receive-Review Update 2
+
+Cloud review found two P2s after the active re-register fix:
+
+1. Active instruction updates still should not fall back to a cached
+   `automationState.ci.headSha` if the fresh PR boundary cannot provide the
+   current head.
+2. Review feedback for head-bound tracking instructions should fail closed when
+   the current review head is unknown.
+
+Fixes:
+- `register-pr-tracking` now rejects non-empty active instruction updates with
+  `503` when the fresh PR boundary is unavailable or lacks `ci.headSha`; it no
+  longer binds new instructions to cached CI head state.
+- CI/review-feedback formatters still fail open for legacy unbound
+  instructions, but fail closed for head-bound instructions when the callback
+  head is unavailable.
+
+Red→Green:
+- `POST register-pr-tracking rejects active instruction updates when current PR head is unavailable`: failed with `200`, now passes with `503`.
+- `omits head-bound instructions when the current review head is unknown`: failed with stale Tracking Instructions present, now passes with the block omitted.
+
+Additional verification after the fix:
+- `pnpm --dir packages/api run build`: passed
+- `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import ./packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 --test-name-pattern "rejects active instruction updates" packages/api/test/callback-routes.test.js`: 1 test passed
+- `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import ./packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 --test-name-pattern "omits head-bound instructions" packages/api/test/review-feedback-router.test.js`: 1 test passed
+- `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import ./packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 packages/api/test/cicd-router.test.js packages/api/test/review-feedback-router.test.js`: 42 tests / 17 suites passed
+- `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import ./packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 --test-name-pattern "binds instructions|rebinds updated instructions|rejects active instruction updates|allows empty instructions" packages/api/test/callback-routes.test.js`: 5 tests passed
+- `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import ./packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 packages/api/test/f202-phase2-c.test.js packages/api/test/task-store-instructions.test.js`: 30 tests / 11 suites passed
+- `pnpm --dir packages/api run lint`: passed
+- `git diff --check`: passed
+- `pnpm check`: passed
 
 ### Related Documents
 


### PR DESCRIPTION
## Summary
- Bind PR tracking instructions to the PR head observed when `/api/callbacks/register-pr-tracking` stores them.
- Suppress tracking instructions from CI/review-feedback callbacks when the callback reports a different PR head.
- Preserve backward compatibility for older tasks without a stored instruction head.

## Why
Daily patrol found #187 callbacks replaying old head-specific tracking instructions after later commits. That made current-head CI/review callbacks tell the receiver to handle already-stale review findings.

## Verification
Red tests first:
- `cicd-router.test.js`: stale-head CI instructions assertion failed before implementation.
- `review-feedback-router.test.js`: stale-head review feedback instructions assertion failed before implementation.
- `callback-routes.test.js`: expected `trackingInstructionsHeadSha === "test-head"`, got `undefined` before implementation.

Green / focused:
- `pnpm --dir packages/api run build`
- `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import ./packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 packages/api/test/cicd-router.test.js packages/api/test/review-feedback-router.test.js`
- `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import ./packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 --test-name-pattern "binds instructions" packages/api/test/callback-routes.test.js`
- `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import ./packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 packages/api/test/f202-phase2-c.test.js packages/api/test/task-store-instructions.test.js`
- `pnpm --dir packages/api run lint`
- `git diff --check`

Dogfood:
- Built `buildCiMessageContent()` with a current head plus old-head instructions; output omitted the stale Tracking Instructions block.

Known unrelated checks:
- `pnpm check` passed Biome and then failed `check-feature-truth` on existing `ROADMAP` reference to missing `F207`.
- A broad accidental API test run hit an unrelated `capabilities-route.test.js` timeout; the targeted suites above passed.

[砚砚/gpt-5.5🐾]
