### PR TITLE
fix: enable HTTPS_PROXY support for Node.js native fetch

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3,6 +3,10 @@
  * 后端 API 入口
  */
 
+// Side-effect import: must be FIRST — installs global fetch proxy dispatcher
+// before any code calls fetch(). See proxy-dispatcher.ts for rationale.
+import './infrastructure/proxy-dispatcher.js';
+
 import { join } from 'node:path';
 import {
   type CatConfig,

--- a/packages/api/src/infrastructure/proxy-dispatcher.ts
+++ b/packages/api/src/infrastructure/proxy-dispatcher.ts
@@ -1,0 +1,37 @@
+/**
+ * Global fetch proxy dispatcher setup.
+ *
+ * Node.js v22 native `fetch()` does NOT honor `HTTPS_PROXY` / `HTTP_PROXY`
+ * environment variables. This module bridges that gap by installing undici's
+ * `EnvHttpProxyAgent` as the global dispatcher when proxy env vars are detected.
+ *
+ * `EnvHttpProxyAgent` automatically reads:
+ *   - `HTTP_PROXY` / `http_proxy`
+ *   - `HTTPS_PROXY` / `https_proxy`
+ *   - `NO_PROXY` / `no_proxy`   (bypass list; typically `localhost,127.0.0.1,::1`)
+ *
+ * Import this module as a side-effect import at the top of the server entry
+ * point — before any code that calls `fetch()`.
+ *
+ * Why global: CatAgentService (and potentially other outbound HTTP clients)
+ * use native `fetch()`. A global dispatcher is the only way to make native
+ * `fetch()` proxy-aware without patching every call site.
+ */
+
+import { EnvHttpProxyAgent, setGlobalDispatcher } from 'undici';
+import { createModuleLogger } from './logger.js';
+
+const log = createModuleLogger('proxy-dispatcher');
+
+const proxyUrl =
+  process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy;
+
+if (proxyUrl) {
+  try {
+    setGlobalDispatcher(new EnvHttpProxyAgent());
+    log.info(`Global fetch proxy enabled: ${proxyUrl}`);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error(`Failed to set global proxy dispatcher: ${msg}`);
+  }
+}


### PR DESCRIPTION
## Summary

- Add `proxy-dispatcher.ts` module that installs `undici.EnvHttpProxyAgent` as the global fetch dispatcher when `HTTPS_PROXY`/`HTTP_PROXY` env vars are detected
- Import it as the first side-effect import in `index.ts` so all subsequent `fetch()` calls are proxy-aware
- Respects `NO_PROXY` automatically (localhost/127.0.0.1 stay direct)

Fixes #65

## Context

Node.js v22 native `fetch()` ignores proxy env vars. CatAgent (littlecat) calls external APIs via `CatAgentService.fetchApi()` which uses native `fetch()` — in proxy-required environments this causes `ECONNRESET` / `fetch failed`.

## Changes

| File | Change |
|------|--------|
| `packages/api/src/infrastructure/proxy-dispatcher.ts` | New — 34-line module, sets global dispatcher |
| `packages/api/src/index.ts` | +3 lines — side-effect import at top |

## Verification

```bash
# Without fix:
node -e "fetch('https://blackaicoding.com/v1/models').then(r=>console.log(r.status)).catch(e=>console.log(e.cause?.code))"
# → ECONNRESET

# With fix (mechanism proven):
node -e "const {setGlobalDispatcher,EnvHttpProxyAgent}=require('undici');setGlobalDispatcher(new EnvHttpProxyAgent());fetch('https://blackaicoding.com/v1/models').then(r=>console.log('OK',r.status)).catch(e=>console.log('FAIL',e.message))"
# → OK 401
```

## Test plan

- [ ] Restart API server after merge
- [ ] `@littlecat 你好吗` → should get a response instead of `fetch failed`
- [ ] Verify localhost MCP/Redis connections still work (NO_PROXY bypass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)