### PR TITLE
verdict(eval:friction): 2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only

### DIFF
--- a/docs/harness-feedback/bundles/2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only/attribution.json
+++ b/docs/harness-feedback/bundles/2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only/attribution.json
@@ -1,0 +1,36 @@
+{
+  "verdictId": "2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only",
+  "featureId": "F245",
+  "evalSnapshotId": "eval-F245-2026-07-09",
+  "generatedAt": "2026-07-09T03:09:18.602Z",
+  "findings": [
+    {
+      "id": "FR-2026-07-09-d981127d413a",
+      "relatedFeature": "F245",
+      "frictionSignal": {
+        "type": "friction.cluster_d981127d413a",
+        "severity": "high",
+        "confidence": 0.7,
+        "detectedAt": "2026-07-09T03:09:18.602Z"
+      },
+      "attribution": {
+        "primaryLayer": "needs_investigation",
+        "evidence": [
+          {
+            "type": "counter",
+            "anchor": "friction-rollup/cluster_d981127d413a",
+            "excerpt": "cluster 'a2a_timeout: codex' count=1 severity=high sensorForms=[reason]"
+          }
+        ]
+      },
+      "proposedAction": [
+        {
+          "action": "triage-top-friction-cluster",
+          "target": "F245/friction-rollup",
+          "rationale": "Highest-ranked friction cluster in the window — eval cat assigns the 7-class root cause in the verdict before handoff."
+        }
+      ],
+      "status": "open"
+    }
+  ]
+}

--- a/docs/harness-feedback/bundles/2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only/provenance.json
+++ b/docs/harness-feedback/bundles/2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only/provenance.json
@@ -1,0 +1,15 @@
+{
+  "verdictId": "2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/bundles/2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only/raw/rollup-report.json",
+      "sha256": "2152e3490b03474074c42fc4d3433908f52dc8aeddc04de378b228bb21c0a25e"
+    }
+  ],
+  "generatedAt": "2026-07-09T03:09:18.602Z",
+  "generator": {
+    "name": "eval-friction-live-verdict",
+    "version": "1"
+  },
+  "sanitizeRulesVersion": "f245-friction-rollup-v1"
+}

--- a/docs/harness-feedback/bundles/2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only/raw/rollup-report.json
+++ b/docs/harness-feedback/bundles/2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only/raw/rollup-report.json
@@ -1,0 +1,313 @@
+{
+  "verdictId": "2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only",
+  "selector": {
+    "kind": "friction-rollup-snapshot",
+    "windowStartMs": 1783306800000,
+    "windowEndMs": 1783566000000,
+    "topN": 10,
+    "tokenCap": 4000
+  },
+  "window": {
+    "sinceMs": 1783306800000,
+    "untilMs": 1783566000000
+  },
+  "signalCount": 9,
+  "clusterCount": 5,
+  "degraded": false,
+  "droppedChannels": [],
+  "report": {
+    "window": {
+      "sinceMs": 1783306800000,
+      "untilMs": 1783566000000
+    },
+    "generatedAt": "2026-07-09T03:09:18.602Z",
+    "topClusters": [
+      {
+        "clusterId": "d981127d413a",
+        "representative": "a2a_timeout: codex",
+        "channels": [
+          "user-feedback"
+        ],
+        "count": 1,
+        "members": [
+          {
+            "signalId": "user-feedback:fi_mrcu4bxlv840fgsx",
+            "rawRef": "fi_mrcu4bxlv840fgsx",
+            "channel": "user-feedback"
+          }
+        ],
+        "method": "rule",
+        "sensorForms": [
+          "reason"
+        ],
+        "severity": "high"
+      },
+      {
+        "clusterId": "23fba4045727",
+        "representative": "c2.void_hold_hint_emitted=6",
+        "channels": [
+          "eval-domain"
+        ],
+        "count": 2,
+        "members": [
+          {
+            "signalId": "eval-domain:2026-07-06-eval-a2a-ordinary-monitoring#C2#c2.void_hold_hint_emitted",
+            "rawRef": "2026-07-06-eval-a2a-ordinary-monitoring#C2#c2.void_hold_hint_emitted",
+            "channel": "eval-domain"
+          },
+          {
+            "signalId": "eval-domain:2026-07-07-eval-a2a-stable-void-hold-baseline#C2#c2.void_hold_hint_emitted",
+            "rawRef": "2026-07-07-eval-a2a-stable-void-hold-baseline#C2#c2.void_hold_hint_emitted",
+            "channel": "eval-domain"
+          }
+        ],
+        "method": "rule",
+        "sensorForms": [
+          "aggregate_proxy"
+        ],
+        "severity": "low"
+      },
+      {
+        "clusterId": "4901ab640cdd",
+        "representative": "inline_action.hint_emitted=1",
+        "channels": [
+          "eval-domain"
+        ],
+        "count": 2,
+        "members": [
+          {
+            "signalId": "eval-domain:2026-07-06-eval-a2a-ordinary-monitoring#route-serial#inline_action.hint_emitted",
+            "rawRef": "2026-07-06-eval-a2a-ordinary-monitoring#route-serial#inline_action.hint_emitted",
+            "channel": "eval-domain"
+          },
+          {
+            "signalId": "eval-domain:2026-07-07-eval-a2a-stable-void-hold-baseline#route-serial#inline_action.hint_emitted",
+            "rawRef": "2026-07-07-eval-a2a-stable-void-hold-baseline#route-serial#inline_action.hint_emitted",
+            "channel": "eval-domain"
+          }
+        ],
+        "method": "rule",
+        "sensorForms": [
+          "aggregate_proxy"
+        ],
+        "severity": "low"
+      },
+      {
+        "clusterId": "9d32022cb1ab",
+        "representative": "inline_action.feedback_written=1",
+        "channels": [
+          "eval-domain"
+        ],
+        "count": 2,
+        "members": [
+          {
+            "signalId": "eval-domain:2026-07-06-eval-a2a-ordinary-monitoring#route-serial#inline_action.feedback_written",
+            "rawRef": "2026-07-06-eval-a2a-ordinary-monitoring#route-serial#inline_action.feedback_written",
+            "channel": "eval-domain"
+          },
+          {
+            "signalId": "eval-domain:2026-07-07-eval-a2a-stable-void-hold-baseline#route-serial#inline_action.feedback_written",
+            "rawRef": "2026-07-07-eval-a2a-stable-void-hold-baseline#route-serial#inline_action.feedback_written",
+            "channel": "eval-domain"
+          }
+        ],
+        "method": "rule",
+        "sensorForms": [
+          "aggregate_proxy"
+        ],
+        "severity": "low"
+      },
+      {
+        "clusterId": "a60da62bea20",
+        "representative": "inline_action.routed_set_skip=1",
+        "channels": [
+          "eval-domain"
+        ],
+        "count": 2,
+        "members": [
+          {
+            "signalId": "eval-domain:2026-07-06-eval-a2a-ordinary-monitoring#route-serial#inline_action.routed_set_skip",
+            "rawRef": "2026-07-06-eval-a2a-ordinary-monitoring#route-serial#inline_action.routed_set_skip",
+            "channel": "eval-domain"
+          },
+          {
+            "signalId": "eval-domain:2026-07-07-eval-a2a-stable-void-hold-baseline#route-serial#inline_action.routed_set_skip",
+            "rawRef": "2026-07-07-eval-a2a-stable-void-hold-baseline#route-serial#inline_action.routed_set_skip",
+            "channel": "eval-domain"
+          }
+        ],
+        "method": "rule",
+        "sensorForms": [
+          "aggregate_proxy"
+        ],
+        "severity": "low"
+      }
+    ],
+    "actionableCandidates": [
+      {
+        "clusterId": "d981127d413a",
+        "representative": "a2a_timeout: codex",
+        "channels": [
+          "user-feedback"
+        ],
+        "count": 1,
+        "members": [
+          {
+            "signalId": "user-feedback:fi_mrcu4bxlv840fgsx",
+            "rawRef": "fi_mrcu4bxlv840fgsx",
+            "channel": "user-feedback"
+          }
+        ],
+        "method": "rule",
+        "sensorForms": [
+          "reason"
+        ],
+        "severity": "high",
+        "actionability": "actionable_candidate",
+        "followupDraft": {
+          "clusterId": "d981127d413a",
+          "title": "Investigate friction cluster: a2a_timeout: codex",
+          "summary": "a2a_timeout: codex",
+          "evidenceRefs": [
+            "fi_mrcu4bxlv840fgsx"
+          ],
+          "reportingMode": "final-only"
+        },
+        "referenceOnlyEvidenceRefs": []
+      }
+    ],
+    "referenceOnly": [
+      {
+        "clusterId": "23fba4045727",
+        "representative": "c2.void_hold_hint_emitted=6",
+        "channels": [
+          "eval-domain"
+        ],
+        "count": 2,
+        "members": [
+          {
+            "signalId": "eval-domain:2026-07-06-eval-a2a-ordinary-monitoring#C2#c2.void_hold_hint_emitted",
+            "rawRef": "2026-07-06-eval-a2a-ordinary-monitoring#C2#c2.void_hold_hint_emitted",
+            "channel": "eval-domain"
+          },
+          {
+            "signalId": "eval-domain:2026-07-07-eval-a2a-stable-void-hold-baseline#C2#c2.void_hold_hint_emitted",
+            "rawRef": "2026-07-07-eval-a2a-stable-void-hold-baseline#C2#c2.void_hold_hint_emitted",
+            "channel": "eval-domain"
+          }
+        ],
+        "method": "rule",
+        "sensorForms": [
+          "aggregate_proxy"
+        ],
+        "severity": "low",
+        "actionability": "reference_only",
+        "evidenceRefs": [
+          "2026-07-06-eval-a2a-ordinary-monitoring#C2#c2.void_hold_hint_emitted",
+          "2026-07-07-eval-a2a-stable-void-hold-baseline#C2#c2.void_hold_hint_emitted"
+        ]
+      },
+      {
+        "clusterId": "4901ab640cdd",
+        "representative": "inline_action.hint_emitted=1",
+        "channels": [
+          "eval-domain"
+        ],
+        "count": 2,
+        "members": [
+          {
+            "signalId": "eval-domain:2026-07-06-eval-a2a-ordinary-monitoring#route-serial#inline_action.hint_emitted",
+            "rawRef": "2026-07-06-eval-a2a-ordinary-monitoring#route-serial#inline_action.hint_emitted",
+            "channel": "eval-domain"
+          },
+          {
+            "signalId": "eval-domain:2026-07-07-eval-a2a-stable-void-hold-baseline#route-serial#inline_action.hint_emitted",
+            "rawRef": "2026-07-07-eval-a2a-stable-void-hold-baseline#route-serial#inline_action.hint_emitted",
+            "channel": "eval-domain"
+          }
+        ],
+        "method": "rule",
+        "sensorForms": [
+          "aggregate_proxy"
+        ],
+        "severity": "low",
+        "actionability": "reference_only",
+        "evidenceRefs": [
+          "2026-07-06-eval-a2a-ordinary-monitoring#route-serial#inline_action.hint_emitted",
+          "2026-07-07-eval-a2a-stable-void-hold-baseline#route-serial#inline_action.hint_emitted"
+        ]
+      },
+      {
+        "clusterId": "9d32022cb1ab",
+        "representative": "inline_action.feedback_written=1",
+        "channels": [
+          "eval-domain"
+        ],
+        "count": 2,
+        "members": [
+          {
+            "signalId": "eval-domain:2026-07-06-eval-a2a-ordinary-monitoring#route-serial#inline_action.feedback_written",
+            "rawRef": "2026-07-06-eval-a2a-ordinary-monitoring#route-serial#inline_action.feedback_written",
+            "channel": "eval-domain"
+          },
+          {
+            "signalId": "eval-domain:2026-07-07-eval-a2a-stable-void-hold-baseline#route-serial#inline_action.feedback_written",
+            "rawRef": "2026-07-07-eval-a2a-stable-void-hold-baseline#route-serial#inline_action.feedback_written",
+            "channel": "eval-domain"
+          }
+        ],
+        "method": "rule",
+        "sensorForms": [
+          "aggregate_proxy"
+        ],
+        "severity": "low",
+        "actionability": "reference_only",
+        "evidenceRefs": [
+          "2026-07-06-eval-a2a-ordinary-monitoring#route-serial#inline_action.feedback_written",
+          "2026-07-07-eval-a2a-stable-void-hold-baseline#route-serial#inline_action.feedback_written"
+        ]
+      },
+      {
+        "clusterId": "a60da62bea20",
+        "representative": "inline_action.routed_set_skip=1",
+        "channels": [
+          "eval-domain"
+        ],
+        "count": 2,
+        "members": [
+          {
+            "signalId": "eval-domain:2026-07-06-eval-a2a-ordinary-monitoring#route-serial#inline_action.routed_set_skip",
+            "rawRef": "2026-07-06-eval-a2a-ordinary-monitoring#route-serial#inline_action.routed_set_skip",
+            "channel": "eval-domain"
+          },
+          {
+            "signalId": "eval-domain:2026-07-07-eval-a2a-stable-void-hold-baseline#route-serial#inline_action.routed_set_skip",
+            "rawRef": "2026-07-07-eval-a2a-stable-void-hold-baseline#route-serial#inline_action.routed_set_skip",
+            "channel": "eval-domain"
+          }
+        ],
+        "method": "rule",
+        "sensorForms": [
+          "aggregate_proxy"
+        ],
+        "severity": "low",
+        "actionability": "reference_only",
+        "evidenceRefs": [
+          "2026-07-06-eval-a2a-ordinary-monitoring#route-serial#inline_action.routed_set_skip",
+          "2026-07-07-eval-a2a-stable-void-hold-baseline#route-serial#inline_action.routed_set_skip"
+        ]
+      }
+    ],
+    "tailSummary": {
+      "clusterCount": 0,
+      "signalCount": 0,
+      "byChannel": {}
+    },
+    "degraded": false,
+    "droppedChannels": [],
+    "tokenBudget": {
+      "cap": 4000,
+      "estimated": 1798
+    }
+  }
+}

--- a/docs/harness-feedback/bundles/2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only/snapshot.json
@@ -1,0 +1,30 @@
+{
+  "verdictId": "2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only",
+  "evalSnapshotId": "eval-F245-2026-07-09",
+  "featureId": "F245",
+  "generatedAt": "2026-07-09T03:09:18.602Z",
+  "window": {
+    "startMs": 1783306800000,
+    "endMs": 1783566000000,
+    "durationHours": 72
+  },
+  "components": [
+    {
+      "id": "friction-rollup",
+      "name": "friction rollup (Top-N + sensorForm)",
+      "confidence": "medium",
+      "activationCounts": {},
+      "frictionCounts": {
+        "cluster_count": 5,
+        "top_cluster_count": 5,
+        "tail_cluster_count": 0,
+        "tail_signal_count": 0,
+        "cluster_d981127d413a": 1,
+        "cluster_23fba4045727": 2,
+        "cluster_4901ab640cdd": 2,
+        "cluster_9d32022cb1ab": 2,
+        "cluster_a60da62bea20": 2
+      }
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only.md
+++ b/docs/harness-feedback/verdicts/2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only.md
@@ -1,0 +1,31 @@
+---
+feature_ids: [F245]
+topics: [harness-eval, eval-friction, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:friction
+packet_id: 2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only
+source_snapshot: "snapshot:bundle/2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only/snapshot"
+---
+
+# Live Verdict — 2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only
+
+- Verdict: `keep_observe`
+- Phenomenon: The every-3d friction window from 2026-07-06 03:00 UTC to 2026-07-09 03:00 UTC surfaced one new high-severity actionable singleton (`a2a_timeout: codex`) from the `Coactive 架构` thread, while the other four top clusters were recurring `eval:a2a` reference-only counters (`c2.void_hold_hint_emitted` plus three `inline_action.*` signals). The rollup remained degraded and the timeout had no second-channel echo, so the new signal looks like an isolated interruption rather than a stable cross-channel friction pattern.
+- Harness: F245/friction-rollup (friction rollup (Top-N + sensorForm))
+- Root cause: Most likely `environment_drift`: the only actionable cluster is a confirmed `a2a_timeout: codex` driven by Codex CLI/backend disconnects in the `Coactive 架构` thread, while the remaining top clusters are recurring `eval:a2a` reference-only counters rather than a fresh friction-harness defect. Confidence stays low because this is a singleton and the rollup remained degraded (rule-only clustering). (confidence low)
+- Owner ask: Keep the every-3d friction rollup running and escalate only if `a2a_timeout: codex` recurs, picks up a second channel, or the recurring `eval:a2a` reference-only clusters turn into a new source-domain verdict.
+- Re-eval: next eval at 2026-07-12T03:00:00.000Z
+
+Evidence:
+- snapshot:bundle/2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only/snapshot
+- attribution:bundle/2026-07-09-eval-friction-timeout-singleton-with-recurring-reference-only/FR-2026-07-09-d981127d413a
+- metric:friction-rollup.cluster_count
+- metric:friction-rollup.top_cluster_count
+- metric:friction-rollup.cluster_d981127d413a
+- metric:friction-rollup.cluster_23fba4045727
+
+Counterarguments:
+- A single high-severity timeout that lasted more than twelve minutes may still justify immediate owner investigation instead of another observation cycle.
+- The recurring reference-only `eval:a2a` counters may already be persistent enough that friction should escalate them again rather than only cite them.
+- Because the current rollup was degraded, the apparent singleton may reflect under-clustering rather than a genuinely isolated event.


### PR DESCRIPTION
Verdict published via cat_cafe_publish_verdict MCP tool.

Verdict: keep_observe
Domain: eval:friction
Phenomenon: The every-3d friction window from 2026-07-06 03:00 UTC to 2026-07-09 03:00 UTC surfaced one new high-severity actionable singleton (`a2a_timeout: codex`) from the `Coactive 架构` thread, while the other four top clusters were recurring `eval:a2a` reference-only counters (`c2.void_hold_hint_emitted` plus three `inline_action.*` signals). The rollup remained degraded and the timeout had no second-channel echo, so the new signal looks like an isolated interruption rather than a stable cross-channel friction pattern.

Reviewed by: gpt52
Action: Keep the every-3d friction rollup running and escalate only if `a2a_timeout: codex` recurs, picks up a second channel, or the recurring `eval:a2a` reference-only clusters turn into a new source-domain verdict.

---
**Cat-owned artifact gate — No operator merge needed.**
(Actionable findings present; eval domain owner cat merges per docs/SOP.md § artifact-only-pr-merge-gate.)