### PR TITLE
verdict(eval:anchor-first): 2026-07-12-eval-anchor-first-c1-keep-observe

### DIFF
--- a/docs/harness-feedback/bundles/2026-07-12-eval-anchor-first-c1-keep-observe/attribution.json
+++ b/docs/harness-feedback/bundles/2026-07-12-eval-anchor-first-c1-keep-observe/attribution.json
@@ -1,0 +1,47 @@
+{
+  "verdictId": "2026-07-12-eval-anchor-first-c1-keep-observe",
+  "featureId": "F236",
+  "evalSnapshotId": "eval-F236-2026-07-12",
+  "generatedAt": "2026-07-12T03:16:06.684Z",
+  "findings": [
+    {
+      "id": "AF-2026-07-12-thread-context",
+      "relatedFeature": "F236",
+      "sunsetSignals": {
+        "anchorTax": false,
+        "highOpenRate": false,
+        "netNegative": false
+      },
+      "frictionSignal": {
+        "type": "anchor.open_rate.thread-context",
+        "severity": "low",
+        "confidence": 0.8,
+        "detectedAt": "2026-07-12T03:16:06.684Z"
+      },
+      "attribution": {
+        "primaryLayer": "needs_investigation",
+        "evidence": [
+          {
+            "type": "counter",
+            "anchor": "anchor-telemetry-rollup/thread-context_drilled_unique_items",
+            "excerpt": "thread-context: 1/110 items drilled (0.9% open rate), charsSaved=280650, drillChars=1453, netBenefit=279197"
+          }
+        ]
+      },
+      "proposedAction": [
+        {
+          "action": "keep-observe",
+          "target": "anchor-telemetry-rollup/thread-context",
+          "rationale": "Open rate 0.9%: 1/110 items drilled, net benefit 279197 chars"
+        }
+      ]
+    }
+  ],
+  "sunsetAssessment": {
+    "toolCount": 1,
+    "toolsWithAnchorTax": 0,
+    "toolsNetNegative": 0,
+    "toolsHighOpenRate": 0,
+    "lowSampleToolCount": 0
+  }
+}

--- a/docs/harness-feedback/bundles/2026-07-12-eval-anchor-first-c1-keep-observe/provenance.json
+++ b/docs/harness-feedback/bundles/2026-07-12-eval-anchor-first-c1-keep-observe/provenance.json
@@ -1,0 +1,15 @@
+{
+  "verdictId": "2026-07-12-eval-anchor-first-c1-keep-observe",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/bundles/2026-07-12-eval-anchor-first-c1-keep-observe/raw/rollup.json",
+      "sha256": "e6d7fd49e6e2c1b2858988d69156324fd70a93b4233ed0b8e0d6afe3d19842d8"
+    }
+  ],
+  "generatedAt": "2026-07-12T03:16:06.684Z",
+  "generator": {
+    "name": "eval-anchor-first-live-verdict",
+    "version": "1"
+  },
+  "sanitizeRulesVersion": "f236-anchor-telemetry-v1"
+}

--- a/docs/harness-feedback/bundles/2026-07-12-eval-anchor-first-c1-keep-observe/raw/rollup.json
+++ b/docs/harness-feedback/bundles/2026-07-12-eval-anchor-first-c1-keep-observe/raw/rollup.json
@@ -1,0 +1,49 @@
+{
+  "verdictId": "2026-07-12-eval-anchor-first-c1-keep-observe",
+  "selector": {
+    "kind": "anchor-telemetry-snapshot",
+    "windowStartMs": 1783739721102,
+    "windowEndMs": 1783826121102
+  },
+  "rollup": {
+    "perTool": {
+      "thread-context": {
+        "previewResponses": 16,
+        "previewedItems": 110,
+        "drills": 1,
+        "drilledUniqueItems": 1,
+        "openRateByItem": 0.00909090909090909,
+        "returnedChars": 35478,
+        "originalChars": 316128,
+        "charsSaved": 280650,
+        "drillChars": 1453,
+        "netBenefit": 279197
+      }
+    },
+    "orphanDrills": 0,
+    "adoption": {
+      "explicitAnchorCalls": 2,
+      "explicitFullCalls": 3,
+      "defaultAnchorCalls": 14,
+      "defaultFullCalls": 0,
+      "legacyEquivalentAnchorCalls": 0,
+      "legacyEquivalentFullCalls": 1,
+      "unknownModeCalls": 0,
+      "uniqueCatsExplicitAnchor": 1
+    },
+    "track1Snapshot": {
+      "returnedByTool": {
+        "thread-context": 16
+      },
+      "returnedCharsByTool": {
+        "thread-context": 85572
+      },
+      "drillByTool": {
+        "get-message": 1
+      },
+      "drillCharsByTool": {
+        "get-message": 1453
+      }
+    }
+  }
+}

--- a/docs/harness-feedback/bundles/2026-07-12-eval-anchor-first-c1-keep-observe/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-07-12-eval-anchor-first-c1-keep-observe/snapshot.json
@@ -1,0 +1,39 @@
+{
+  "verdictId": "2026-07-12-eval-anchor-first-c1-keep-observe",
+  "evalSnapshotId": "eval-F236-2026-07-12",
+  "featureId": "F236",
+  "generatedAt": "2026-07-12T03:16:06.684Z",
+  "window": {
+    "startMs": 1783739721102,
+    "endMs": 1783826121102,
+    "durationHours": 24
+  },
+  "components": [
+    {
+      "id": "anchor-telemetry-rollup",
+      "name": "anchor-first preview/drill open-rate rollup",
+      "confidence": "medium",
+      "activationCounts": {
+        "orphan_drills": 0,
+        "adoption_explicit_anchor_calls": 2,
+        "adoption_explicit_full_calls": 3,
+        "adoption_default_anchor_calls": 14,
+        "adoption_default_full_calls": 0,
+        "adoption_legacy_equivalent_anchor_calls": 0,
+        "adoption_legacy_equivalent_full_calls": 1,
+        "adoption_unique_cats_explicit_anchor": 1,
+        "adoption_unknown_mode_calls": 0,
+        "thread-context_preview_responses": 16,
+        "thread-context_previewed_items": 110,
+        "thread-context_drills": 1,
+        "thread-context_drilled_unique_items": 1,
+        "thread-context_returned_chars": 35478,
+        "thread-context_original_chars": 316128,
+        "thread-context_chars_saved": 280650,
+        "thread-context_drill_chars": 1453,
+        "thread-context_net_benefit": 279197
+      },
+      "frictionCounts": {}
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-07-12-eval-anchor-first-c1-keep-observe.md
+++ b/docs/harness-feedback/verdicts/2026-07-12-eval-anchor-first-c1-keep-observe.md
@@ -1,0 +1,44 @@
+---
+feature_ids: [F192, F236]
+topics: [harness-eval, eval-anchor-first, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:anchor-first
+packet_id: 2026-07-12-eval-anchor-first-c1-keep-observe
+source_snapshot: "snapshot:bundle/2026-07-12-eval-anchor-first-c1-keep-observe/snapshot"
+---
+
+# Live Verdict — 2026-07-12-eval-anchor-first-c1-keep-observe
+
+- Verdict: `keep_observe`
+- Phenomenon: The latest 24h anchor-first window appears low-volume and concentrated in thread-context preview traffic, while independent blindness evidence is absent because eval:task-outcome has not yet produced published verdict trends. Current evidence is enough to watch adoption and open-rate detail, but not enough to justify sunset or a corrective fix.
+- Harness: F236/anchor-telemetry-rollup (anchor-first preview/drill open-rate rollup)
+- Owner ask: Keep F236 in observe mode, gather another full 24h anchor-telemetry window, and wait for eval:task-outcome trend evidence before considering fix or sunset.
+- Re-eval: Re-evaluate when the next 24h rollup either shows a tool with enough preview volume to assess sunset signals confidently or eval:task-outcome publishes trend evidence that can confirm or reject blindness. at 2026-07-19T03:15:21.102Z
+
+Sunset Signal Assessment:
+- thread-context: HEALTHY (openRate=0.9%, netBenefit=279197)
+
+Open-Rate Detail:
+- thread-context: 0.9% open rate (1/110 items), charsSaved=280650, drillChars=1453, netBenefit=279197
+- Orphan drills: 0
+
+Adoption Detail:
+- explicitAnchorCalls=2; explicitFullCalls=3; uniqueCatsExplicitAnchor=1
+- defaultAnchorCalls=14; defaultFullCalls=0
+- legacyEquivalentAnchorCalls=0; legacyEquivalentFullCalls=1
+- unknownModeCalls=0
+
+Evidence:
+- snapshot:bundle/2026-07-12-eval-anchor-first-c1-keep-observe/snapshot
+- attribution:bundle/2026-07-12-eval-anchor-first-c1-keep-observe/AF-2026-07-12-thread-context
+- metric:prometheus:cat_cafe_anchor_returned_count_total{anchor_tool="thread-context"}
+- metric:prometheus:cat_cafe_anchor_full_drill_count_total{anchor_tool="get-message"}
+- metric:sqlite:task_outcome_episodes.with_verdict=0
+- data/transcripts/threads/thread_eval_anchor_first/gpt52/sessions/bb6104ac-0a88-4f75-81cd-b14e856c39db/events.live.jsonl
+- task-outcome-episodes.sqlite
+
+Counterarguments:
+- The live rollup could still show a high open-rate or negative net benefit on a low-visibility tool even though Track-1 counters look healthy at the aggregate level.
+- Because task-outcome evidence is currently missing, this verdict may be underreacting to a real but unmeasured blindness effect.
+- If the current process lifetime is materially shorter than 24h, the window may under-sample adoption and make the rollout look healthier than it is.


### PR DESCRIPTION
Verdict published via cat_cafe_publish_verdict MCP tool.

Verdict: keep_observe
Domain: eval:anchor-first
Phenomenon: The latest 24h anchor-first window appears low-volume and concentrated in thread-context preview traffic, while independent blindness evidence is absent because eval:task-outcome has not yet produced published verdict trends. Current evidence is enough to watch adoption and open-rate detail, but not enough to justify sunset or a corrective fix.

Reviewed by: opus-47
Action: Keep F236 in observe mode, gather another full 24h anchor-telemetry window, and wait for eval:task-outcome trend evidence before considering fix or sunset.

---
**Cat-owned artifact gate — No operator merge needed.**
(Actionable findings present; eval domain owner cat merges per docs/SOP.md § artifact-only-pr-merge-gate.)