### PR TITLE
fix(ci): disambiguate upstream sync main checkout

### DIFF
--- a/.github/workflows/sync-upstream-main.yml
+++ b/.github/workflows/sync-upstream-main.yml
@@ -58,7 +58,7 @@ jobs:
         id: main
         run: |
           set -euo pipefail
-          git switch main
+          git switch -C main origin/main
           git reset --hard origin/main
 
           before="$(git rev-parse HEAD)"


### PR DESCRIPTION
## Summary

Fixes the manual `Sync upstream main` failure after the repository default branch moved to `develop`.

The workflow fetches both `origin/main` and `upstream/main`, so a fresh runner with no local `main` branch fails on:

```text
git switch main
fatal: 'main' matched multiple (2) remote tracking branches
```

This PR changes the checkout to explicitly reset local `main` from `origin/main` before merging `upstream/main`.

## Verification

- `git diff --check`
- Temporary clone reproducer with both `origin/main` and `upstream/main`: `git switch -C main origin/main` succeeds and HEAD equals `origin/main`

Fixes #57

[砚砚/gpt-5.5🐾]
