### PR TITLE
feat(F241 Phase C 2c): real cliProbe health executor (drop-in DI swap)

### DIFF
--- a/packages/api/src/domains/plugin/agent-provider-health-executor.ts
+++ b/packages/api/src/domains/plugin/agent-provider-health-executor.ts
@@ -25,13 +25,14 @@
  * structured `passed` + bound `descriptorHash` it returns.
  */
 
-import { spawn as nodeSpawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
+import { type ChildProcess, spawn as nodeSpawn, type SpawnOptions } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import type {
   AgentProviderHealthCheckRequest,
   AgentProviderHealthResult,
   PluginAgentProviderResource,
 } from '@cat-cafe/shared';
+import { resolveCliCommand } from '../../utils/cli-resolve.js';
 import type { ProviderTransportRegistry } from '../cats/services/agents/providers/transport/ProviderTransportRegistry.js';
 
 /** Inputs to a single health check run. */
@@ -169,6 +170,10 @@ function healthCheckTypeToTransport(type: AgentProviderHealthCheckRequest['type'
 export interface RealCliProbeDeps {
   /** Test seam — replaces `node:child_process.spawn` for unit tests. */
   readonly spawnFn?: typeof nodeSpawn;
+  /** Test seam — replaces `resolveCliCommand` for unit tests so they don't
+   *  depend on real `which` / filesystem state. Production keeps the
+   *  default resolver so probe + invocation stay in lock-step. */
+  readonly resolveFn?: typeof resolveCliCommand;
   /** Override the probe timeout. Default 10s — generous for `--version`
    *  on cold-cache filesystems, tight enough that a hung binary doesn't
    *  block the approval RPC for minutes. */
@@ -177,8 +182,89 @@ export interface RealCliProbeDeps {
 
 const DEFAULT_CLI_PROBE_TIMEOUT_MS = 10_000;
 
+/** Build a passed health result with the standard TTL + descriptor binding. */
+function buildPassed(now: () => number, descriptorHash: string): AgentProviderHealthResult {
+  return { passed: true, checkedAt: now(), ttlMs: DEFAULT_HEALTH_TTL_MS, descriptorHash };
+}
+
+/** Build a failed health result with a structured `failureReason`. */
+function buildFailed(now: () => number, descriptorHash: string, failureReason: string): AgentProviderHealthResult {
+  return { passed: false, checkedAt: now(), ttlMs: DEFAULT_HEALTH_TTL_MS, descriptorHash, failureReason };
+}
+
+/**
+ * Bounded spawn of `--version` against the (already-resolved) binary path.
+ * Pure-ish: takes settled-closure inputs, returns a Promise. Extracted from
+ * `createRealCliProbeHealthExecutor` to keep the executor body under the
+ * Biome cognitive-complexity budget (P2 review feedback) and to make the
+ * spawn lifecycle easier to read in isolation.
+ */
+function spawnVersionProbe(args: {
+  spawnFn: typeof nodeSpawn;
+  resolvedCommand: string;
+  probeTimeoutMs: number;
+  now: () => number;
+  descriptorHash: string;
+}): Promise<AgentProviderHealthResult> {
+  const { spawnFn, resolvedCommand, probeTimeoutMs, now, descriptorHash } = args;
+  return new Promise((resolvePromise) => {
+    const spawnOptions: SpawnOptions = {
+      cwd: tmpdir(),
+      // Minimal env: PATH only. The health probe must NOT inherit cat-cafe
+      // callback / MCP credentials — it is a liveness check, not a real
+      // invocation. PATH is required so a bare command like `clowder-code`
+      // (npm-linked) still resolves on a system where the user's $PATH
+      // sees it but the resolver fallback also covers GUI / nvm cases.
+      env: { PATH: process.env.PATH ?? '' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    };
+
+    let child: ChildProcess;
+    try {
+      child = spawnFn(resolvedCommand, ['--version'], spawnOptions);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      resolvePromise(buildFailed(now, descriptorHash, `cli-probe-spawn-error:${message}`));
+      return;
+    }
+
+    let settled = false;
+    const settle = (result: AgentProviderHealthResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (!result.passed) {
+        // Best-effort cleanup so a hung probe doesn't outlive its own result.
+        try {
+          child.kill('SIGTERM');
+        } catch {
+          /* already dead */
+        }
+      }
+      resolvePromise(result);
+    };
+
+    const timer = setTimeout(() => {
+      settle(buildFailed(now, descriptorHash, `cli-probe-timeout:${probeTimeoutMs}ms`));
+    }, probeTimeoutMs);
+
+    child.on('error', (err) => {
+      settle(buildFailed(now, descriptorHash, `cli-probe-spawn-error:${err.message}`));
+    });
+
+    child.on('exit', (code) => {
+      if (code === 0) {
+        settle(buildPassed(now, descriptorHash));
+      } else {
+        settle(buildFailed(now, descriptorHash, `cli-probe-nonzero-exit:${code}`));
+      }
+    });
+  });
+}
+
 export function createRealCliProbeHealthExecutor(deps?: RealCliProbeDeps): AgentProviderHealthExecutor {
   const spawnFn = deps?.spawnFn ?? nodeSpawn;
+  const resolveFn = deps?.resolveFn ?? resolveCliCommand;
   const probeTimeoutMs = deps?.probeTimeoutMs ?? DEFAULT_CLI_PROBE_TIMEOUT_MS;
 
   return async (context) => {
@@ -191,85 +277,25 @@ export function createRealCliProbeHealthExecutor(deps?: RealCliProbeDeps): Agent
     // and any future type fall through to the transport-availability result.
     if (context.resource.healthCheck?.type !== 'cliProbe') return gateResult;
 
-    // Step 3: bounded spawn + exit-code check.
-    return new Promise<AgentProviderHealthResult>((resolve) => {
-      const spawnOptions: SpawnOptions = {
-        cwd: tmpdir(),
-        // Minimal env: PATH only. We do NOT inherit cat-cafe callback / MCP
-        // credentials into a health probe — the probe must not be able to do
-        // anything meaningful with the runtime env. PATH is required so a
-        // bare command like `clowder-code` (npm-linked) still resolves.
-        env: { PATH: process.env.PATH ?? '' },
-        stdio: ['ignore', 'pipe', 'pipe'],
-      };
-      let child: ChildProcess;
-      try {
-        child = spawnFn(context.resource.command, ['--version'], spawnOptions);
-      } catch (err) {
-        resolve({
-          passed: false,
-          checkedAt: now(),
-          ttlMs: DEFAULT_HEALTH_TTL_MS,
-          descriptorHash: context.descriptorHash,
-          failureReason: `cli-probe-spawn-error:${err instanceof Error ? err.message : String(err)}`,
-        });
-        return;
-      }
+    // Step 3: resolve the command using the SAME resolver the real cli-jsonl
+    // invocation uses (CliJsonlAgentService → resolveCliCommand). Probing the
+    // raw `context.resource.command` directly would create a split-brain when
+    // the binary lives in a non-$PATH location like `~/.local/bin` or an nvm
+    // version dir (cli-resolve fallback paths). With this in place, an
+    // approve-time probe and a real invocation share command resolution
+    // semantics, so they pass / fail consistently. (P2 review @codex on PR #38.)
+    const resolvedCommand = resolveFn(context.resource.command);
+    if (!resolvedCommand) {
+      return buildFailed(now, context.descriptorHash, `cli-probe-cli-not-found:${context.resource.command}`);
+    }
 
-      let settled = false;
-      const finalize = (result: AgentProviderHealthResult): void => {
-        if (settled) return;
-        settled = true;
-        if (timer) clearTimeout(timer);
-        if (!result.passed) {
-          // Best-effort cleanup so a hung probe doesn't outlive its own result.
-          try {
-            child.kill('SIGTERM');
-          } catch {
-            /* already dead */
-          }
-        }
-        resolve(result);
-      };
-
-      const timer = setTimeout(() => {
-        finalize({
-          passed: false,
-          checkedAt: now(),
-          ttlMs: DEFAULT_HEALTH_TTL_MS,
-          descriptorHash: context.descriptorHash,
-          failureReason: `cli-probe-timeout:${probeTimeoutMs}ms`,
-        });
-      }, probeTimeoutMs);
-
-      child.on('error', (err) => {
-        finalize({
-          passed: false,
-          checkedAt: now(),
-          ttlMs: DEFAULT_HEALTH_TTL_MS,
-          descriptorHash: context.descriptorHash,
-          failureReason: `cli-probe-spawn-error:${err.message}`,
-        });
-      });
-
-      child.on('exit', (code) => {
-        if (code === 0) {
-          finalize({
-            passed: true,
-            checkedAt: now(),
-            ttlMs: DEFAULT_HEALTH_TTL_MS,
-            descriptorHash: context.descriptorHash,
-          });
-        } else {
-          finalize({
-            passed: false,
-            checkedAt: now(),
-            ttlMs: DEFAULT_HEALTH_TTL_MS,
-            descriptorHash: context.descriptorHash,
-            failureReason: `cli-probe-nonzero-exit:${code}`,
-          });
-        }
-      });
+    // Step 4: bounded spawn + exit-code check (extracted helper).
+    return spawnVersionProbe({
+      spawnFn,
+      resolvedCommand,
+      probeTimeoutMs,
+      now,
+      descriptorHash: context.descriptorHash,
     });
   };
 }

--- a/packages/api/src/domains/plugin/agent-provider-health-executor.ts
+++ b/packages/api/src/domains/plugin/agent-provider-health-executor.ts
@@ -25,6 +25,8 @@
  * structured `passed` + bound `descriptorHash` it returns.
  */
 
+import { spawn as nodeSpawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
+import { tmpdir } from 'node:os';
 import type {
   AgentProviderHealthCheckRequest,
   AgentProviderHealthResult,
@@ -129,4 +131,145 @@ function healthCheckTypeToTransport(type: AgentProviderHealthCheckRequest['type'
     default:
       return null;
   }
+}
+
+/**
+ * F241 Phase C — Real `cliProbe` executor (bounded spawn + exit-code check).
+ *
+ * Per F241 doc § 2b "Health executor ships as transport-availability probe;
+ * real `acpInitialize` (runtime initialize handshake) and `cliProbe` (bounded
+ * spawn + exit-code check) probes are tracked as Slice 2c follow-on hardening
+ * — the executor is a drop-in DI swap (`AgentProviderHealthExecutor` interface
+ * in `agent-provider-health-executor.ts`), no further redesign needed."
+ *
+ * Semantics:
+ *   1. Gate (cheap): run the transport-availability check first. If the host
+ *      transport for the declared `healthCheck.type` is not registered, fail
+ *      fast WITHOUT spawning — same observable failure as the 2b stub.
+ *   2. For `cliProbe`-declared resources: spawn `resource.command --version`
+ *      with stdin closed, in `os.tmpdir()`, with a `PATH`-only minimal env.
+ *      Bounded by `probeTimeoutMs` (default 10s). Exit code 0 ⇒ passed.
+ *      Non-zero ⇒ `cli-probe-nonzero-exit:N`. Spawn error ⇒
+ *      `cli-probe-spawn-error:<msg>`. Timeout ⇒ `cli-probe-timeout:Nms` +
+ *      `child.kill('SIGTERM')` so a lingering probe doesn't leak.
+ *   3. For `acpInitialize`-declared resources: fall through to transport-
+ *      availability result — the ACP carrier (F161 PR #899) owns the real
+ *      initialize handshake once it lands; spawning a CLI here would be wrong.
+ *
+ * Why `--version`: standard CLI convention, fast-exit, no side effects, no
+ * stdin requirement, no callback config / MCP injection needed. Compatible
+ * with clowder-code (verified) and any well-formed CLI runtime. If a future
+ * runtime needs a different probe argv, extend `healthCheck` schema with an
+ * optional `probeArgs` field (tracked as a separate 2c follow-on; the
+ * reference runtime is covered by `--version` today).
+ *
+ * Why a factory: lets production wiring inject deterministic spawn + a tight
+ * timeout in tests, while keeping the default production semantics simple.
+ */
+export interface RealCliProbeDeps {
+  /** Test seam — replaces `node:child_process.spawn` for unit tests. */
+  readonly spawnFn?: typeof nodeSpawn;
+  /** Override the probe timeout. Default 10s — generous for `--version`
+   *  on cold-cache filesystems, tight enough that a hung binary doesn't
+   *  block the approval RPC for minutes. */
+  readonly probeTimeoutMs?: number;
+}
+
+const DEFAULT_CLI_PROBE_TIMEOUT_MS = 10_000;
+
+export function createRealCliProbeHealthExecutor(deps?: RealCliProbeDeps): AgentProviderHealthExecutor {
+  const spawnFn = deps?.spawnFn ?? nodeSpawn;
+  const probeTimeoutMs = deps?.probeTimeoutMs ?? DEFAULT_CLI_PROBE_TIMEOUT_MS;
+
+  return async (context) => {
+    const now = context.now ?? Date.now;
+    // Step 1: transport availability gate (same as the 2b stub semantics).
+    const gateResult = await transportAvailabilityHealthExecutor(context);
+    if (!gateResult.passed) return gateResult;
+
+    // Step 2: only `cliProbe` declarations get a real spawn. `acpInitialize`
+    // and any future type fall through to the transport-availability result.
+    if (context.resource.healthCheck?.type !== 'cliProbe') return gateResult;
+
+    // Step 3: bounded spawn + exit-code check.
+    return new Promise<AgentProviderHealthResult>((resolve) => {
+      const spawnOptions: SpawnOptions = {
+        cwd: tmpdir(),
+        // Minimal env: PATH only. We do NOT inherit cat-cafe callback / MCP
+        // credentials into a health probe — the probe must not be able to do
+        // anything meaningful with the runtime env. PATH is required so a
+        // bare command like `clowder-code` (npm-linked) still resolves.
+        env: { PATH: process.env.PATH ?? '' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      };
+      let child: ChildProcess;
+      try {
+        child = spawnFn(context.resource.command, ['--version'], spawnOptions);
+      } catch (err) {
+        resolve({
+          passed: false,
+          checkedAt: now(),
+          ttlMs: DEFAULT_HEALTH_TTL_MS,
+          descriptorHash: context.descriptorHash,
+          failureReason: `cli-probe-spawn-error:${err instanceof Error ? err.message : String(err)}`,
+        });
+        return;
+      }
+
+      let settled = false;
+      const finalize = (result: AgentProviderHealthResult): void => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        if (!result.passed) {
+          // Best-effort cleanup so a hung probe doesn't outlive its own result.
+          try {
+            child.kill('SIGTERM');
+          } catch {
+            /* already dead */
+          }
+        }
+        resolve(result);
+      };
+
+      const timer = setTimeout(() => {
+        finalize({
+          passed: false,
+          checkedAt: now(),
+          ttlMs: DEFAULT_HEALTH_TTL_MS,
+          descriptorHash: context.descriptorHash,
+          failureReason: `cli-probe-timeout:${probeTimeoutMs}ms`,
+        });
+      }, probeTimeoutMs);
+
+      child.on('error', (err) => {
+        finalize({
+          passed: false,
+          checkedAt: now(),
+          ttlMs: DEFAULT_HEALTH_TTL_MS,
+          descriptorHash: context.descriptorHash,
+          failureReason: `cli-probe-spawn-error:${err.message}`,
+        });
+      });
+
+      child.on('exit', (code) => {
+        if (code === 0) {
+          finalize({
+            passed: true,
+            checkedAt: now(),
+            ttlMs: DEFAULT_HEALTH_TTL_MS,
+            descriptorHash: context.descriptorHash,
+          });
+        } else {
+          finalize({
+            passed: false,
+            checkedAt: now(),
+            ttlMs: DEFAULT_HEALTH_TTL_MS,
+            descriptorHash: context.descriptorHash,
+            failureReason: `cli-probe-nonzero-exit:${code}`,
+          });
+        }
+      });
+    });
+  };
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1192,7 +1192,11 @@ async function main(): Promise<void> {
       './domains/plugin/agent-provider-admission-snapshot.js'
     );
     const { refreshExpiredHealthInPlace } = await import('./domains/plugin/agent-provider-health-refresh.js');
-    const { transportAvailabilityHealthExecutor } = await import('./domains/plugin/agent-provider-health-executor.js');
+    const { createRealCliProbeHealthExecutor } = await import('./domains/plugin/agent-provider-health-executor.js');
+    // F241 Phase C — Real cliProbe (drop-in DI swap from the 2b transport-
+    // availability stub per F241 doc L340). The factory caches the spawnFn
+    // reference so the sync loop reuses the same instance for every refresh.
+    const realCliProbeExecutor = createRealCliProbeHealthExecutor();
     const { readCapabilitiesConfig: readCaps, writeCapabilitiesConfig: writeCaps } = await import(
       './config/capabilities/capability-orchestrator.js'
     );
@@ -1225,7 +1229,7 @@ async function main(): Promise<void> {
           capabilities: capabilitiesConfig,
           rows,
           now: () => Date.now(),
-          healthExecutor: transportAvailabilityHealthExecutor,
+          healthExecutor: realCliProbeExecutor,
           getHealthExecutorContext: () => ({
             providerTransportRegistry: { has: (id) => providerTransportRegistry.has(id) },
           }),
@@ -2462,6 +2466,13 @@ async function main(): Promise<void> {
     const { buildAgentProviderAdmissionSnapshot } = await import(
       './domains/plugin/agent-provider-admission-snapshot.js'
     );
+    // F241 Phase C — same real cliProbe executor for the approval orchestration
+    // path so operator-driven approve-routeable goes through the same probe
+    // semantics as background TTL refresh (no split-brain between sync paths).
+    const { createRealCliProbeHealthExecutor: createRealCliProbeForApproval } = await import(
+      './domains/plugin/agent-provider-health-executor.js'
+    );
+    const approvalCliProbeExecutor = createRealCliProbeForApproval();
     const agentProviderApprovalService = new AgentProviderApprovalService({
       readCapabilities: () => readCapabilitiesConfig(resolveActiveProjectRoot()),
       writeCapabilities: async (config) => {
@@ -2490,6 +2501,7 @@ async function main(): Promise<void> {
           candidateCapId: capId,
         });
       },
+      healthExecutor: approvalCliProbeExecutor,
       getHealthExecutorContext: () => ({
         providerTransportRegistry: { has: (id) => providerTransportRegistry.has(id) },
       }),

--- a/packages/api/test/agent-provider-health-executor.test.js
+++ b/packages/api/test/agent-provider-health-executor.test.js
@@ -1,0 +1,170 @@
+/**
+ * F241 Phase C — Real cliProbe health executor tests.
+ *
+ * Covers the bounded-spawn + exit-code semantics that replace the 2b
+ * transport-availability stub for `cliProbe`-declared resources. `acpInitialize`
+ * still falls through to transport-availability until F161 ACP carrier lands.
+ */
+
+import './helpers/setup-cat-registry.js';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { describe, it } from 'node:test';
+
+const { transportAvailabilityHealthExecutor, createRealCliProbeHealthExecutor, DEFAULT_HEALTH_TTL_MS } = await import(
+  '../dist/domains/plugin/agent-provider-health-executor.js'
+);
+
+const REGISTRY_HAS_CLI_JSONL = { has: (id) => id === 'cli-jsonl' };
+const REGISTRY_HAS_NOTHING = { has: () => false };
+
+function makeResource(overrides = {}) {
+  return {
+    name: 'clowder-code',
+    transport: 'cli-jsonl',
+    command: '/usr/bin/true',
+    startupArgs: ['--json'],
+    healthCheck: { type: 'cliProbe' },
+    ...overrides,
+  };
+}
+
+function makeContext(resourceOverrides = {}, registry = REGISTRY_HAS_CLI_JSONL) {
+  return {
+    resource: makeResource(resourceOverrides),
+    descriptorHash: 'hash-A',
+    providerTransportRegistry: registry,
+    now: () => 12_345,
+  };
+}
+
+/**
+ * Fake `spawn` returning a controllable ChildProcess-like emitter. The caller
+ * triggers `emit('exit', code)` / `emit('error', err)` to drive outcomes; the
+ * kill() recorder lets tests assert cleanup on timeout.
+ */
+function makeFakeSpawn() {
+  const calls = [];
+  const fakeSpawn = (command, args, opts) => {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    let killed = false;
+    child.kill = (signal) => {
+      killed = true;
+      child.lastKillSignal = signal;
+    };
+    Object.defineProperty(child, 'killed', { get: () => killed });
+    calls.push({ command, args, opts, child });
+    return child;
+  };
+  return { fakeSpawn, calls };
+}
+
+describe('transportAvailabilityHealthExecutor (regression — 2b stub still works)', () => {
+  it('passes when declared transport is registered', async () => {
+    const result = await transportAvailabilityHealthExecutor(makeContext());
+    assert.equal(result.passed, true);
+    assert.equal(result.descriptorHash, 'hash-A');
+    assert.equal(result.ttlMs, DEFAULT_HEALTH_TTL_MS);
+  });
+
+  it('fails when no healthCheck is declared', async () => {
+    const result = await transportAvailabilityHealthExecutor(makeContext({ healthCheck: undefined }));
+    assert.equal(result.passed, false);
+    assert.equal(result.failureReason, 'no-healthcheck-declared');
+  });
+
+  it('fails when the cliProbe-required transport is not registered', async () => {
+    const result = await transportAvailabilityHealthExecutor(makeContext({}, REGISTRY_HAS_NOTHING));
+    assert.equal(result.passed, false);
+    assert.match(result.failureReason, /transport-not-registered:cli-jsonl/);
+  });
+});
+
+describe('createRealCliProbeHealthExecutor — bounded spawn + exit-code check', () => {
+  it('passes when the spawned binary exits 0', async () => {
+    const { fakeSpawn, calls } = makeFakeSpawn();
+    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, probeTimeoutMs: 5_000 });
+    const promise = exec(makeContext());
+    // Drive the spawned process to exit 0.
+    setImmediate(() => calls[0].child.emit('exit', 0, null));
+    const result = await promise;
+    assert.equal(result.passed, true);
+    assert.equal(result.descriptorHash, 'hash-A');
+    assert.equal(result.ttlMs, DEFAULT_HEALTH_TTL_MS);
+    assert.equal(calls[0].command, '/usr/bin/true');
+    assert.deepEqual(calls[0].args, ['--version']);
+    assert.equal(calls[0].opts.stdio[0], 'ignore', 'cliProbe must not feed stdin');
+  });
+
+  it('fails with cli-probe-nonzero-exit when binary exits non-zero', async () => {
+    const { fakeSpawn, calls } = makeFakeSpawn();
+    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, probeTimeoutMs: 5_000 });
+    const promise = exec(makeContext());
+    setImmediate(() => calls[0].child.emit('exit', 7, null));
+    const result = await promise;
+    assert.equal(result.passed, false);
+    assert.equal(result.failureReason, 'cli-probe-nonzero-exit:7');
+  });
+
+  it('fails with cli-probe-spawn-error when child emits error', async () => {
+    const { fakeSpawn, calls } = makeFakeSpawn();
+    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, probeTimeoutMs: 5_000 });
+    const promise = exec(makeContext());
+    setImmediate(() => calls[0].child.emit('error', new Error('ENOENT: not found')));
+    const result = await promise;
+    assert.equal(result.passed, false);
+    assert.match(result.failureReason, /cli-probe-spawn-error:.*ENOENT/);
+  });
+
+  it('fails with cli-probe-timeout when probe exceeds bounded duration and kills child', async () => {
+    const { fakeSpawn, calls } = makeFakeSpawn();
+    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, probeTimeoutMs: 50 });
+    const promise = exec(makeContext());
+    const result = await promise;
+    assert.equal(result.passed, false);
+    assert.equal(result.failureReason, 'cli-probe-timeout:50ms');
+    assert.equal(calls[0].child.killed, true, 'lingering probe must be killed on timeout');
+    assert.equal(calls[0].child.lastKillSignal, 'SIGTERM');
+  });
+
+  it('skips spawn for acpInitialize (falls through to transport-availability)', async () => {
+    const { fakeSpawn, calls } = makeFakeSpawn();
+    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, probeTimeoutMs: 5_000 });
+    // acpInitialize requires ACP transport; use a registry that has it.
+    const ctx = makeContext({ transport: 'acp', healthCheck: { type: 'acpInitialize' } }, { has: (id) => id === 'acp' });
+    const result = await exec(ctx);
+    assert.equal(result.passed, true, 'acpInitialize uses transport-availability semantics for now');
+    assert.equal(calls.length, 0, 'no spawn should fire for acpInitialize');
+  });
+
+  it('fails fast (no spawn) when declared transport is not registered', async () => {
+    const { fakeSpawn, calls } = makeFakeSpawn();
+    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, probeTimeoutMs: 5_000 });
+    const result = await exec(makeContext({}, REGISTRY_HAS_NOTHING));
+    assert.equal(result.passed, false);
+    assert.match(result.failureReason, /transport-not-registered/);
+    assert.equal(calls.length, 0, 'no spawn should fire when transport is missing');
+  });
+
+  it('fails fast (no spawn) when no healthCheck is declared', async () => {
+    const { fakeSpawn, calls } = makeFakeSpawn();
+    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, probeTimeoutMs: 5_000 });
+    const result = await exec(makeContext({ healthCheck: undefined }));
+    assert.equal(result.passed, false);
+    assert.equal(result.failureReason, 'no-healthcheck-declared');
+    assert.equal(calls.length, 0);
+  });
+
+  it('only fires once — extra exit events after timeout do not double-resolve', async () => {
+    const { fakeSpawn, calls } = makeFakeSpawn();
+    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, probeTimeoutMs: 30 });
+    const promise = exec(makeContext());
+    const result = await promise;
+    // Now simulate the dead-but-not-yet-reaped child eventually emitting exit.
+    // The executor must already have settled; this should be a no-op.
+    calls[0].child.emit('exit', 0, null);
+    assert.equal(result.failureReason, 'cli-probe-timeout:30ms');
+  });
+});

--- a/packages/api/test/agent-provider-health-executor.test.js
+++ b/packages/api/test/agent-provider-health-executor.test.js
@@ -83,11 +83,30 @@ describe('transportAvailabilityHealthExecutor (regression — 2b stub still work
 });
 
 describe('createRealCliProbeHealthExecutor — bounded spawn + exit-code check', () => {
-  it('passes when the spawned binary exits 0', async () => {
+  /**
+   * Default test wiring: identity resolver (treats the declared command as
+   * the resolved absolute path) so unit tests are deterministic + offline.
+   * Production wires the real `resolveCliCommand` via the default factory.
+   */
+  const makeIdentityResolver = () => {
+    const seen = [];
+    const resolveFn = (command) => {
+      seen.push(command);
+      return command;
+    };
+    return { resolveFn, seen };
+  };
+
+  const buildExec = (probeTimeoutMs = 5_000, extra = {}) => {
     const { fakeSpawn, calls } = makeFakeSpawn();
-    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, probeTimeoutMs: 5_000 });
+    const { resolveFn, seen } = makeIdentityResolver();
+    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, resolveFn, probeTimeoutMs, ...extra });
+    return { exec, calls, resolverCalls: seen };
+  };
+
+  it('passes when the spawned binary exits 0', async () => {
+    const { exec, calls } = buildExec();
     const promise = exec(makeContext());
-    // Drive the spawned process to exit 0.
     setImmediate(() => calls[0].child.emit('exit', 0, null));
     const result = await promise;
     assert.equal(result.passed, true);
@@ -99,8 +118,7 @@ describe('createRealCliProbeHealthExecutor — bounded spawn + exit-code check',
   });
 
   it('fails with cli-probe-nonzero-exit when binary exits non-zero', async () => {
-    const { fakeSpawn, calls } = makeFakeSpawn();
-    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, probeTimeoutMs: 5_000 });
+    const { exec, calls } = buildExec();
     const promise = exec(makeContext());
     setImmediate(() => calls[0].child.emit('exit', 7, null));
     const result = await promise;
@@ -109,8 +127,7 @@ describe('createRealCliProbeHealthExecutor — bounded spawn + exit-code check',
   });
 
   it('fails with cli-probe-spawn-error when child emits error', async () => {
-    const { fakeSpawn, calls } = makeFakeSpawn();
-    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, probeTimeoutMs: 5_000 });
+    const { exec, calls } = buildExec();
     const promise = exec(makeContext());
     setImmediate(() => calls[0].child.emit('error', new Error('ENOENT: not found')));
     const result = await promise;
@@ -119,10 +136,8 @@ describe('createRealCliProbeHealthExecutor — bounded spawn + exit-code check',
   });
 
   it('fails with cli-probe-timeout when probe exceeds bounded duration and kills child', async () => {
-    const { fakeSpawn, calls } = makeFakeSpawn();
-    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, probeTimeoutMs: 50 });
-    const promise = exec(makeContext());
-    const result = await promise;
+    const { exec, calls } = buildExec(50);
+    const result = await exec(makeContext());
     assert.equal(result.passed, false);
     assert.equal(result.failureReason, 'cli-probe-timeout:50ms');
     assert.equal(calls[0].child.killed, true, 'lingering probe must be killed on timeout');
@@ -131,17 +146,23 @@ describe('createRealCliProbeHealthExecutor — bounded spawn + exit-code check',
 
   it('skips spawn for acpInitialize (falls through to transport-availability)', async () => {
     const { fakeSpawn, calls } = makeFakeSpawn();
-    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, probeTimeoutMs: 5_000 });
+    const { resolveFn, seen } = makeIdentityResolver();
+    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, resolveFn, probeTimeoutMs: 5_000 });
     // acpInitialize requires ACP transport; use a registry that has it.
-    const ctx = makeContext({ transport: 'acp', healthCheck: { type: 'acpInitialize' } }, { has: (id) => id === 'acp' });
+    const ctx = makeContext(
+      { transport: 'acp', healthCheck: { type: 'acpInitialize' } },
+      { has: (id) => id === 'acp' },
+    );
     const result = await exec(ctx);
     assert.equal(result.passed, true, 'acpInitialize uses transport-availability semantics for now');
     assert.equal(calls.length, 0, 'no spawn should fire for acpInitialize');
+    assert.equal(seen.length, 0, 'no resolve should fire for acpInitialize either');
   });
 
   it('fails fast (no spawn) when declared transport is not registered', async () => {
     const { fakeSpawn, calls } = makeFakeSpawn();
-    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, probeTimeoutMs: 5_000 });
+    const { resolveFn } = makeIdentityResolver();
+    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, resolveFn, probeTimeoutMs: 5_000 });
     const result = await exec(makeContext({}, REGISTRY_HAS_NOTHING));
     assert.equal(result.passed, false);
     assert.match(result.failureReason, /transport-not-registered/);
@@ -150,7 +171,8 @@ describe('createRealCliProbeHealthExecutor — bounded spawn + exit-code check',
 
   it('fails fast (no spawn) when no healthCheck is declared', async () => {
     const { fakeSpawn, calls } = makeFakeSpawn();
-    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, probeTimeoutMs: 5_000 });
+    const { resolveFn } = makeIdentityResolver();
+    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, resolveFn, probeTimeoutMs: 5_000 });
     const result = await exec(makeContext({ healthCheck: undefined }));
     assert.equal(result.passed, false);
     assert.equal(result.failureReason, 'no-healthcheck-declared');
@@ -158,13 +180,44 @@ describe('createRealCliProbeHealthExecutor — bounded spawn + exit-code check',
   });
 
   it('only fires once — extra exit events after timeout do not double-resolve', async () => {
-    const { fakeSpawn, calls } = makeFakeSpawn();
-    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, probeTimeoutMs: 30 });
-    const promise = exec(makeContext());
-    const result = await promise;
+    const { exec, calls } = buildExec(30);
+    const result = await exec(makeContext());
     // Now simulate the dead-but-not-yet-reaped child eventually emitting exit.
     // The executor must already have settled; this should be a no-op.
     calls[0].child.emit('exit', 0, null);
     assert.equal(result.failureReason, 'cli-probe-timeout:30ms');
+  });
+
+  /**
+   * P2 review @codex on PR #38: probe MUST resolve the command with the same
+   * resolver the real cli-jsonl invocation uses, or approve / invoke split-brain
+   * when the binary lives outside $PATH (~/.local/bin, nvm version dirs, etc.).
+   * These two tests lock in the new contract.
+   */
+  it('uses resolveFn to map the manifest command to an absolute path before spawning', async () => {
+    const { fakeSpawn, calls } = makeFakeSpawn();
+    const resolveFn = (command) => {
+      assert.equal(command, 'clowder-code', 'resolver must see the raw manifest command');
+      return '/home/user/.local/bin/clowder-code';
+    };
+    const exec = createRealCliProbeHealthExecutor({ spawnFn: fakeSpawn, resolveFn, probeTimeoutMs: 5_000 });
+    const promise = exec(makeContext({ command: 'clowder-code' }));
+    setImmediate(() => calls[0].child.emit('exit', 0, null));
+    const result = await promise;
+    assert.equal(result.passed, true);
+    assert.equal(calls[0].command, '/home/user/.local/bin/clowder-code', 'spawn must use the resolved path');
+  });
+
+  it('fails with cli-probe-cli-not-found (no spawn) when resolver returns null', async () => {
+    const { fakeSpawn, calls } = makeFakeSpawn();
+    const exec = createRealCliProbeHealthExecutor({
+      spawnFn: fakeSpawn,
+      resolveFn: () => null,
+      probeTimeoutMs: 5_000,
+    });
+    const result = await exec(makeContext({ command: 'never-installed-cli' }));
+    assert.equal(result.passed, false);
+    assert.equal(result.failureReason, 'cli-probe-cli-not-found:never-installed-cli');
+    assert.equal(calls.length, 0, 'no spawn should fire when the binary cannot be resolved');
   });
 });


### PR DESCRIPTION
## Summary
- F241 Phase C 2c hardening: replace the 2b transport-availability stub with a real `cliProbe` health executor (bounded spawn of `command --version` + exit-code check + timeout cleanup).
- Wires the new executor into both `syncAgentRegistry` background refresh AND `AgentProviderApprovalService` operator approval — no split-brain between sync paths.
- 11 new unit tests + 0 regressions across 121 F241-related tests.

## Why
F241 doc § 2b L340 explicitly defers this as "drop-in DI swap, no further redesign needed". Under the 2b stub, `health.passed=true` even when the declared `command` doesn't exist / crashes / hangs — operator gets `routeable=true` for a binary that never actually runs. Phase C E2E in `thread_mqxva63tuebxj9sn` only worked because `clowder-code` happened to be a valid binary path; a typo / missing binary today silently approves and surfaces as a much later invocation timeout instead of an approve-time failure.

## What changed
**`packages/api/src/domains/plugin/agent-provider-health-executor.ts`**
- New `createRealCliProbeHealthExecutor({ spawnFn?, probeTimeoutMs? })` factory.
- Layered: transport-availability gate first (same stub semantics on missing transport / no `healthCheck`), then for `cliProbe`-declared resources spawn `command --version` with bounded timeout (default 10s), PATH-only env, `cwd=os.tmpdir()`, `stdin=ignore`. `acpInitialize` falls through to transport-availability — ACP carrier (F161 PR #899) owns the real handshake when it lands.
- Failure reasons are stable strings: `cli-probe-nonzero-exit:N`, `cli-probe-spawn-error:<msg>`, `cli-probe-timeout:Nms`.
- Lingering probe is SIGTERM'd on timeout so no zombie spawn outlives its own result.

**`packages/api/src/index.ts`**
- Replaces `transportAvailabilityHealthExecutor` with `createRealCliProbeHealthExecutor()` in `syncAgentRegistry` (background refresh) AND adds `healthExecutor: approvalCliProbeExecutor` to the `AgentProviderApprovalService` construction so operator-driven approve-routeable goes through the same probe semantics.

**`packages/api/test/agent-provider-health-executor.test.js` (new, 11 tests)**
- transportAvailabilityHealthExecutor regression (3): passed / no healthCheck / transport unregistered
- createRealCliProbeHealthExecutor (8): exit 0 = passed, non-zero exit, spawn error, timeout + SIGTERM cleanup, acpInitialize skips spawn, transport-missing fast-fail (no spawn), no-healthCheck fast-fail (no spawn), no double-resolve on late-arriving exit events

## Observable behavior change
A misconfigured manifest where `command:` points at a missing/broken binary now fails `POST /api/plugins/:id/capabilities/:capId/approve-routeable` with HTTP 422 + structured `failureReason` (operator-visible), instead of silently approving and surfacing as an invocation hang later when a user `@`s the cat.

## Design choices
- **Probe argv = `--version`** (standard CLI convention, fast-exit, no side effects, no stdin / credentials needed). Future runtime needing a different probe → extend `healthCheck` schema with optional `probeArgs` (separate 2c follow-on; reference runtime covered by `--version` today; clowder-code `--version` verified takes < 1s).
- **Probe env = `{ PATH }`** only. The health probe must NOT inherit cat-cafe callback / MCP credentials — it's a liveness check, not a real invocation. PATH required so npm-linked bare command resolves.
- **DI swap, not config flag.** The 2b stub stays in the module (other deployments / tests can still use it). Production wiring is the only opinion change.

## Test plan
- [x] `node --test packages/api/test/agent-provider-health-executor.test.js` → 11/11 pass
- [x] Regression: `node --test packages/api/test/agent-provider*.test.js cli-jsonl*.test.js routing-admission-service.test.js plugin-agent-provider*.test.js l0-compiler.test.js` → 121/121 pass
- [x] `pnpm --filter @cat-cafe/api run build` clean
- [ ] Manual E2E after merge: pull, restart API, re-trigger `@clowder-cat` in `thread_mqxva63tuebxj9sn`, confirm probe runs at approve time (not just at invocation), observe new `failureReason` on a deliberately-broken `command:` (separate manual verification step)

## Phase C scope this PR closes
F241 doc Phase C acceptance criterion "session chain, audit, **cancel, timeout, and failure states are inspectable**" — failure states for the health probe path are now structured + operator-visible. Cancel/timeout for invocation itself live in `cli-spawn.ts` (already shipped). Audit lives in `plugin-routes.ts` `approve-routeable` handler (already shipped).

## Remaining F241 Phase C work (not in this PR)
- F241 2c PR-B: manifest `providerId / displayName / mentionPatterns` claim fields (currently operator-only at approve time)
- F241 Phase C Hub UI for owner approval (currently host-internal HTTP only; per 2b design notes "Hub admin UI is Phase C scope")
- F241 completion audit + close

## Review request
**@codex (cross-family)** — cross-family review per shared-rules.md. Particular focus appreciated on: probe timeout default (10s) sufficient for cold-cache filesystems? `--version` assumption for future plugins (acceptable until `probeArgs` extension)? Env stripping behavior (PATH-only) right tradeoff?

🤖 Generated with [Claude Code](https://claude.com/claude-code)