### PR TITLE
fix(F192): pin publish verdict gh repo to origin

### DIFF
--- a/packages/api/src/infrastructure/harness-eval/publish-verdict/git-worktree-publisher.ts
+++ b/packages/api/src/infrastructure/harness-eval/publish-verdict/git-worktree-publisher.ts
@@ -7,6 +7,37 @@ import type { GitPublisher, PublishOnIsolatedWorktreeOpts } from './publish-verd
 
 const exec = promisify(execFile);
 
+export function parseGitHubRepoFromRemoteUrl(remoteUrl: string): string | null {
+  const trimmed = remoteUrl.trim();
+  if (!trimmed) return null;
+
+  const scpLike = /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/.exec(trimmed);
+  if (scpLike) return `${scpLike[1]}/${scpLike[2]}`;
+
+  try {
+    const url = new URL(trimmed);
+    if (url.hostname !== 'github.com') return null;
+    const [owner, repoWithSuffix] = url.pathname.replace(/^\/+/, '').split('/');
+    if (!owner || !repoWithSuffix) return null;
+    return `${owner}/${repoWithSuffix.replace(/\.git$/, '')}`;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveOriginGitHubRepo(repoRoot: string): Promise<string | null> {
+  try {
+    const result = await exec('git', ['-C', repoRoot, 'remote', 'get-url', '--push', 'origin'], { timeout: 10_000 });
+    return parseGitHubRepoFromRemoteUrl(result.stdout);
+  } catch {
+    return null;
+  }
+}
+
+function withGhRepo(args: string[], repo: string | null): string[] {
+  return repo ? [...args, '--repo', repo] : args;
+}
+
 /**
  * F192 Phase H — Real GitPublisher impl using `git worktree add` + `gh pr create`.
  *
@@ -42,10 +73,12 @@ export function createGitWorktreePublisher(deps: GitWorktreePublisherDeps): GitP
       let pushSucceeded = false;
       let prUrl: string | null = null;
       let branchExistedBefore = false;
+      let ghRepo: string | null = null;
 
       try {
         // 1. Fetch latest origin/main to ensure isolated worktree is current
         await exec('git', ['-C', deps.repoRoot, 'fetch', 'origin', 'main'], { timeout: 60_000 });
+        ghRepo = await resolveOriginGitHubRepo(deps.repoRoot);
 
         // Probe upfront so partial-failure cleanup never deletes a pre-existing branch.
         try {
@@ -95,9 +128,9 @@ export function createGitWorktreePublisher(deps: GitWorktreePublisherDeps): GitP
         const commitSha = shaResult.stdout.trim();
 
         // 7. Open auto-PR via gh.
-        // 砚砚 R4 P1 cloud: `--repo .` is NOT valid gh syntax (fails with
-        // 'expected the "[HOST/]OWNER/REPO" format'). Rely on cwd inside the
-        // worktree — gh auto-detects owner/repo from the git remote.
+        // Derive `--repo` from origin's push URL. In multi-remote worktrees gh can
+        // auto-detect an upstream/fork remote while the branch was pushed to origin,
+        // which makes PR creation look for a head branch in the wrong repository.
         //
         // PR-3 (砚砚 R2): pass each label via separate `--label` flag (gh CLI accepts
         // repeated --label X; not comma-separated). `computePublishPolicy` decides
@@ -120,7 +153,7 @@ export function createGitWorktreePublisher(deps: GitWorktreePublisherDeps): GitP
         };
         for (const label of labels ?? []) {
           const meta = standardLabelMeta[label];
-          const args = ['label', 'create', label, '--force'];
+          const args = withGhRepo(['label', 'create', label, '--force'], ghRepo);
           if (meta) {
             args.push('--color', meta.color, '--description', meta.description);
           }
@@ -135,19 +168,22 @@ export function createGitWorktreePublisher(deps: GitWorktreePublisherDeps): GitP
         const labelFlags = (labels ?? []).flatMap((label) => ['--label', label]);
         const prResult = await exec(
           'gh',
-          [
-            'pr',
-            'create',
-            '--base',
-            'main',
-            '--head',
-            opts.branchName,
-            '--title',
-            prTitle,
-            '--body',
-            prBody,
-            ...labelFlags,
-          ],
+          withGhRepo(
+            [
+              'pr',
+              'create',
+              '--base',
+              'main',
+              '--head',
+              opts.branchName,
+              '--title',
+              prTitle,
+              '--body',
+              prBody,
+              ...labelFlags,
+            ],
+            ghRepo,
+          ),
           { cwd: worktreePath, timeout: 60_000 },
         );
         prUrl =
@@ -225,7 +261,10 @@ export function createGitWorktreePublisher(deps: GitWorktreePublisherDeps): GitP
             try {
               const probe = await exec(
                 'gh',
-                ['pr', 'list', '--head', opts.branchName, '--state', 'open', '--json', 'state', '--limit', '1'],
+                withGhRepo(
+                  ['pr', 'list', '--head', opts.branchName, '--state', 'open', '--json', 'state', '--limit', '1'],
+                  ghRepo,
+                ),
                 { cwd: deps.repoRoot, timeout: 30_000 },
               );
               const parsed = JSON.parse(probe.stdout) as Array<{ state?: string }>;

--- a/packages/api/test/harness-eval/git-worktree-publisher.test.js
+++ b/packages/api/test/harness-eval/git-worktree-publisher.test.js
@@ -38,6 +38,25 @@ afterEach(() => {
   syncBuiltinESMExports();
 });
 
+describe('parseGitHubRepoFromRemoteUrl', () => {
+  it('parses GitHub origin push URL forms used for gh --repo pinning', async () => {
+    const { parseGitHubRepoFromRemoteUrl } = await import(
+      `../../dist/infrastructure/harness-eval/publish-verdict/git-worktree-publisher.js?t=${Date.now()}-parse`
+    );
+
+    assert.equal(
+      parseGitHubRepoFromRemoteUrl('https://github.com/clowder-labs/clowder-ai.git'),
+      'clowder-labs/clowder-ai',
+    );
+    assert.equal(parseGitHubRepoFromRemoteUrl('git@github.com:clowder-labs/clowder-ai.git'), 'clowder-labs/clowder-ai');
+    assert.equal(
+      parseGitHubRepoFromRemoteUrl('ssh://git@github.com/clowder-labs/clowder-ai.git'),
+      'clowder-labs/clowder-ai',
+    );
+    assert.equal(parseGitHubRepoFromRemoteUrl('/tmp/local-bare-origin.git'), null);
+  });
+});
+
 describe('createGitWorktreePublisher', () => {
   it('cleans up a partially-created local branch when worktree add fails before stage', async (t) => {
     const { repoRoot, remoteRoot } = createRepoWithOrigin();


### PR DESCRIPTION
## What
- Derive the GitHub owner/repo from origin's push URL in the publish-verdict git worktree publisher.
- Pass explicit `--repo owner/repo` to `gh label create`, `gh pr create`, and cleanup `gh pr list` probes.
- Add regression coverage for HTTPS, SSH scp-like, and ssh:// GitHub origin URLs.

## Why
`cat_cafe_publish_verdict` pushes verdict branches to `origin`, but this worktree has both `origin=clowder-labs/clowder-ai` and `upstream=zts212653/clowder-ai`. Without explicit `--repo`, `gh` can auto-detect the wrong repo and fail PR creation with no head branch/commits.

## Verification
- `pnpm --dir ../.. build` — pass
- `node --test test/harness-eval/git-worktree-publisher.test.js test/harness-eval/eval-a2a-artifact-resolver-sampled-anchors.test.js test/harness-eval/eval-a2a-artifact-resolver.test.js test/harness-eval/eval-a2a-live-verdict.test.js` — 34/34 pass
- `pnpm --dir ../.. exec biome check packages/api/src/infrastructure/harness-eval/publish-verdict/git-worktree-publisher.ts packages/api/test/harness-eval/git-worktree-publisher.test.js --diagnostic-level=error` — pass
- `pnpm --dir ../.. check` — blocked by pre-existing catagent formatting errors outside this PR scope (openai-chat-adapter/catagent tests); this PR's two files pass scoped Biome.

[砚砚/gpt-5.5🐾]