### PR TITLE
feat(F241 Phase C 2c): manifest identity claim fields + descriptor hash v2

### DIFF
--- a/packages/api/src/domains/plugin/agent-provider-descriptor-hash.ts
+++ b/packages/api/src/domains/plugin/agent-provider-descriptor-hash.ts
@@ -44,13 +44,24 @@ export interface AgentProviderDescriptorHashInputs {
  *   - All keys appear in a fixed order via the explicit object literal below.
  *   - Optional fields are normalized to `null` (never omitted) so absence vs.
  *     presence is distinguishable from "field missing on read".
- *   - Array fields with set-semantics (e.g. `mcpWhitelistRequest`) are sorted.
- *     Positional arrays (`startupArgs`, `resumeArgs`) preserve insertion order.
+ *   - Array fields with set-semantics (e.g. `mcpWhitelistRequest`,
+ *     `mentionPatterns`) are sorted. Positional arrays (`startupArgs`,
+ *     `resumeArgs`) preserve insertion order.
+ *
+ * Versioning: `v` is bumped whenever the canonical input shape changes. A
+ * descriptor stored under `v: N-1` MUST NOT collide with the same descriptor
+ * under `v: N` so that older approvals are invalidated by the activator
+ * when the runtime is upgraded.
+ *
+ * Version history:
+ *   - v: 1 (2b shipped) — original 2b inputs.
+ *   - v: 2 (2c manifest identity claims) — adds `providerId / displayName /
+ *     mentionPatterns` so any claim change forces re-approval.
  */
 export function computeAgentProviderDescriptorHash(inputs: AgentProviderDescriptorHashInputs): string {
   const r = inputs.resource;
   const canonical = {
-    v: 1 as const,
+    v: 2 as const,
     pluginId: inputs.pluginId,
     capId: inputs.capId,
     transport: r.transport,
@@ -63,6 +74,12 @@ export function computeAgentProviderDescriptorHash(inputs: AgentProviderDescript
     mcpWhitelistRequest: r.mcpWhitelistRequest ? [...r.mcpWhitelistRequest].slice().sort() : null,
     sandboxRequest: r.sandboxRequest ?? null,
     healthCheck: r.healthCheck ?? null,
+    // F241 Phase C 2c — Manifest identity claims feed the hash so any claim
+    // change forces re-approval (operator must re-confirm the new identity
+    // claim). Per F241 doc § Phase B 2b "Routeable identity ownership".
+    providerId: r.providerId ?? null,
+    displayName: r.displayName ?? null,
+    mentionPatterns: r.mentionPatterns ? [...r.mentionPatterns].slice().sort() : null,
     pluginFingerprint: inputs.pluginFingerprint ?? null,
   };
   return createHash('sha256').update(JSON.stringify(canonical)).digest('hex');

--- a/packages/api/src/domains/plugin/agent-provider-manifest.ts
+++ b/packages/api/src/domains/plugin/agent-provider-manifest.ts
@@ -181,6 +181,12 @@ function parseAgentProviderMentionPatterns(value: unknown, yamlPath: string): st
     );
   }
   const patterns: string[] = [];
+  // P2 review (@codex on PR #39): runtime mention matching is case-insensitive
+  // (CatConfig side normalizes lowercased), so duplicates must be detected on
+  // the lowercased form — otherwise `@clowder` and `@Clowder` slip through the
+  // parser but collide downstream. Sibling check below: reject bare `@` (must
+  // have at least one name character after the prefix per the `@name` contract).
+  const seenLowercased = new Set<string>();
   for (const entry of value) {
     if (typeof entry !== 'string' || entry.trim().length === 0) {
       throw new Error(`Invalid agentProvider mentionPattern in ${yamlPath}: each entry must be a non-empty string`);
@@ -189,13 +195,22 @@ function parseAgentProviderMentionPatterns(value: unknown, yamlPath: string): st
     if (!trimmed.startsWith('@')) {
       throw new Error(`Invalid agentProvider mentionPattern '${trimmed}' in ${yamlPath}: must start with '@'`);
     }
+    if (trimmed.length < 2) {
+      throw new Error(
+        `Invalid agentProvider mentionPattern '${trimmed}' in ${yamlPath}: must have at least one character after '@'`,
+      );
+    }
     if (/\s/.test(trimmed)) {
       throw new Error(`Invalid agentProvider mentionPattern '${trimmed}' in ${yamlPath}: must not contain whitespace`);
     }
+    const lowered = trimmed.toLowerCase();
+    if (seenLowercased.has(lowered)) {
+      throw new Error(
+        `Invalid agentProvider mentionPatterns in ${yamlPath}: duplicate entries are not allowed (case-insensitive match on '${trimmed}')`,
+      );
+    }
+    seenLowercased.add(lowered);
     patterns.push(trimmed);
-  }
-  if (new Set(patterns).size !== patterns.length) {
-    throw new Error(`Invalid agentProvider mentionPatterns in ${yamlPath}: duplicate entries are not allowed`);
   }
   return patterns;
 }

--- a/packages/api/src/domains/plugin/agent-provider-manifest.ts
+++ b/packages/api/src/domains/plugin/agent-provider-manifest.ts
@@ -151,6 +151,55 @@ function parseAgentProviderSandboxRequest(
   return value as AgentProviderResource['sandboxRequest'];
 }
 
+function parseAgentProviderProviderId(value: unknown, yamlPath: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`Invalid agentProvider providerId in ${yamlPath}: must be a non-empty string`);
+  }
+  const trimmed = value.trim();
+  if (/[/\\]/.test(trimmed)) {
+    throw new Error(
+      `Invalid agentProvider providerId '${trimmed}' in ${yamlPath}: must not contain path separators (/ or \\)`,
+    );
+  }
+  return trimmed;
+}
+
+function parseAgentProviderDisplayName(value: unknown, yamlPath: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`Invalid agentProvider displayName in ${yamlPath}: must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function parseAgentProviderMentionPatterns(value: unknown, yamlPath: string): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(
+      `Invalid agentProvider mentionPatterns in ${yamlPath}: must be a non-empty array of '@name' strings`,
+    );
+  }
+  const patterns: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== 'string' || entry.trim().length === 0) {
+      throw new Error(`Invalid agentProvider mentionPattern in ${yamlPath}: each entry must be a non-empty string`);
+    }
+    const trimmed = entry.trim();
+    if (!trimmed.startsWith('@')) {
+      throw new Error(`Invalid agentProvider mentionPattern '${trimmed}' in ${yamlPath}: must start with '@'`);
+    }
+    if (/\s/.test(trimmed)) {
+      throw new Error(`Invalid agentProvider mentionPattern '${trimmed}' in ${yamlPath}: must not contain whitespace`);
+    }
+    patterns.push(trimmed);
+  }
+  if (new Set(patterns).size !== patterns.length) {
+    throw new Error(`Invalid agentProvider mentionPatterns in ${yamlPath}: duplicate entries are not allowed`);
+  }
+  return patterns;
+}
+
 export function parseAgentProviderResource(
   raw: Record<string, unknown>,
   name: string | undefined,
@@ -171,6 +220,14 @@ export function parseAgentProviderResource(
   const mcpWhitelistRequest = parseAgentProviderMcpWhitelistRequest(raw.mcpWhitelist, yamlPath);
   const sandboxRequest = parseAgentProviderSandboxRequest(raw.sandbox, yamlPath);
   const healthCheck = parseAgentProviderHealthCheck(raw.healthCheck, yamlPath);
+  // F241 Phase C 2c — Optional manifest identity claims.
+  // Pure schema additions: they feed the descriptor hash (any change forces
+  // re-approval) and become available for Hub UI pre-fill, but do NOT bypass
+  // admission or auto-promote routeability — host-owned `routeableBinding`
+  // remains the only routing truth source.
+  const providerId = parseAgentProviderProviderId(raw.providerId, yamlPath);
+  const displayName = parseAgentProviderDisplayName(raw.displayName, yamlPath);
+  const mentionPatterns = parseAgentProviderMentionPatterns(raw.mentionPatterns, yamlPath);
 
   return {
     name,
@@ -182,5 +239,8 @@ export function parseAgentProviderResource(
     ...(mcpWhitelistRequest ? { mcpWhitelistRequest } : {}),
     ...(sandboxRequest ? { sandboxRequest } : {}),
     ...(healthCheck ? { healthCheck } : {}),
+    ...(providerId ? { providerId } : {}),
+    ...(displayName ? { displayName } : {}),
+    ...(mentionPatterns ? { mentionPatterns } : {}),
   };
 }

--- a/packages/api/test/agent-provider-descriptor-hash.test.js
+++ b/packages/api/test/agent-provider-descriptor-hash.test.js
@@ -77,6 +77,11 @@ describe('computeAgentProviderDescriptorHash — sensitivity (every input matter
     ['sandboxRequest', { resource: { sandboxRequest: 'workspace-read' } }],
     ['healthCheck type', { resource: { healthCheck: { type: 'acpInitialize' } } }],
     ['pluginFingerprint added', { pluginFingerprint: 'sha256:abc' }],
+    // F241 Phase C 2c — manifest identity claims feed the hash so any claim
+    // change forces re-approval.
+    ['providerId added', { resource: { providerId: 'clowder-code' } }],
+    ['displayName added', { resource: { displayName: 'Clowder Code' } }],
+    ['mentionPatterns added', { resource: { mentionPatterns: ['@clowder'] } }],
   ];
 
   for (const [label, override] of mutations) {
@@ -91,5 +96,45 @@ describe('computeAgentProviderDescriptorHash — sensitivity (every input matter
     const withPolicy = computeAgentProviderDescriptorHash(makeInputs({ resource: { sessionPolicy: 'resume' } }));
     const noPolicy = computeAgentProviderDescriptorHash(makeInputs({ resource: { sessionPolicy: undefined } }));
     assert.notEqual(withPolicy, noPolicy);
+  });
+
+  it('mentionPatterns hash is order-insensitive (set semantics)', () => {
+    const ascending = computeAgentProviderDescriptorHash(
+      makeInputs({ resource: { mentionPatterns: ['@a', '@b', '@c'] } }),
+    );
+    const descending = computeAgentProviderDescriptorHash(
+      makeInputs({ resource: { mentionPatterns: ['@c', '@b', '@a'] } }),
+    );
+    assert.equal(ascending, descending, 'mentionPatterns is a set; insertion order must not change the hash');
+  });
+
+  it('v: 2 hash differs from a pre-2c v: 1 hash for the same inputs (version-bump invalidates old approvals)', async () => {
+    // Recompute the v: 1 canonical shape that 2b shipped — same inputs minus
+    // the new identity-claim fields, with v: 1 in the version slot. If the
+    // production hash equals this, the version bump didn't take effect and
+    // operators upgrading from 2b would have their old approvals silently
+    // inherited under the new shape (bypassing the re-approval invariant).
+    const inputs = makeInputs();
+    const v1Canonical = {
+      v: 1,
+      pluginId: inputs.pluginId,
+      capId: inputs.capId,
+      transport: inputs.resource.transport,
+      command: inputs.resource.command,
+      startupArgs: [...inputs.resource.startupArgs],
+      resumeArgs: inputs.resource.resumeArgs ? [...inputs.resource.resumeArgs] : null,
+      sessionPolicy: inputs.resource.sessionPolicy ?? null,
+      outputProfile: inputs.resource.outputProfile ?? null,
+      timeoutMs: inputs.resource.timeoutMs ?? null,
+      mcpWhitelistRequest: inputs.resource.mcpWhitelistRequest
+        ? [...inputs.resource.mcpWhitelistRequest].slice().sort()
+        : null,
+      sandboxRequest: inputs.resource.sandboxRequest ?? null,
+      healthCheck: inputs.resource.healthCheck ?? null,
+      pluginFingerprint: inputs.pluginFingerprint ?? null,
+    };
+    const { createHash } = await import('node:crypto');
+    const v1Hash = createHash('sha256').update(JSON.stringify(v1Canonical)).digest('hex');
+    assert.notEqual(baseline, v1Hash, 'v: 2 must produce a different hash than v: 1 for the same descriptor inputs');
   });
 });

--- a/packages/api/test/plugin-manifest-safety.test.js
+++ b/packages/api/test/plugin-manifest-safety.test.js
@@ -371,6 +371,159 @@ describe('parsePluginManifest security', () => {
     assert.throws(() => parsePluginManifest(yamlPath), /agentProvider transport/);
   });
 
+  it('parses optional F241 2c identity-claim fields (providerId / displayName / mentionPatterns)', () => {
+    tmpDir = mkdtempSync(join(os.tmpdir(), 'plugin-test-'));
+    const yamlPath = writeTmpManifest(
+      tmpDir,
+      'clowder-code',
+      [
+        'id: clowder-code',
+        'name: Clowder Code',
+        'version: 1.0.0',
+        'resources:',
+        '  - type: agentProvider',
+        '    name: clowder-code',
+        '    transport: cli-jsonl',
+        '    command: clowder-code',
+        '    startupArgs: ["--json"]',
+        '    sessionPolicy: stateless',
+        '    outputProfile: clowder-code-turn-result-v1',
+        '    providerId: clowder-code',
+        '    displayName: Clowder Code',
+        '    mentionPatterns:',
+        '      - "@clowder"',
+        '      - "@clowder-code"',
+      ].join('\n'),
+    );
+    const manifest = parsePluginManifest(yamlPath);
+    const ap = manifest.resources[0].agentProvider;
+    assert.equal(ap.providerId, 'clowder-code');
+    assert.equal(ap.displayName, 'Clowder Code');
+    assert.deepEqual(ap.mentionPatterns, ['@clowder', '@clowder-code']);
+  });
+
+  it('omits F241 2c identity-claim fields when not declared (backward-compat with 2b manifests)', () => {
+    tmpDir = mkdtempSync(join(os.tmpdir(), 'plugin-test-'));
+    const yamlPath = writeTmpManifest(
+      tmpDir,
+      'clowder-code',
+      [
+        'id: clowder-code',
+        'name: Clowder Code',
+        'version: 1.0.0',
+        'resources:',
+        '  - type: agentProvider',
+        '    name: clowder-code',
+        '    transport: cli-jsonl',
+        '    command: clowder-code',
+        '    startupArgs: ["--json"]',
+        '    sessionPolicy: stateless',
+        '    outputProfile: clowder-code-turn-result-v1',
+      ].join('\n'),
+    );
+    const manifest = parsePluginManifest(yamlPath);
+    const ap = manifest.resources[0].agentProvider;
+    assert.equal(ap.providerId, undefined);
+    assert.equal(ap.displayName, undefined);
+    assert.equal(ap.mentionPatterns, undefined);
+  });
+
+  it('rejects agentProvider mentionPattern that does not start with @', () => {
+    tmpDir = mkdtempSync(join(os.tmpdir(), 'plugin-test-'));
+    const yamlPath = writeTmpManifest(
+      tmpDir,
+      'clowder-code',
+      [
+        'id: clowder-code',
+        'name: Clowder Code',
+        'version: 1.0.0',
+        'resources:',
+        '  - type: agentProvider',
+        '    name: clowder-code',
+        '    transport: cli-jsonl',
+        '    command: clowder-code',
+        '    startupArgs: ["--json"]',
+        '    sessionPolicy: stateless',
+        '    outputProfile: clowder-code-turn-result-v1',
+        '    mentionPatterns:',
+        '      - clowder',
+      ].join('\n'),
+    );
+    assert.throws(() => parsePluginManifest(yamlPath), /must start with '@'/);
+  });
+
+  it('rejects agentProvider mentionPattern that contains whitespace', () => {
+    tmpDir = mkdtempSync(join(os.tmpdir(), 'plugin-test-'));
+    const yamlPath = writeTmpManifest(
+      tmpDir,
+      'clowder-code',
+      [
+        'id: clowder-code',
+        'name: Clowder Code',
+        'version: 1.0.0',
+        'resources:',
+        '  - type: agentProvider',
+        '    name: clowder-code',
+        '    transport: cli-jsonl',
+        '    command: clowder-code',
+        '    startupArgs: ["--json"]',
+        '    sessionPolicy: stateless',
+        '    outputProfile: clowder-code-turn-result-v1',
+        '    mentionPatterns:',
+        '      - "@with space"',
+      ].join('\n'),
+    );
+    assert.throws(() => parsePluginManifest(yamlPath), /must not contain whitespace/);
+  });
+
+  it('rejects agentProvider providerId with path separators (reserved namespace shape)', () => {
+    tmpDir = mkdtempSync(join(os.tmpdir(), 'plugin-test-'));
+    const yamlPath = writeTmpManifest(
+      tmpDir,
+      'clowder-code',
+      [
+        'id: clowder-code',
+        'name: Clowder Code',
+        'version: 1.0.0',
+        'resources:',
+        '  - type: agentProvider',
+        '    name: clowder-code',
+        '    transport: cli-jsonl',
+        '    command: clowder-code',
+        '    startupArgs: ["--json"]',
+        '    sessionPolicy: stateless',
+        '    outputProfile: clowder-code-turn-result-v1',
+        '    providerId: namespaced/id',
+      ].join('\n'),
+    );
+    assert.throws(() => parsePluginManifest(yamlPath), /must not contain path separators/);
+  });
+
+  it('rejects agentProvider with duplicate mentionPatterns', () => {
+    tmpDir = mkdtempSync(join(os.tmpdir(), 'plugin-test-'));
+    const yamlPath = writeTmpManifest(
+      tmpDir,
+      'clowder-code',
+      [
+        'id: clowder-code',
+        'name: Clowder Code',
+        'version: 1.0.0',
+        'resources:',
+        '  - type: agentProvider',
+        '    name: clowder-code',
+        '    transport: cli-jsonl',
+        '    command: clowder-code',
+        '    startupArgs: ["--json"]',
+        '    sessionPolicy: stateless',
+        '    outputProfile: clowder-code-turn-result-v1',
+        '    mentionPatterns:',
+        '      - "@dup"',
+        '      - "@dup"',
+      ].join('\n'),
+    );
+    assert.throws(() => parsePluginManifest(yamlPath), /duplicate entries are not allowed/);
+  });
+
   it('rejects agentProvider with negative timeoutMs', () => {
     tmpDir = mkdtempSync(join(os.tmpdir(), 'plugin-test-'));
     const yamlPath = writeTmpManifest(

--- a/packages/api/test/plugin-manifest-safety.test.js
+++ b/packages/api/test/plugin-manifest-safety.test.js
@@ -524,6 +524,61 @@ describe('parsePluginManifest security', () => {
     assert.throws(() => parsePluginManifest(yamlPath), /duplicate entries are not allowed/);
   });
 
+  // P2 review (@codex on PR #39): runtime mention matching is case-insensitive,
+  // so `@clowder` and `@Clowder` are runtime-equivalent. Parser must reject them
+  // at the schema gate or operators get a non-obvious admission collision later.
+  it('rejects agentProvider mentionPatterns that differ only by case (case-insensitive duplicate)', () => {
+    tmpDir = mkdtempSync(join(os.tmpdir(), 'plugin-test-'));
+    const yamlPath = writeTmpManifest(
+      tmpDir,
+      'clowder-code',
+      [
+        'id: clowder-code',
+        'name: Clowder Code',
+        'version: 1.0.0',
+        'resources:',
+        '  - type: agentProvider',
+        '    name: clowder-code',
+        '    transport: cli-jsonl',
+        '    command: clowder-code',
+        '    startupArgs: ["--json"]',
+        '    sessionPolicy: stateless',
+        '    outputProfile: clowder-code-turn-result-v1',
+        '    mentionPatterns:',
+        '      - "@clowder"',
+        '      - "@Clowder"',
+      ].join('\n'),
+    );
+    assert.throws(() => parsePluginManifest(yamlPath), /case-insensitive match/);
+  });
+
+  // P2 review (@codex on PR #39): the `@name` contract requires at least one
+  // character after the `@` prefix. A bare `@` would otherwise pass startsWith
+  // + non-empty checks but be meaningless to the routing layer.
+  it('rejects agentProvider mentionPattern that is just "@"', () => {
+    tmpDir = mkdtempSync(join(os.tmpdir(), 'plugin-test-'));
+    const yamlPath = writeTmpManifest(
+      tmpDir,
+      'clowder-code',
+      [
+        'id: clowder-code',
+        'name: Clowder Code',
+        'version: 1.0.0',
+        'resources:',
+        '  - type: agentProvider',
+        '    name: clowder-code',
+        '    transport: cli-jsonl',
+        '    command: clowder-code',
+        '    startupArgs: ["--json"]',
+        '    sessionPolicy: stateless',
+        '    outputProfile: clowder-code-turn-result-v1',
+        '    mentionPatterns:',
+        '      - "@"',
+      ].join('\n'),
+    );
+    assert.throws(() => parsePluginManifest(yamlPath), /at least one character after '@'/);
+  });
+
   it('rejects agentProvider with negative timeoutMs', () => {
     tmpDir = mkdtempSync(join(os.tmpdir(), 'plugin-test-'));
     const yamlPath = writeTmpManifest(

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -44,6 +44,28 @@ export interface PluginAgentProviderResource {
   /** Plugin-requested sandbox tier. Host policy decides the actual grant in later slices. */
   sandboxRequest?: AgentProviderSandboxRequest;
   healthCheck?: AgentProviderHealthCheckRequest;
+  /**
+   * F241 Phase C 2c — Manifest-declared identity claims.
+   *
+   * These are CLAIMS the plugin makes about how it would like to be routed.
+   * They do NOT bypass admission and they do NOT auto-promote routeability —
+   * the host-owned `routeableBinding` is still the only routing truth source
+   * (per F241 doc § Phase B 2b "Routeable identity ownership"). The operator's
+   * `approve-routeable` call may use these claims as form defaults / pre-fill,
+   * but ultimately writes its own catId/mentionPatterns into `routeableBinding`.
+   *
+   * All three feed `computeAgentProviderDescriptorHash` so any claim change
+   * forces re-approval (operator must re-confirm the new identity claim).
+   */
+
+  /** Suggested provider id (often used as the default catId by operator UX). Reserved namespace rules still apply. */
+  providerId?: string;
+
+  /** Human-readable label for Hub UI rendering. Defaults to `name` when absent. */
+  displayName?: string;
+
+  /** Suggested `@alias` patterns. Each entry MUST start with `@`. */
+  mentionPatterns?: string[];
 }
 
 /** Plugin resource declaration */


### PR DESCRIPTION
## Summary
F241 Phase C 2c follow-on: closes the schema gap for **manifest identity claims**. Extends `PluginAgentProviderResource` with optional `providerId / displayName / mentionPatterns`, parses + validates them, and bumps the descriptor hash to `v: 2` so any claim change forces re-approval (matches the existing descriptor-delta contract).

**Pure additive metadata** — no behavioral change to approve-routeable. Host-owned `routeableBinding` remains the only routing truth source. The fields are now ready for Hub UI for owner approval (Phase C) and any future "default catId-from-claim" UX.

## Why (F241 doc § Phase B 2b "Routeable identity ownership")
> Plugin manifest declares `providerId / displayName / mentionPatterns` as **claims**; host owns the actual binding record (`catId / @alias`) decoupled from manifest. Route resolver reads ONLY the host-owned binding — never the manifest resource directly.

2b shipped the host-owned binding side; this PR adds the manifest claim side. Without it, every approval requires operator guesswork or out-of-band documentation about what catId/mentionPatterns to use — plugin authors cannot publish their preferred identity in the manifest itself.

## What changed

**`packages/shared/src/types/plugin.ts`**
- `PluginAgentProviderResource` gains three optional fields:
  - `providerId?: string` — suggested provider id (often used as default catId by operator UX). Reserved namespace rules still apply.
  - `displayName?: string` — human-readable label for Hub UI rendering.
  - `mentionPatterns?: string[]` — suggested `@alias` patterns; each entry MUST start with `@`.
- Doc block at the type definition site spells out the "claim, not promotion" contract so future contributors don't accidentally route off manifest data.

**`packages/api/src/domains/plugin/agent-provider-manifest.ts`**
- Three new validating parser helpers (`parseAgentProviderProviderId`, `parseAgentProviderDisplayName`, `parseAgentProviderMentionPatterns`).
- Rejects: `mentionPattern` not starting with `@`, `mentionPattern` containing whitespace, `providerId` with path separators (reserved namespace shape), duplicate `mentionPatterns`, empty / non-array shapes.
- Backward-compat: all three fields are optional, so 2b manifests without them parse unchanged.

**`packages/api/src/domains/plugin/agent-provider-descriptor-hash.ts`**
- Bumps canonical version `v: 1` → `v: 2` and adds the three claim fields to the hash inputs.
- `mentionPatterns` is sorted in the canonical form (set semantics); positional arrays (`startupArgs`, `resumeArgs`) continue to preserve order.
- Comment block updated with version history (v: 1 = 2b shipped, v: 2 = 2c manifest claims).

## Behavior contract (intentionally restrained)
- Schema parse + descriptor hash now know about the claim fields.
- `agent-provider-projection.ts`, `agent-provider-approval-service.ts`, `RoutingAdmissionService.ts` are **NOT modified**. The approval handler still requires `body.catId`, ignores manifest claims. This PR is the schema-side foundation; the consuming side (Hub UI default-prefill, optional fallback-to-claim) is intentionally separate so each piece can be reviewed in isolation.

## Hash-version invalidation (operator-visible)
After upgrade from 2b, any existing routeable plugin agentProvider row will have its `descriptorHash` recomputed under `v: 2` on the next activator run. The hash differs from the old `v: 1` hash → activator resets `routeableApproved = false` + invalidates `health`. Operator must re-approve once. This matches the existing "descriptor delta forces re-approval" contract (F241 doc § Phase B 2b Design Notes — Descriptor hash).

## Test plan
- [x] `agent-provider-descriptor-hash.test.js` (12 → 16 tests):
  - `+ providerId added`, `+ displayName added`, `+ mentionPatterns added` sensitivity
  - `+ mentionPatterns hash is order-insensitive (set semantics)`
  - `+ v: 2 hash differs from a pre-2c v: 1 hash for the same inputs (version-bump invalidates old approvals)` — reconstructs the v: 1 canonical shape, asserts the production hash is different
- [x] `plugin-manifest-safety.test.js` (+6 tests):
  - `+ parses optional F241 2c identity-claim fields`
  - `+ omits F241 2c identity-claim fields when not declared (backward-compat with 2b manifests)`
  - `+ rejects agentProvider mentionPattern that does not start with @`
  - `+ rejects agentProvider mentionPattern that contains whitespace`
  - `+ rejects agentProvider providerId with path separators`
  - `+ rejects agentProvider with duplicate mentionPatterns`
- [x] F241 regression (`agent-provider*.test.js cli-jsonl*.test.js routing-admission-service.test.js plugin-agent-provider*.test.js plugin-manifest-safety.test.js l0-compiler.test.js`): 191/191 pass
- [x] `pnpm --filter @cat-cafe/api run build` clean
- [x] `biome check` clean on all touched files (a pre-existing `writeCallCount` warning in plugin-manifest-safety.test.js at line 1533 is from commit 9ac16836b / 2026-06-17, unrelated and out of this PR's scope)

## Coordinates with
- PR #38 (real cliProbe, awaiting @codex review) — independent change surface, both target develop. No conflicts (different files).
- F241 Phase C Hub UI for owner approval (follow-on) — will consume these claim fields as form defaults.

## Review request
**@codex (cross-family)** — cross-family review per shared-rules.md. Focus appreciated on: hash version bump strategy (force re-approval on upgrade — is the operator-visible churn acceptable?), claim-field validation rules (mentionPattern syntax checks correct?), backward-compat assertion thorough enough?

🤖 Generated with [Claude Code](https://claude.com/claude-code)