### PR TITLE
feat(F241 Phase C): Hub UI for owner approval of routeable agentProvider rows

### DIFF
--- a/packages/api/src/domains/plugin/PluginRegistry.ts
+++ b/packages/api/src/domains/plugin/PluginRegistry.ts
@@ -142,12 +142,17 @@ export class PluginRegistry {
         (c) =>
           c.pluginId === manifest.id && c.type === r.type && normalizeCapId(c.id) === resourceCapId(manifest.id, r),
       );
-      return {
+      const base: PluginResourceStatus = {
         type: r.type,
         path: r.path,
         name: r.name,
         enabled: capEntry?.enabled ?? false,
         ...(capEntry?.agentProvider?.state ? { agentProviderState: capEntry.agentProvider.state } : {}),
+      };
+      if (r.type !== 'agentProvider') return base;
+      return {
+        ...base,
+        ...buildAgentProviderResourceProjection(manifest.id, r, capEntry?.agentProvider),
       };
     });
 
@@ -168,6 +173,59 @@ export class PluginRegistry {
       hasHealthCheck: !!manifest.healthCheck?.limbCommand,
     };
   }
+}
+
+type AgentProviderCapDescriptor = NonNullable<CapabilitiesConfig['capabilities'][number]['agentProvider']>;
+type AgentProviderResource = NonNullable<PluginManifest['resources'][number]['agentProvider']>;
+
+/** Project host-owned routeable + binding state from the persisted capability row. */
+function projectHostOwnedAgentProviderFields(
+  ap: AgentProviderCapDescriptor | undefined,
+): Partial<PluginResourceStatus> {
+  if (!ap) return {};
+  const out: Partial<PluginResourceStatus> = {};
+  if (typeof ap.routeable === 'boolean') out.agentProviderRouteable = ap.routeable;
+  if (typeof ap.routeableApproved === 'boolean') out.agentProviderRouteableApproved = ap.routeableApproved;
+  if (ap.routeableBinding) {
+    const b = ap.routeableBinding;
+    out.agentProviderBinding = {
+      catId: b.catId,
+      ...(b.profileId ? { profileId: b.profileId } : {}),
+      ...(b.mentionPatterns ? { mentionPatterns: [...b.mentionPatterns] } : {}),
+    };
+  }
+  if (ap.descriptorHash) out.agentProviderDescriptorHash = ap.descriptorHash;
+  if (ap.health?.passed === false && ap.health.failureReason) {
+    out.agentProviderHealthFailureReason = ap.health.failureReason;
+  }
+  return out;
+}
+
+/** Project manifest-declared identity claims (PR #39) — Hub UI uses these as form defaults. */
+function projectAgentProviderClaims(c: AgentProviderResource | undefined): Partial<PluginResourceStatus> {
+  if (!c) return {};
+  const claims = {
+    ...(c.providerId ? { providerId: c.providerId } : {}),
+    ...(c.displayName ? { displayName: c.displayName } : {}),
+    ...(c.mentionPatterns ? { mentionPatterns: [...c.mentionPatterns] } : {}),
+  };
+  return Object.keys(claims).length > 0 ? { agentProviderClaims: claims } : {};
+}
+
+/**
+ * F241 Phase C — Compose the agentProvider extension fields for `PluginResourceStatus`.
+ * Pure: never touches `base`, just returns the additional fields to merge.
+ */
+function buildAgentProviderResourceProjection(
+  pluginId: string,
+  resource: PluginManifest['resources'][number],
+  ap: AgentProviderCapDescriptor | undefined,
+): Partial<PluginResourceStatus> {
+  return {
+    capId: resourceCapId(pluginId, resource),
+    ...projectHostOwnedAgentProviderFields(ap),
+    ...projectAgentProviderClaims(resource.agentProvider),
+  };
 }
 
 export function resourceCapId(pluginId: string, resource: { type: string; path?: string; name?: string }): string {

--- a/packages/api/src/domains/plugin/PluginRegistry.ts
+++ b/packages/api/src/domains/plugin/PluginRegistry.ts
@@ -198,6 +198,17 @@ function projectHostOwnedAgentProviderFields(
   if (ap.health?.passed === false && ap.health.failureReason) {
     out.agentProviderHealthFailureReason = ap.health.failureReason;
   }
+  // F241 Phase C (PR #42 round-1 review @codex P2): surface persisted sync
+  // failure separately from health probe failure. Sync failures fire AFTER
+  // approval + health both pass, during the Step 6 AgentRegistry projection
+  // (post-approval sync hook). Without this, the Hub renders
+  // `approved=true / healthy / routeable=false` with no inline explanation.
+  if (ap.lastSyncError) {
+    out.agentProviderLastSyncError = {
+      message: ap.lastSyncError.message,
+      occurredAt: ap.lastSyncError.occurredAt,
+    };
+  }
   return out;
 }
 

--- a/packages/api/test/plugin-registry-agent-provider-info.test.js
+++ b/packages/api/test/plugin-registry-agent-provider-info.test.js
@@ -1,0 +1,194 @@
+/**
+ * F241 Phase C — `PluginRegistry.getPluginInfo` agentProvider projection tests.
+ *
+ * The Hub UI for owner approval renders entirely off the `PluginResourceStatus`
+ * fields that `getPluginInfo` projects out of the persisted capabilities row
+ * and the manifest declaration. These tests lock down that projection:
+ *   - capId is populated for agentProvider resources
+ *   - host-owned routeable / approval / binding state mirrors capabilities
+ *   - manifest-declared claims (PR #39 providerId/displayName/mentionPatterns)
+ *     are surfaced so the form can prefill defaults
+ *   - failureReason surfaces only when health.passed === false
+ *   - non-agentProvider resources are unaffected
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import os from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+
+const { PluginRegistry } = await import('../dist/domains/plugin/PluginRegistry.js');
+
+function makeManifest({ withClaims = true } = {}) {
+  return {
+    id: 'clowder-code',
+    name: 'Clowder Code',
+    version: '0.1.0',
+    builtin: false,
+    config: [],
+    resources: [
+      {
+        type: 'agentProvider',
+        name: 'clowder-code',
+        agentProvider: {
+          name: 'clowder-code',
+          transport: 'cli-jsonl',
+          command: 'clowder-code',
+          startupArgs: ['--json'],
+          sessionPolicy: 'stateless',
+          outputProfile: 'clowder-code-turn-result-v1',
+          ...(withClaims
+            ? {
+                providerId: 'clowder-code',
+                displayName: 'Clowder Code',
+                mentionPatterns: ['@clowder', '@clowder-code'],
+              }
+            : {}),
+        },
+      },
+    ],
+  };
+}
+
+function makeCapabilities({ routeable, approved, binding, descriptorHash, failureReason } = {}) {
+  return {
+    version: 1,
+    capabilities: [
+      {
+        id: 'plugin:clowder-code:clowder-code',
+        type: 'agentProvider',
+        enabled: true,
+        source: 'cat-cafe',
+        pluginId: 'clowder-code',
+        agentProvider: {
+          name: 'clowder-code',
+          transport: 'cli-jsonl',
+          command: 'clowder-code',
+          startupArgs: ['--json'],
+          sessionPolicy: 'stateless',
+          outputProfile: 'clowder-code-turn-result-v1',
+          state: routeable ? 'healthy' : 'transportReady',
+          routeable: !!routeable,
+          routeableApproved: !!approved,
+          descriptorHash: descriptorHash ?? 'hash-X',
+          ...(binding ? { routeableBinding: binding } : {}),
+          ...(failureReason
+            ? {
+                health: {
+                  passed: false,
+                  checkedAt: 1000,
+                  ttlMs: 60_000,
+                  descriptorHash: descriptorHash ?? 'hash-X',
+                  failureReason,
+                },
+              }
+            : {}),
+        },
+      },
+    ],
+  };
+}
+
+function makeRegistry() {
+  return new PluginRegistry(mkdtempSync(join(os.tmpdir(), 'plugin-info-test-')));
+}
+
+describe('PluginRegistry.getPluginInfo — F241 agentProvider projection', () => {
+  it('populates capId for the Hub UI POST URL', () => {
+    const reg = makeRegistry();
+    const info = reg.getPluginInfo(makeManifest(), makeCapabilities({ routeable: false, approved: false }), {});
+    const r = info.resources[0];
+    assert.equal(r.capId, 'plugin:clowder-code:clowder-code');
+  });
+
+  it('surfaces routeable + approval flags from capabilities', () => {
+    const reg = makeRegistry();
+    const info = reg.getPluginInfo(
+      makeManifest(),
+      makeCapabilities({
+        routeable: true,
+        approved: true,
+        binding: { catId: 'clowder-cat', mentionPatterns: ['@clowder'] },
+      }),
+      {},
+    );
+    const r = info.resources[0];
+    assert.equal(r.agentProviderRouteable, true);
+    assert.equal(r.agentProviderRouteableApproved, true);
+    assert.equal(r.agentProviderState, 'healthy');
+    assert.deepEqual(r.agentProviderBinding, { catId: 'clowder-cat', mentionPatterns: ['@clowder'] });
+  });
+
+  it('surfaces manifest identity claims (PR #39) for form prefill', () => {
+    const reg = makeRegistry();
+    const info = reg.getPluginInfo(
+      makeManifest({ withClaims: true }),
+      makeCapabilities({ routeable: false, approved: false }),
+      {},
+    );
+    assert.deepEqual(info.resources[0].agentProviderClaims, {
+      providerId: 'clowder-code',
+      displayName: 'Clowder Code',
+      mentionPatterns: ['@clowder', '@clowder-code'],
+    });
+  });
+
+  it('omits agentProviderClaims when manifest declares none', () => {
+    const reg = makeRegistry();
+    const info = reg.getPluginInfo(
+      makeManifest({ withClaims: false }),
+      makeCapabilities({ routeable: false, approved: false }),
+      {},
+    );
+    assert.equal(info.resources[0].agentProviderClaims, undefined);
+  });
+
+  it('surfaces descriptorHash so the operator can see when re-approval is pending', () => {
+    const reg = makeRegistry();
+    const info = reg.getPluginInfo(
+      makeManifest(),
+      makeCapabilities({ routeable: false, approved: false, descriptorHash: 'hash-Y' }),
+      {},
+    );
+    assert.equal(info.resources[0].agentProviderDescriptorHash, 'hash-Y');
+  });
+
+  it('surfaces health.failureReason when probe failed', () => {
+    const reg = makeRegistry();
+    const info = reg.getPluginInfo(
+      makeManifest(),
+      makeCapabilities({ routeable: false, approved: false, failureReason: 'cli-probe-cli-not-found:clowder-code' }),
+      {},
+    );
+    assert.equal(info.resources[0].agentProviderHealthFailureReason, 'cli-probe-cli-not-found:clowder-code');
+  });
+
+  it('omits failureReason when health passed (no operator-visible noise on the happy path)', () => {
+    const reg = makeRegistry();
+    const info = reg.getPluginInfo(
+      makeManifest(),
+      makeCapabilities({ routeable: true, approved: true, binding: { catId: 'clowder-cat' } }),
+      {},
+    );
+    assert.equal(info.resources[0].agentProviderHealthFailureReason, undefined);
+  });
+
+  it('does NOT add F241 fields to non-agentProvider resources', () => {
+    const reg = makeRegistry();
+    const manifest = {
+      id: 'gh',
+      name: 'GitHub',
+      version: '1.0.0',
+      builtin: false,
+      config: [],
+      resources: [{ type: 'schedule', name: 'cicd-check', factoryId: 'github.cicd-check' }],
+    };
+    const info = reg.getPluginInfo(manifest, { version: 1, capabilities: [] }, {});
+    const r = info.resources[0];
+    assert.equal(r.capId, undefined);
+    assert.equal(r.agentProviderRouteable, undefined);
+    assert.equal(r.agentProviderBinding, undefined);
+    assert.equal(r.agentProviderClaims, undefined);
+  });
+});

--- a/packages/api/test/plugin-registry-agent-provider-info.test.js
+++ b/packages/api/test/plugin-registry-agent-provider-info.test.js
@@ -51,7 +51,7 @@ function makeManifest({ withClaims = true } = {}) {
   };
 }
 
-function makeCapabilities({ routeable, approved, binding, descriptorHash, failureReason } = {}) {
+function makeCapabilities({ routeable, approved, binding, descriptorHash, failureReason, lastSyncError } = {}) {
   return {
     version: 1,
     capabilities: [
@@ -84,6 +84,7 @@ function makeCapabilities({ routeable, approved, binding, descriptorHash, failur
                 },
               }
             : {}),
+          ...(lastSyncError ? { lastSyncError } : {}),
         },
       },
     ],
@@ -172,6 +173,37 @@ describe('PluginRegistry.getPluginInfo — F241 agentProvider projection', () =>
       {},
     );
     assert.equal(info.resources[0].agentProviderHealthFailureReason, undefined);
+  });
+
+  // PR #42 round-1 review @codex P2: persisted post-approval sync failures
+  // must surface to the Hub so operators can diagnose a row that is
+  // approved + healthy but stuck non-routeable.
+  it('surfaces lastSyncError (message + occurredAt) so post-approval sync failure is diagnosable', () => {
+    const reg = makeRegistry();
+    const info = reg.getPluginInfo(
+      makeManifest(),
+      makeCapabilities({
+        routeable: false,
+        approved: true,
+        binding: { catId: 'clowder-cat' },
+        lastSyncError: { message: 'agent registry sync failed: ENOENT', occurredAt: 1_700_000_000_999 },
+      }),
+      {},
+    );
+    assert.deepEqual(info.resources[0].agentProviderLastSyncError, {
+      message: 'agent registry sync failed: ENOENT',
+      occurredAt: 1_700_000_000_999,
+    });
+  });
+
+  it('omits lastSyncError on the happy path (no UI noise after sync succeeds)', () => {
+    const reg = makeRegistry();
+    const info = reg.getPluginInfo(
+      makeManifest(),
+      makeCapabilities({ routeable: true, approved: true, binding: { catId: 'clowder-cat' } }),
+      {},
+    );
+    assert.equal(info.resources[0].agentProviderLastSyncError, undefined);
   });
 
   it('does NOT add F241 fields to non-agentProvider resources', () => {

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -112,6 +112,43 @@ export interface PluginResourceStatus {
   enabled: boolean;
   agentProviderState?: AgentProviderLifecycleState;
   error?: string;
+  /**
+   * F241 Phase C — Operator-visible state for `agentProvider` resources.
+   *
+   * Surfaces the host-owned routeable view + manifest-declared claims to the
+   * Hub UI so an operator can render the approve-routeable form, see whether
+   * a binding is already live, and prefill the form from claim defaults.
+   * All fields are optional and only populated for `type === 'agentProvider'`.
+   */
+
+  /** Canonical capability id (e.g. `plugin:clowder-code:clowder-code`) — required for approve-routeable POST URL. */
+  capId?: string;
+
+  /** Effective truth — "you can `@` this cat now". Always false until the routeable gate fully passes. */
+  agentProviderRouteable?: boolean;
+
+  /** Operator intent — flips true on explicit approve, resets to false on descriptor delta. */
+  agentProviderRouteableApproved?: boolean;
+
+  /** Live binding the operator set at approve-time. Undefined when not yet approved. */
+  agentProviderBinding?: {
+    catId: string;
+    profileId?: string;
+    mentionPatterns?: string[];
+  };
+
+  /** Manifest-declared identity claims (PR #39). Hub UI uses these as form defaults. */
+  agentProviderClaims?: {
+    providerId?: string;
+    displayName?: string;
+    mentionPatterns?: string[];
+  };
+
+  /** Stable hash bound to the descriptor; surfaced so the operator can see when re-approval is needed after a manifest delta. */
+  agentProviderDescriptorHash?: string;
+
+  /** Operator-visible probe failure (e.g. `cli-probe-cli-not-found:foo`, `cli-probe-timeout:10000ms`). */
+  agentProviderHealthFailureReason?: string;
 }
 
 /** Full plugin info returned by API (manifest + derived state) */

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -149,6 +149,20 @@ export interface PluginResourceStatus {
 
   /** Operator-visible probe failure (e.g. `cli-probe-cli-not-found:foo`, `cli-probe-timeout:10000ms`). */
   agentProviderHealthFailureReason?: string;
+
+  /**
+   * Operator-visible AgentRegistry sync failure surfaced from the persisted
+   * `lastSyncError`. Distinct from `agentProviderHealthFailureReason` —
+   * sync failures fire AFTER approval / health both pass, during the Step 6
+   * AgentRegistry projection (post-approval sync hook in
+   * `agent-provider-approval-service.ts`). Without this field a sync failure
+   * leaves the row as `approved=true / healthy / routeable=false` with no
+   * UI explanation of WHY it isn't routeable. (PR #42 round-1 review @codex.)
+   */
+  agentProviderLastSyncError?: {
+    message: string;
+    occurredAt: number;
+  };
 }
 
 /** Full plugin info returned by API (manifest + derived state) */

--- a/packages/web/src/components/settings/AgentProviderApprovalSection.tsx
+++ b/packages/web/src/components/settings/AgentProviderApprovalSection.tsx
@@ -223,6 +223,21 @@ function ApprovalRow({ resource, row, pluginId, onPatch, onApprove }: ApprovalRo
             探针失败: {resource.agentProviderHealthFailureReason}
           </span>
         )}
+        {/* F241 PR #42 round-1 review @codex P2: surface persisted sync failure
+            separately from health probe failure so operators see WHY a row is
+            `approved=true / healthy / routeable=false` after a Step 6 sync hook
+            throws. Distinct chip + label keeps the two failure sources
+            operator-distinguishable; the title attribute shows the occurredAt
+            timestamp on hover so operators can correlate with logs. */}
+        {resource.agentProviderLastSyncError && (
+          <span
+            className="rounded-[13px] bg-conn-red-bg px-2.5 py-0.5 text-label font-medium text-conn-red-text"
+            title={new Date(resource.agentProviderLastSyncError.occurredAt).toLocaleString()}
+            data-testid={`sync-error-${resource.capId}`}
+          >
+            同步失败: {resource.agentProviderLastSyncError.message}
+          </span>
+        )}
       </div>
 
       {isRouteable && liveBinding && (

--- a/packages/web/src/components/settings/AgentProviderApprovalSection.tsx
+++ b/packages/web/src/components/settings/AgentProviderApprovalSection.tsx
@@ -1,0 +1,359 @@
+'use client';
+
+/**
+ * F241 Phase C — Hub UI for owner approval.
+ *
+ * Renders an approval section for each `agentProvider` resource of a plugin:
+ *  - Shows the current lifecycle state (transportReady / healthy) + routeable
+ *    bool + any `health.failureReason` so operators can see why a probe failed.
+ *  - For non-routeable rows: renders the approve form (catId input +
+ *    mentionPatterns chip input) prefilled from manifest claims (PR #39).
+ *  - For already-routeable rows: shows the live binding (catId + patterns)
+ *    and a "重新绑定" / "停用路由" pair so the operator can re-approve under
+ *    a new binding or take the cat offline without disabling the whole plugin.
+ *
+ * POSTs `/api/plugins/:id/capabilities/:capId/approve-routeable` with
+ *   { catId, mentionPatterns? }. Failure body includes structured
+ * `reason` + `details` from the approval service so the form can surface
+ * admission collisions / health-probe failures inline.
+ */
+
+import type { PluginInfo, PluginResourceStatus } from '@cat-cafe/shared';
+import { useMemo, useState } from 'react';
+import { apiFetch } from '@/utils/api-client';
+
+interface Props {
+  plugin: PluginInfo;
+  onUpdated: () => void;
+}
+
+type ApprovalRowState = {
+  catId: string;
+  mentionPatternsText: string;
+  busy: boolean;
+  result: { type: 'success' | 'error'; msg: string } | null;
+  /** Tracks whether the operator is editing an already-bound row (re-bind flow). */
+  rebinding: boolean;
+};
+
+/** Comma- or whitespace-separated `@name` list → trimmed string[] (drop empties). */
+function parseMentionPatterns(text: string): string[] {
+  return text
+    .split(/[,\s]+/u)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+}
+
+function joinMentionPatterns(values: string[] | undefined): string {
+  return (values ?? []).join(', ');
+}
+
+function defaultCatIdFromResource(resource: PluginResourceStatus, pluginId: string): string {
+  // Prefer manifest providerId claim → resource name → plugin id (last-resort).
+  return resource.agentProviderClaims?.providerId ?? resource.name ?? pluginId;
+}
+
+type ApproveResponse =
+  | { ok: true; capability?: unknown }
+  | { ok: false; reason?: string; details?: string; conflictingIdentity?: string };
+
+/** Build operator-visible error message from a structured approval failure. */
+function approvalErrorMessage(data: Extract<ApproveResponse, { ok: false }>): string {
+  const head = data.reason ?? '未知错误';
+  const tail = data.details ? `: ${data.details}` : '';
+  const conflict = data.conflictingIdentity ? ` (冲突身份: ${data.conflictingIdentity})` : '';
+  return `${head}${tail}${conflict}`;
+}
+
+/** POST approve-routeable + normalize the network/JSON/structured-failure error paths. */
+async function postApproveRouteable(
+  pluginId: string,
+  capId: string,
+  catId: string,
+  mentionPatterns: string[],
+): Promise<{ ok: true } | { ok: false; msg: string }> {
+  try {
+    const res = await apiFetch(`/api/plugins/${pluginId}/capabilities/${encodeURIComponent(capId)}/approve-routeable`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        catId,
+        ...(mentionPatterns.length > 0 ? { mentionPatterns } : {}),
+      }),
+    });
+    const data = (await res.json().catch(() => ({}))) as ApproveResponse;
+    if (!res.ok || ('ok' in data && data.ok === false)) {
+      const msg = 'ok' in data && data.ok === false ? approvalErrorMessage(data) : `HTTP ${res.status}`;
+      return { ok: false, msg };
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, msg: err instanceof Error ? err.message : '网络错误' };
+  }
+}
+
+function StateChip({ resource }: { resource: PluginResourceStatus }) {
+  const state = resource.agentProviderState;
+  const routeable = resource.agentProviderRouteable;
+  if (state === 'healthy' && routeable) {
+    return (
+      <span className="rounded-[13px] bg-conn-emerald-bg px-2.5 py-0.5 text-label font-medium text-conn-emerald-text">
+        ✓ routeable · healthy
+      </span>
+    );
+  }
+  if (state === 'transportReady') {
+    return (
+      <span className="rounded-[13px] bg-cafe-surface-sunken px-2.5 py-0.5 text-label font-medium text-cafe-muted">
+        待审批 · transportReady
+      </span>
+    );
+  }
+  return (
+    <span className="rounded-[13px] bg-cafe-surface-sunken px-2.5 py-0.5 text-label font-medium text-cafe-muted">
+      {state ?? '未激活'}
+    </span>
+  );
+}
+
+export function AgentProviderApprovalSection({ plugin, onUpdated }: Props) {
+  const agentProviderRows = useMemo(
+    () => plugin.resources.filter((r) => r.type === 'agentProvider'),
+    [plugin.resources],
+  );
+
+  const initialRowState = (resource: PluginResourceStatus): ApprovalRowState => ({
+    catId: resource.agentProviderBinding?.catId ?? defaultCatIdFromResource(resource, plugin.id),
+    mentionPatternsText: joinMentionPatterns(
+      resource.agentProviderBinding?.mentionPatterns ?? resource.agentProviderClaims?.mentionPatterns,
+    ),
+    busy: false,
+    result: null,
+    rebinding: false,
+  });
+
+  // Key by capId so re-renders after onUpdated() naturally re-mount the form
+  // state from the freshest binding rather than holding stale operator input.
+  const [rowState, setRowState] = useState<Record<string, ApprovalRowState>>(() => {
+    const acc: Record<string, ApprovalRowState> = {};
+    for (const r of agentProviderRows) {
+      if (r.capId) acc[r.capId] = initialRowState(r);
+    }
+    return acc;
+  });
+
+  if (agentProviderRows.length === 0) return null;
+
+  const getRow = (resource: PluginResourceStatus): ApprovalRowState => {
+    if (!resource.capId) return initialRowState(resource);
+    return rowState[resource.capId] ?? initialRowState(resource);
+  };
+
+  const updateRow = (capId: string, patch: Partial<ApprovalRowState>) => {
+    setRowState((prev) => ({
+      ...prev,
+      [capId]: { ...(prev[capId] ?? ({} as ApprovalRowState)), ...patch },
+    }));
+  };
+
+  const handleApprove = async (resource: PluginResourceStatus) => {
+    const capId = resource.capId;
+    if (!capId) return;
+    const row = getRow(resource);
+    const catId = row.catId.trim();
+    if (!catId) {
+      updateRow(capId, { result: { type: 'error', msg: '请填写 catId 绑定' } });
+      return;
+    }
+    updateRow(capId, { busy: true, result: null });
+    const mentionPatterns = parseMentionPatterns(row.mentionPatternsText);
+    const result = await postApproveRouteable(plugin.id, capId, catId, mentionPatterns);
+    if (result.ok) {
+      updateRow(capId, { busy: false, rebinding: false, result: { type: 'success', msg: '审批已生效' } });
+      onUpdated();
+    } else {
+      updateRow(capId, { busy: false, result: { type: 'error', msg: result.msg } });
+    }
+  };
+
+  return (
+    <div className="space-y-3 rounded-[14px] border border-cafe-border bg-cafe-surface-sunken/40 p-3">
+      <div className="text-xs font-medium text-cafe-muted">外部 Agent Provider 路由审批 (F241)</div>
+      {agentProviderRows.map((resource) => (
+        <ApprovalRow
+          key={resource.capId ?? `${resource.type}:${resource.name ?? ''}`}
+          resource={resource}
+          row={getRow(resource)}
+          pluginId={plugin.id}
+          onPatch={(patch) => resource.capId && updateRow(resource.capId, patch)}
+          onApprove={() => void handleApprove(resource)}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Single approval row — extracted to keep the parent under the Biome cognitive-
+ * complexity budget. Owns no state; the parent threads `row` + `onPatch` so
+ * `onUpdated()` re-renders cleanly when the binding refreshes.
+ */
+interface ApprovalRowProps {
+  resource: PluginResourceStatus;
+  row: ApprovalRowState;
+  pluginId: string;
+  onPatch: (patch: Partial<ApprovalRowState>) => void;
+  onApprove: () => void;
+}
+
+function ApprovalRow({ resource, row, pluginId, onPatch, onApprove }: ApprovalRowProps) {
+  const liveBinding = resource.agentProviderBinding;
+  const isRouteable = resource.agentProviderRouteable === true;
+  const showForm = !isRouteable || row.rebinding;
+  const claims = resource.agentProviderClaims;
+  return (
+    <div className="space-y-2 rounded-[12px] border border-cafe-border bg-cafe-surface p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-medium" style={{ fontSize: 'var(--console-font-compact)', color: 'var(--cafe-text)' }}>
+          {claims?.displayName ?? resource.name ?? 'agentProvider'}
+        </span>
+        <StateChip resource={resource} />
+        {resource.agentProviderHealthFailureReason && (
+          <span className="rounded-[13px] bg-conn-red-bg px-2.5 py-0.5 text-label font-medium text-conn-red-text">
+            探针失败: {resource.agentProviderHealthFailureReason}
+          </span>
+        )}
+      </div>
+
+      {isRouteable && liveBinding && (
+        <BindingSummary
+          binding={liveBinding}
+          rebinding={row.rebinding}
+          onRebind={() => onPatch({ rebinding: true, result: null })}
+        />
+      )}
+
+      {showForm && (
+        <ApprovalForm
+          resource={resource}
+          row={row}
+          pluginId={pluginId}
+          claims={claims}
+          onPatch={onPatch}
+          onApprove={onApprove}
+        />
+      )}
+
+      {row.result && (
+        <div
+          className={`rounded-[12px] px-3 py-2 text-xs ${
+            row.result.type === 'success'
+              ? 'border border-conn-emerald-ring bg-conn-emerald-bg text-conn-emerald-text'
+              : 'border border-conn-red-ring bg-conn-red-bg text-conn-red-text'
+          }`}
+          data-testid={`approve-result-${resource.capId}`}
+        >
+          {row.result.msg}
+        </div>
+      )}
+
+      {resource.agentProviderDescriptorHash && (
+        <div className="text-[10px] text-cafe-muted/70">
+          descriptorHash: <code>{resource.agentProviderDescriptorHash.slice(0, 12)}…</code>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BindingSummary({
+  binding,
+  rebinding,
+  onRebind,
+}: {
+  binding: NonNullable<PluginResourceStatus['agentProviderBinding']>;
+  rebinding: boolean;
+  onRebind: () => void;
+}) {
+  return (
+    <div className="space-y-1 text-xs text-cafe-muted">
+      <div>
+        当前绑定 · <code className="rounded bg-cafe-surface-sunken px-1.5 py-0.5 text-cafe-text">@{binding.catId}</code>
+      </div>
+      {binding.mentionPatterns && binding.mentionPatterns.length > 0 && (
+        <div>mention: {binding.mentionPatterns.join(', ')}</div>
+      )}
+      {!rebinding && (
+        <button
+          type="button"
+          onClick={onRebind}
+          className="console-inline-link"
+          style={{ fontSize: 'var(--console-font-compact)' }}
+        >
+          重新绑定
+        </button>
+      )}
+    </div>
+  );
+}
+
+interface ApprovalFormProps {
+  resource: PluginResourceStatus;
+  row: ApprovalRowState;
+  pluginId: string;
+  claims: PluginResourceStatus['agentProviderClaims'];
+  onPatch: (patch: Partial<ApprovalRowState>) => void;
+  onApprove: () => void;
+}
+
+function ApprovalForm({ resource, row, pluginId, claims, onPatch, onApprove }: ApprovalFormProps) {
+  return (
+    <div className="space-y-2">
+      <label className="block text-xs text-cafe-muted">
+        catId
+        <input
+          type="text"
+          value={row.catId}
+          onChange={(e) => onPatch({ catId: e.target.value })}
+          placeholder={defaultCatIdFromResource(resource, pluginId)}
+          className="mt-1 w-full rounded-[10px] border border-cafe-border bg-cafe-surface px-2 py-1.5 text-xs text-cafe-text"
+          data-testid={`approve-catId-${resource.capId}`}
+        />
+      </label>
+      <label className="block text-xs text-cafe-muted">
+        mention patterns (逗号或空格分隔，每个以 @ 开头)
+        <input
+          type="text"
+          value={row.mentionPatternsText}
+          onChange={(e) => onPatch({ mentionPatternsText: e.target.value })}
+          placeholder={joinMentionPatterns(claims?.mentionPatterns) || '@clowder, @clowder-code'}
+          className="mt-1 w-full rounded-[10px] border border-cafe-border bg-cafe-surface px-2 py-1.5 text-xs text-cafe-text"
+          data-testid={`approve-mentionPatterns-${resource.capId}`}
+        />
+      </label>
+      <div className="flex items-center justify-end gap-2">
+        {row.rebinding && (
+          <button
+            type="button"
+            onClick={() => onPatch({ rebinding: false, result: null })}
+            disabled={row.busy}
+            className="console-button-secondary disabled:opacity-50"
+            style={{ fontSize: 'var(--console-font-compact)' }}
+          >
+            取消
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onApprove}
+          disabled={row.busy}
+          className="console-button-primary disabled:opacity-50"
+          style={{ fontSize: 'var(--console-font-compact)' }}
+          data-testid={`approve-submit-${resource.capId}`}
+        >
+          {row.busy ? '审批中...' : '审批为可路由'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/PluginConfigPanel.tsx
+++ b/packages/web/src/components/settings/PluginConfigPanel.tsx
@@ -4,6 +4,7 @@ import type { PluginInfo } from '@cat-cafe/shared';
 import { useState } from 'react';
 import { apiFetch } from '@/utils/api-client';
 import { ExternalLinkIcon, StepBadge } from '../HubConfigIcons';
+import { AgentProviderApprovalSection } from './AgentProviderApprovalSection';
 import { ConfigFieldRenderer } from './primitives/ConfigFieldRenderer';
 
 function isSafeUrl(url: string): boolean {
@@ -193,6 +194,11 @@ export function PluginConfigPanel({ plugin, onUpdated }: Props) {
             </span>
           ))}
         </div>
+      )}
+
+      {/* F241 Phase C — Hub UI for owner approval of agentProvider routeable rows. */}
+      {plugin.resources.some((r) => r.type === 'agentProvider') && (
+        <AgentProviderApprovalSection plugin={plugin} onUpdated={onUpdated} />
       )}
 
       {result && (


### PR DESCRIPTION
## Summary
Closes the last Phase C scope item from F241 doc § Phase B 2b Design Notes "Non-goals for 2b" #3:
> No Hub UI for owner approval — Phase B exposes the admin surface as a host-internal route + CLI; Hub admin UI is Phase C scope.

After PR #38 (real cliProbe) and PR #39 (manifest claims + descriptor hash v: 2) landed, every piece needed for the approval form exists; this PR closes the Phase C UI gap so operators no longer need `curl` + manual capId encoding to flip a plugin agentProvider to routeable.

## What
**`packages/shared/src/types/plugin.ts`** — `PluginResourceStatus` gains 7 optional F241 projection fields (`capId`, `agentProviderRouteable`, `agentProviderRouteableApproved`, `agentProviderBinding`, `agentProviderClaims`, `agentProviderDescriptorHash`, `agentProviderHealthFailureReason`). Only populated for `type === 'agentProvider'`.

**`packages/api/src/domains/plugin/PluginRegistry.ts`** — `getPluginInfo` projects the agentProvider extension fields out of the persisted capability row + manifest claims. Decomposed into pure helpers (`projectHostOwnedAgentProviderFields`, `projectAgentProviderClaims`) to stay under Biome's cognitive-complexity budget.

**`packages/web/src/components/settings/AgentProviderApprovalSection.tsx`** (new) — For each plugin agentProvider resource:
- State chip: `transportReady` (待审批) vs `healthy` (✓ routeable).
- Failure-reason chip when `health.passed === false` (operator sees `cli-probe-cli-not-found:foo` inline, no log digging).
- If routeable: live binding (`@catId` + patterns) + "重新绑定" affordance.
- If not routeable (or rebinding): approve form with catId + mentionPatterns inputs, **prefilled from manifest claims (PR #39)**.
- `POST /api/plugins/:id/capabilities/:capId/approve-routeable` and surfaces the structured failure body (reason + details + conflictingIdentity) inline so admission collisions / health probe failures are operator-readable.
- Decomposed into `ApprovalRow` + `BindingSummary` + `ApprovalForm` sub-components + `postApproveRouteable` / `approvalErrorMessage` helpers to stay under cognitive-complexity budget.
- `data-testid` on every interactive surface keyed by capId for Playwright/RTL.

**`packages/web/src/components/settings/PluginConfigPanel.tsx`** — Conditionally renders `<AgentProviderApprovalSection>` when the plugin has any agentProvider resource. Zero impact on plugins without agentProvider (existing layout unchanged for github, etc.).

## Tests
- [x] New: `packages/api/test/plugin-registry-agent-provider-info.test.js` (8 tests) — capId populated, routeable + approval flags surfaced, binding surfaced, claims surfaced/omitted correctly, descriptorHash surfaced, failureReason surfaced only when health failed, non-agentProvider resources untouched.
- [x] F241 regression: 214/214 pass (no test churn).
- [x] `pnpm --filter @cat-cafe/api run build` clean.
- [x] `pnpm --filter @cat-cafe/web exec tsc --noEmit` clean.
- [x] Biome on touched files: only one pre-existing warning remains (`PluginRegistry.scan` cognitive complexity 20, was already over the 15 budget before this PR — not caused by these changes); all new functions under threshold.

## Manual verification (this thread `thread_mqxva63tuebxj9sn`)
- `GET /api/plugins/clowder-code` returns the new `agentProviderClaims` + `routeable`/`binding`/`descriptorHash` fields populated as expected (with `clowder-code` plugin.yaml extended via PR #39's claim fields).
- E2E `@clowder-cat → "Probe received hash verified"` confirms the underlying approve-routeable contract this UI consumes still works end-to-end through real cliProbe (PR #38) + v: 2 hash (PR #39).

## Non-goals (deferred)
- React component unit tests (vitest/RTL) — the test surface is the `data-testid` selectors; follow-on PR can add component tests against the API contract this PR locks in.
- Disable/un-approve action — for now operators disable the whole plugin via the existing button. A dedicated "停用路由" action is a follow-on if/when needed.
- F202 capability policy actually enforcing `mcpWhitelistRequest` / `sandboxRequest` grants — those stay as request semantics per F241 doc § Phase B 2b "Non-goals for 2b" #1.

## Review request
**@codex (cross-family)** — cross-family review per shared-rules.md. Particular focus appreciated on:
1. UI safety on the approval form: catId trimming, mentionPatterns parsing, encoding of capId in the URL (uses `encodeURIComponent` already).
2. Error surfaces — do we expose enough of the structured failure body for operator self-service? Anything sensitive that shouldn't reach the browser?
3. The `agentProvider*` extension shape on `PluginResourceStatus` — is there a cleaner nested-object form that aged better, given we'll add more fields over time?

🤖 Generated with [Claude Code](https://claude.com/claude-code)