### PR TITLE
verdict(eval:qc): 2026-07-12-eval-qc-zero-baseline-w28

### DIFF
--- a/docs/harness-feedback/bundles/2026-07-12-eval-qc-zero-baseline-w28/attribution.json
+++ b/docs/harness-feedback/bundles/2026-07-12-eval-qc-zero-baseline-w28/attribution.json
@@ -1,0 +1,11 @@
+{
+  "verdictId": "2026-07-12-eval-qc-zero-baseline-w28",
+  "featureId": "F253",
+  "evalSnapshotId": "qc-snapshot-2026-07-12-eval-qc-zero-baseline-w28",
+  "generatedAt": "2026-07-12T03:07:54.524Z",
+  "findings": [],
+  "noFindingRecord": {
+    "reason": "Zero-baseline bootstrap (Phase C) — no live QC data sources wired",
+    "evidence": "All QC metrics are zero (prCount=0). Eval:qc data pipeline not yet active."
+  }
+}

--- a/docs/harness-feedback/bundles/2026-07-12-eval-qc-zero-baseline-w28/provenance.json
+++ b/docs/harness-feedback/bundles/2026-07-12-eval-qc-zero-baseline-w28/provenance.json
@@ -1,0 +1,15 @@
+{
+  "verdictId": "2026-07-12-eval-qc-zero-baseline-w28",
+  "rawInputs": [
+    {
+      "path": "bundles/2026-07-12-eval-qc-zero-baseline-w28/snapshot.json",
+      "sha256": "4235c7eb9bb3e203ad46425451f5e2766546a24ede6f831759e96d4605a36c9d"
+    }
+  ],
+  "generatedAt": "2026-07-12T03:07:54.524Z",
+  "generator": {
+    "name": "qc-generator-adapter",
+    "version": "1.0.0"
+  },
+  "sanitizeRulesVersion": "1.0.0"
+}

--- a/docs/harness-feedback/bundles/2026-07-12-eval-qc-zero-baseline-w28/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-07-12-eval-qc-zero-baseline-w28/snapshot.json
@@ -1,0 +1,27 @@
+{
+  "verdictId": "2026-07-12-eval-qc-zero-baseline-w28",
+  "evalSnapshotId": "qc-snapshot-2026-07-12-eval-qc-zero-baseline-w28",
+  "featureId": "F253",
+  "generatedAt": "2026-07-12T03:07:54.524Z",
+  "window": {
+    "startMs": 1783209600000,
+    "endMs": 1783814400000,
+    "durationHours": 168
+  },
+  "components": [
+    {
+      "componentId": "qc-pipeline",
+      "componentName": "QC Pipeline",
+      "activationCounts": {
+        "finding_yield": 0,
+        "reviewer_delta": 0,
+        "pr_count": 0
+      },
+      "frictionCounts": {
+        "false_positive_rate": 0,
+        "post_merge_bug_rate": 0
+      },
+      "confidence": "no-data"
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-07-12-eval-qc-zero-baseline-w28.md
+++ b/docs/harness-feedback/verdicts/2026-07-12-eval-qc-zero-baseline-w28.md
@@ -1,0 +1,36 @@
+---
+feature_ids: [F253]
+topics: [harness-eval, eval-qc, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:qc
+packet_id: 2026-07-12-eval-qc-zero-baseline-w28
+source_snapshot: "snapshot:bundle/2026-07-12-eval-qc-zero-baseline-w28/snapshot"
+---
+
+# eval:qc Verdict — 2026-07-12-eval-qc-zero-baseline-w28
+
+- Verdict: `keep_observe`
+- Phenomenon: QC pipeline metrics remain in zero-baseline state — no review telemetry events collected during the Jul 5–12 window. Phase C bootstrap: the qc-metrics-provider returns zeroes for all 4 metrics (finding yield, false positive rate, reviewer delta, post-merge bug rate) because no live data source is wired yet.
+- Harness: F253/qc-pipeline (QC Review Loop)
+- Owner ask: No action required. Continue observing until a future phase wires live review telemetry events into the QC metrics provider.
+- Re-eval: next eval at 2026-07-19T03:00:00.000Z
+
+Evidence:
+- snapshot:bundle/2026-07-12-eval-qc-zero-baseline-w28/snapshot
+- attribution:bundle/2026-07-12-eval-qc-zero-baseline-w28/qc-snapshot-2026-07-12-eval-qc-zero-baseline-w28:no-finding
+
+**Window**: 7 days | **PRs analyzed**: 0
+
+## Metrics
+
+| Metric | Value |
+|--------|-------|
+| Finding Yield (avg/review) | 0 |
+| False Positive Rate | 0 |
+| Reviewer Delta | 0 |
+| Post-Merge Bug Rate | 0 |
+
+## Notes
+
+No PR data available in this window. Zero-baseline snapshot (Phase C bootstrap — live data sources not yet wired).


### PR DESCRIPTION
Verdict published via cat_cafe_publish_verdict MCP tool.

Verdict: keep_observe
Domain: eval:qc
Phenomenon: QC pipeline metrics remain in zero-baseline state — no review telemetry events collected during the Jul 5–12 window. Phase C bootstrap: the qc-metrics-provider returns zeroes for all 4 metrics (finding yield, false positive rate, reviewer delta, post-merge bug rate) because no live data source is wired yet.

Reviewed by: opus
Action: No action required. Continue observing until a future phase wires live review telemetry events into the QC metrics provider.

---
**Cat-owned artifact gate — No operator merge needed.**
(Interim: keep_observe + no actionable findings. Rollup mechanism deferred to future Phase. See docs/SOP.md § artifact-only-pr-merge-gate for cat merge contract.)