### PR TITLE
fix: unblock develop build after upstream-sync merge (#62)

### DIFF
--- a/packages/api/src/config/account-resolver.ts
+++ b/packages/api/src/config/account-resolver.ts
@@ -262,7 +262,11 @@ function accountToRuntimeProfile(ref: string, account: AccountConfig, projectRoo
   // (which is freeform display, not authoritative routing/security identity).
   // Legacy api_key accounts without `clientFamily` fall through with
   // `profile.client=undefined`, preserving pre-G2 best-effort resolution.
-  const apiKeyClient = !isOAuth ? account.clientFamily : undefined;
+  // clientFamily's literal union includes 'dare' (Hub display), but RuntimeProviderProfile.client
+  // is BuiltinAccountClient — 'dare' has no builtin account and cannot satisfy the fail-closed
+  // family guard, so it falls through as undefined (same as legacy no-clientFamily accounts).
+  const apiKeyClient: BuiltinAccountClient | undefined =
+    !isOAuth && account.clientFamily && account.clientFamily !== 'dare' ? account.clientFamily : undefined;
   const resolvedClient = isBuiltin ? builtinClient : apiKeyClient;
   return {
     id: ref,

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -1451,7 +1451,7 @@ export async function* routeSerial(
               if (callbackResult.messageId) callbackPostMessageId = callbackResult.messageId;
             }
             if (completedToolName) {
-              if (callbackResult.confirmed && isSameTurnEventDrivenCoverageToolName(completedToolName)) {
+              if (callbackResult.confirmed && isSameTurnEventDrivenCoverageToolName(completedToolName.toolName)) {
                 hasEventDrivenExternalWaitCoverage = true;
               }
               const settledExit = settleCallbackRoutingExit(completedToolName, callbackResult.confirmed);
@@ -1897,7 +1897,7 @@ export async function* routeSerial(
                 if (callbackResult.messageId) callbackPostMessageId = callbackResult.messageId;
               }
               if (completedToolName) {
-                if (callbackResult.confirmed && isSameTurnEventDrivenCoverageToolName(completedToolName)) {
+                if (callbackResult.confirmed && isSameTurnEventDrivenCoverageToolName(completedToolName.toolName)) {
                   hasEventDrivenExternalWaitCoverage = true;
                 }
                 const settledExit = settleCallbackRoutingExit(completedToolName, callbackResult.confirmed);

--- a/packages/api/src/domains/cats/services/agents/routing/verdict-detect.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/verdict-detect.ts
@@ -14,7 +14,7 @@
  */
 
 import { stripTrailingCatSignatures } from './cat-signature-strip.js';
-import { finalRoutingSlot } from './final-routing-slot.js';
+import { finalRoutingSlot, hasEventDrivenExternalWaitExit } from './final-routing-slot.js';
 
 // 2026-06-20 verdict eval:a2a C2 void-hold English fix: signature stripping
 // extracted to `cat-signature-strip.ts` so void-hold-detect.ts can share the

--- a/packages/api/src/domains/cats/services/agents/routing/void-hold-detect.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/void-hold-detect.ts
@@ -23,7 +23,7 @@
  */
 
 import { stripTrailingCatSignatures } from './cat-signature-strip.js';
-import { finalRoutingSlot } from './final-routing-slot.js';
+import { finalRoutingSlot, hasEventDrivenExternalWaitExit } from './final-routing-slot.js';
 
 /**
  * Hold pattern catalog. Order matters: more-specific patterns first so a

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -2696,7 +2696,7 @@ async function main(): Promise<void> {
         const root = resolveActiveProjectRoot();
         await writeCapabilitiesConfig(root, config);
         const { paths } = resolveStartupCliConfigContext(root);
-        await generateCliConfigs(config, paths);
+        await generateCliConfigs(config, paths, root);
       },
       withCapabilityLock: (fn) => withCapabilityLock(resolveActiveProjectRoot(), fn),
       buildAdmissionSnapshot: async (pluginId, capId, capabilitiesConfig) => {

--- a/packages/web/src/components/HubCatEditor.tsx
+++ b/packages/web/src/components/HubCatEditor.tsx
@@ -107,7 +107,7 @@ export function HubCatEditor({ cat, draft, existingCats, hasDossier, open, onClo
   }, [open, cat, draft]);
 
   // Re-fetch profiles when Provider Profiles page creates/saves/deletes an account.
-  const [_profilesVersion, setProfilesVersion] = useState(0);
+  const [, setProfilesVersion] = useState(0);
   useEffect(() => {
     const handler = () => setProfilesVersion((v) => v + 1);
     window.addEventListener('accounts-changed', handler);


### PR DESCRIPTION
Closes #62.

## Summary

Merge commit **ef269373e** ("sync: merge upstream main into develop", 2026-07-08) took upstream's refactored versions of `verdict-detect` / `void-hold-detect` and adjacent files but left fork-side callers/imports out of sync. `pnpm develop:start` currently fails with 5 TS errors + 1 ESLint error, blocking dev startup on `develop`.

This PR is **6 mechanical unblocks, +11 −7 lines, no design changes**.

## Changes

| File | Change |
|---|---|
| `.../routing/verdict-detect.ts` | Restore `hasEventDrivenExternalWaitExit` import (already exported by `./final-routing-slot.js`; `route-serial.ts` and `routing-guard-remedial.ts` import it correctly — same source of truth) |
| `.../routing/void-hold-detect.ts` | Same import restore |
| `config/account-resolver.ts` | `AccountConfig.clientFamily` union includes `'dare'` but `BuiltinAccountClient` (the target `RuntimeProviderProfile.client` type) does not. `'dare'` has no builtin account and no fail-closed family guard, so drop it to `undefined` here — mirrors existing legacy no-`clientFamily` fall-through |
| `.../routing/route-serial.ts` (1454, 1900) | Pass `completedToolName.toolName` to `isSameTurnEventDrivenCoverageToolName` — matches same-block usage at line 1446 and the function's `string \| undefined` signature |
| `index.ts:2699` | Pass `root` as third arg to `generateCliConfigs` (`capability-orchestrator.ts:1715` signature is `(config, paths, projectRoot)`) |
| `HubCatEditor.tsx:110` | Drop unused `_profilesVersion` — only the setter is used to force re-render on `accounts-changed` event |

## Test plan

- [x] `pnpm -C packages/api build` — clean
- [x] `pnpm develop:start` — web (3003) HTTP 200, API listening on 3004
- [ ] CI — full check pipeline
- [ ] Reviewer verifies `'dare'` fall-through matches intent (alternative: add `'dare'` to `BuiltinAccountClient` union, which would require adding a builtin account mapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)