### PR TITLE
fix(F241): project plugin cats into L0 bootstrap

### DIFF
--- a/packages/api/src/domains/plugin/agent-provider-projection.ts
+++ b/packages/api/src/domains/plugin/agent-provider-projection.ts
@@ -60,6 +60,8 @@ export interface AgentProviderProjectionInputs {
   readonly buildSnapshot: (pluginId: string, capId: string) => RoutingAdmissionSnapshot;
   /** Current epoch ms — injected for testability. */
   readonly now: () => number;
+  /** API sync enforces TTL refresh/degrade; read-only mirrors such as L0 bootstrap must not independently de-route. */
+  readonly enforceHealthTtl?: boolean;
   /** Optional logger for skip reasons. */
   readonly onSkip?: (pluginId: string, capId: string, reason: string) => void;
 }
@@ -105,7 +107,7 @@ export function projectRouteableAgentProviders(inputs: AgentProviderProjectionIn
       inputs.onSkip?.(row.pluginId, row.capId, 'health-descriptor-mismatch');
       continue;
     }
-    if (now > descriptor.health.checkedAt + descriptor.health.ttlMs) {
+    if (inputs.enforceHealthTtl !== false && now > descriptor.health.checkedAt + descriptor.health.ttlMs) {
       skipped.push({ pluginId: row.pluginId, capId: row.capId, reason: 'health-ttl-expired' });
       inputs.onSkip?.(row.pluginId, row.capId, 'health-ttl-expired');
       continue;

--- a/packages/api/test/l0-compiler.test.js
+++ b/packages/api/test/l0-compiler.test.js
@@ -9,6 +9,7 @@
  */
 
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -236,6 +237,75 @@ test('F231: profileDir falls back to script-path-based when cwd has no private/p
     resolve(root, 'private/profile'),
     'profileDir must fall back to script-path-based when cwd has no private/profile/',
   );
+});
+
+test('F241 Phase C: compileL0 bootstrap registers plugin-projected cats from capabilities.json', () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'l0-f241-project-'));
+  const sourceTemplate = resolve(import.meta.dirname, '../../../cat-template.json');
+  const templatePath = join(projectRoot, 'cat-template.json');
+  mkdirSync(join(projectRoot, '.cat-cafe'), { recursive: true });
+  writeFileSync(templatePath, readFileSync(sourceTemplate, 'utf8'));
+
+  const descriptorHash = 'hash-for-l0-projection-test';
+  writeFileSync(
+    join(projectRoot, '.cat-cafe', 'capabilities.json'),
+    JSON.stringify(
+      {
+        version: 2,
+        capabilities: [
+          {
+            id: 'plugin:clowder-code:clowder-code',
+            type: 'agentProvider',
+            enabled: true,
+            source: 'cat-cafe',
+            pluginId: 'clowder-code',
+            agentProvider: {
+              name: 'clowder-code',
+              transport: 'cli-jsonl',
+              command: 'clowder-code',
+              startupArgs: ['--json', '--non-interactive'],
+              resumeArgs: ['resume', '{sessionId}', '--json'],
+              sessionPolicy: 'resume',
+              outputProfile: 'clowder-code-turn-result-v1',
+              healthCheck: { type: 'cliProbe' },
+              state: 'healthy',
+              routeable: true,
+              routeableApproved: true,
+              descriptorHash,
+              health: {
+                passed: true,
+                // Deliberately expired. L0 bootstrap mirrors runtime-visible
+                // routeable cats; TTL refresh/degrade is owned by API sync.
+                checkedAt: 1,
+                ttlMs: 1,
+                descriptorHash,
+              },
+              routeableBinding: {
+                catId: 'clowder-cat',
+                mentionPatterns: ['clowder'],
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const scriptPath = resolve(import.meta.dirname, '../../../scripts/compile-system-prompt-l0.mjs');
+  const out = execFileSync(process.execPath, [scriptPath, '--cat', 'clowder-cat'], {
+    cwd: resolve(import.meta.dirname, '../../..'),
+    env: {
+      ...process.env,
+      CAT_TEMPLATE_PATH: templatePath,
+    },
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024,
+  });
+
+  assert.match(out, /clowder-code/);
+  assert.match(out, /Plugin-projected agentProvider/);
 });
 
 // --- L0 template content guard ---

--- a/scripts/compile-system-prompt-l0.mjs
+++ b/scripts/compile-system-prompt-l0.mjs
@@ -50,11 +50,68 @@ let _loadCompiledGovernanceL0 = null;
 // 渲染（buildStaticIdentity L568-571 同源），非 L0 硬编码 @co-creator——
 // 否则删 user message 后 co-creator 多 handle / 自定义 name 丢失。
 let _coCreatorConfig = null;
+
+function resolveConfigProjectRoot() {
+  const templatePath = process.env.CAT_TEMPLATE_PATH ?? resolve(REPO_ROOT, 'cat-template.json');
+  return dirname(resolve(templatePath));
+}
+
+function readCapabilitiesConfigSync(projectRoot) {
+  try {
+    const raw = readFileSync(resolve(projectRoot, '.cat-cafe/capabilities.json'), 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.capabilities)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+async function projectRouteableAgentProviderConfigs(allConfigs, catConfigLoader) {
+  const projectRoot = resolveConfigProjectRoot();
+  const capabilitiesConfig = readCapabilitiesConfigSync(projectRoot);
+  if (!capabilitiesConfig) return {};
+
+  const { listApprovedRouteableRows, projectRouteableAgentProviders } = await import(
+    '../packages/api/dist/domains/plugin/agent-provider-projection.js'
+  );
+  const { buildAgentProviderAdmissionSnapshot } = await import(
+    '../packages/api/dist/domains/plugin/agent-provider-admission-snapshot.js'
+  );
+
+  const rows = listApprovedRouteableRows(capabilitiesConfig);
+  if (rows.length === 0) return {};
+
+  const templateBaselineIds = catConfigLoader.getTemplateBuiltinCatIds(projectRoot);
+  const projection = projectRouteableAgentProviders({
+    rows,
+    buildSnapshot: (pluginId, capId) =>
+      buildAgentProviderAdmissionSnapshot({
+        capabilitiesConfig,
+        activeCatConfigs: allConfigs,
+        templateBaselineIds,
+        hasProviderTransportConfig: (id) => {
+          const pt = catConfigLoader.getProviderTransportConfig(id, projectRoot);
+          return pt !== undefined && pt !== null;
+        },
+        candidatePluginId: pluginId,
+        candidateCapId: capId,
+      }),
+    now: () => Date.now(),
+    // L0 bootstrap mirrors routeable cats already materialized by API sync.
+    // TTL refresh/degrade requires live providerTransportRegistry and belongs
+    // to syncAgentRegistry; the read-only compiler must not independently
+    // de-route a cat that the API in-memory catRegistry can still route.
+    enforceHealthTtl: false,
+  });
+
+  return projection.configs;
+}
+
 async function bootstrapCatRegistry() {
   if (_bootstrapped) return;
-  const { loadCatConfig, toAllCatConfigs, isCatAvailable, getCoCreatorConfig } = await import(
-    '../packages/api/dist/config/cat-config-loader.js'
-  );
+  const catConfigLoader = await import('../packages/api/dist/config/cat-config-loader.js');
+  const { loadCatConfig, toAllCatConfigs, isCatAvailable, getCoCreatorConfig } = catConfigLoader;
   const { getCatModel } = await import('../packages/api/dist/config/cat-models.js');
   const { loadCompiledGovernanceL0 } = await import(
     '../packages/api/dist/domains/cats/services/context/governance-l0.js'
@@ -69,6 +126,10 @@ async function bootstrapCatRegistry() {
     if (!catRegistry.has(id)) {
       catRegistry.register(id, config);
     }
+  }
+  const projectedConfigs = await projectRouteableAgentProviderConfigs(allConfigs, catConfigLoader);
+  for (const [id, config] of Object.entries(projectedConfigs)) {
+    catRegistry.registerOrReplace(id, config);
   }
   _bootstrapped = true;
 }


### PR DESCRIPTION
## Summary
- Teach the L0 compiler subprocess to mirror approved F241 agentProvider projections from .cat-cafe/capabilities.json during catRegistry bootstrap.
- Keep API sync as the owner of TTL refresh/degrade; L0 bootstrap does not independently de-route persisted routeable cats just because wall-clock TTL has elapsed.
- Add a subprocess-level regression test for compiling a plugin-projected clowder-cat from capabilities.json.

## Verification
- pnpm --filter @cat-cafe/api run build
- CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash ./scripts/with-test-home.sh node --import /Users/xxx/workspace/AI/clowder-ai/test/helpers/setup-cat-registry.js --test --test-timeout=60000 test/l0-compiler.test.js
- CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash ./scripts/with-test-home.sh node --import /Users/xxx/workspace/AI/clowder-ai/test/helpers/setup-cat-registry.js --test --test-timeout=60000 test/agent-provider-*.test.js
- CAT_TEMPLATE_PATH=/Users/xxx/workspace/AI/cat-cafe-develop/cat-template.json node scripts/compile-system-prompt-l0.mjs --cat clowder-cat > /tmp/clowder-spike/clowder-cat-l0-after-fix.md && rg -n "clowder-code|Plugin-projected agentProvider" /tmp/clowder-spike/clowder-cat-l0-after-fix.md
- pnpm biome check scripts/compile-system-prompt-l0.mjs packages/api/src/domains/plugin/agent-provider-projection.ts packages/api/test/l0-compiler.test.js --diagnostic-level=error
- git diff --check

## Note
- pnpm check currently fails before this branch's checks on unrelated existing Biome formatting drift in catagent/web files; this PR does not touch those files.