### PR TITLE
fix(test): isolate runtime worktree env fixtures

### DIFF
--- a/packages/api/test/install-script-test-helpers.js
+++ b/packages/api/test/install-script-test-helpers.js
@@ -19,6 +19,23 @@ const repoRoot = resolve(testDir, '..', '..', '..');
 
 export const installScript = resolve(repoRoot, 'scripts', 'install.sh');
 
+const INSTALL_TEST_ENV_KEYS = [
+  'CAT_CAFE_GLOBAL_CONFIG_ROOT',
+  'CAT_CAFE_RUNTIME_BRANCH',
+  'CAT_CAFE_RUNTIME_DIR',
+  'CAT_CAFE_RUNTIME_REMOTE',
+  'CAT_CAFE_RUNTIME_ROOT',
+  'CAT_CAFE_WORKSPACE_ROOT',
+];
+
+function withInstallTestEnv(overrides = {}) {
+  const env = { ...process.env };
+  for (const key of INSTALL_TEST_ENV_KEYS) {
+    delete env[key];
+  }
+  return { ...env, ...overrides };
+}
+
 export {
   assert,
   basename,
@@ -39,7 +56,7 @@ export function runSourceOnlySnippet(snippet) {
   const result = spawnSync(
     'bash',
     ['-lc', `set -e\nsource "${installScript}" --source-only >/dev/null 2>&1\n${snippet}`],
-    { encoding: 'utf8' },
+    { encoding: 'utf8', env: withInstallTestEnv() },
   );
 
   assert.equal(

--- a/packages/api/test/runtime-worktree-script.test.js
+++ b/packages/api/test/runtime-worktree-script.test.js
@@ -20,6 +20,22 @@ const tempProcs = [];
 
 process.env.CAT_CAFE_SKIP_NODE_RUNTIME_GUARD = '1';
 
+const RUNTIME_WORKTREE_TEST_ENV_KEYS = [
+  'CAT_CAFE_RUNTIME_BRANCH',
+  'CAT_CAFE_RUNTIME_DIR',
+  'CAT_CAFE_RUNTIME_REMOTE',
+  'CAT_CAFE_RUNTIME_ROOT',
+  'CAT_CAFE_WORKSPACE_ROOT',
+];
+
+function withRuntimeWorktreeTestEnv(overrides = {}) {
+  const env = { ...process.env };
+  for (const key of RUNTIME_WORKTREE_TEST_ENV_KEYS) {
+    delete env[key];
+  }
+  return { ...env, CAT_CAFE_SKIP_NODE_RUNTIME_GUARD: '1', ...overrides };
+}
+
 function createTempProject(name) {
   const projectDir = mkdtempSync(join(tmpdir(), `${name}-`));
   tempDirs.push(projectDir);
@@ -150,12 +166,11 @@ exit 0
 
 function withStubbedPnpmEnv(projectDir, options = {}) {
   const { binDir, logFile } = createPnpmStub(projectDir, options);
-  return {
-    ...process.env,
+  return withRuntimeWorktreeTestEnv({
     CAT_CAFE_RUNTIME_RESTART_OK: '1',
     PATH: `${binDir}:${process.env.PATH}`,
     RUNTIME_TEST_PNPM_LOG: logFile,
-  };
+  });
 }
 
 function seedRuntimeDependencyMarkers(projectDir) {
@@ -321,7 +336,7 @@ printf 'ok'`,
     const result = spawnSync('bash', [join(projectDir, 'scripts', 'runtime-worktree.sh'), 'start', '--no-sync'], {
       cwd: projectDir,
       encoding: 'utf8',
-      env: { ...process.env, CAT_CAFE_RUNTIME_RESTART_OK: '1' },
+      env: withRuntimeWorktreeTestEnv({ CAT_CAFE_RUNTIME_RESTART_OK: '1' }),
     });
 
     assert.equal(result.status, 0);
@@ -354,7 +369,7 @@ server.listen(3010,'127.0.0.1',()=>setInterval(()=>{},1000));`,
     const result = spawnSync('bash', [join(projectDir, 'scripts', 'runtime-worktree.sh'), 'start', '--no-sync'], {
       cwd: projectDir,
       encoding: 'utf8',
-      env: { ...process.env, CAT_CAFE_RUNTIME_RESTART_OK: '1' },
+      env: withRuntimeWorktreeTestEnv({ CAT_CAFE_RUNTIME_RESTART_OK: '1' }),
     });
 
     assert.equal(result.status, 0, `exit=${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
@@ -396,6 +411,7 @@ server.listen(3010,'127.0.0.1',()=>setInterval(()=>{},1000));`,
       {
         cwd: projectDir,
         encoding: 'utf8',
+        env: withRuntimeWorktreeTestEnv(),
       },
     );
 
@@ -416,7 +432,7 @@ server.listen(3010,'127.0.0.1',()=>setInterval(()=>{},1000));`,
     const result = spawnSync('bash', [join(projectDir, 'scripts', 'runtime-worktree.sh'), 'start', '--no-sync'], {
       cwd: projectDir,
       encoding: 'utf8',
-      env: { ...process.env, CAT_CAFE_RUNTIME_RESTART_OK: '1' },
+      env: withRuntimeWorktreeTestEnv({ CAT_CAFE_RUNTIME_RESTART_OK: '1' }),
     });
 
     assert.notEqual(result.status, 0);
@@ -624,7 +640,7 @@ server.listen(3010,'127.0.0.1',()=>setInterval(()=>{},1000));`,
     const result = spawnSync('bash', [join(projectDir, 'scripts', 'runtime-worktree.sh'), 'start', '--no-sync'], {
       cwd: projectDir,
       encoding: 'utf8',
-      env: { ...process.env, CAT_CAFE_RUNTIME_RESTART_OK: '1' },
+      env: withRuntimeWorktreeTestEnv({ CAT_CAFE_RUNTIME_RESTART_OK: '1' }),
     });
 
     assert.equal(result.status, 0, `exit=${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
@@ -652,12 +668,11 @@ server.listen(3002,'127.0.0.1',()=>setInterval(()=>{},1000));`,
     tempProcs.push(server);
     await waitForLocalPort(3002);
 
-    const ncFallbackEnv = {
-      ...process.env,
+    const ncFallbackEnv = withRuntimeWorktreeTestEnv({
       API_SERVER_PORT: '3002',
       PATH: `${binDir}:${process.env.PATH}`,
       RUNTIME_TEST_PNPM_LOG: logFile,
-    };
+    });
     // Ensure CAT_CAFE_RUNTIME_RESTART_OK is not inherited from the parent env;
     // this test specifically validates that restart is REFUSED when the API port is active.
     delete ncFallbackEnv.CAT_CAFE_RUNTIME_RESTART_OK;
@@ -691,10 +706,9 @@ server.listen(3010,'127.0.0.1',()=>setInterval(()=>{},1000));`,
     tempProcs.push(server);
     await waitForLocalPort(3010);
 
-    const envFilePortEnv = {
-      ...process.env,
+    const envFilePortEnv = withRuntimeWorktreeTestEnv({
       CAT_CAFE_RUNTIME_DIR: projectDir,
-    };
+    });
     // Ensure CAT_CAFE_RUNTIME_RESTART_OK is not inherited from the parent env;
     // this test validates that restart is REFUSED when .env API_SERVER_PORT is active.
     delete envFilePortEnv.CAT_CAFE_RUNTIME_RESTART_OK;
@@ -837,11 +851,10 @@ server.listen(3010,'127.0.0.1',()=>setInterval(()=>{},1000));`,
     const result = spawnSync('bash', [join(projectDir, 'scripts', 'runtime-worktree.sh'), 'start', '--no-install'], {
       cwd: projectDir,
       encoding: 'utf8',
-      env: {
-        ...process.env,
+      env: withRuntimeWorktreeTestEnv({
         CAT_CAFE_RUNTIME_DIR: normalizedRuntimeDir,
         API_SERVER_PORT: '19899',
-      },
+      }),
     });
 
     assert.notEqual(result.status, 0);
@@ -884,11 +897,10 @@ server.listen(3010,'127.0.0.1',()=>setInterval(()=>{},1000));`,
     const result = spawnSync('bash', [join(projectDir, 'scripts', 'runtime-worktree.sh'), 'start', '--no-install'], {
       cwd: projectDir,
       encoding: 'utf8',
-      env: {
-        ...process.env,
+      env: withRuntimeWorktreeTestEnv({
         CAT_CAFE_RUNTIME_DIR: normalizedRuntimeDir,
         API_SERVER_PORT: '19899',
-      },
+      }),
     });
 
     assert.notEqual(result.status, 0);
@@ -933,11 +945,10 @@ server.listen(3010,'127.0.0.1',()=>setInterval(()=>{},1000));`,
     const result = spawnSync('bash', [join(projectDir, 'scripts', 'runtime-worktree.sh'), 'start', '--no-install'], {
       cwd: projectDir,
       encoding: 'utf8',
-      env: {
-        ...process.env,
+      env: withRuntimeWorktreeTestEnv({
         CAT_CAFE_RUNTIME_DIR: normalizedRuntimeDir,
         API_SERVER_PORT: '19899',
-      },
+      }),
     });
 
     assert.notEqual(result.status, 0);


### PR DESCRIPTION
## What

- Isolate install/runtime worktree test subprocess environments from ambient runtime session variables.
- Add shared sanitizers for runtime worktree fixture tests so active session values do not change fixture branch/dir expectations.
- Scope is test harness only: two files under packages/api/test.

## Why

The scheduler missed-ledger branch was blocked by unrelated baseline gate failures. The failing install/runtime worktree suites inherited active session variables such as CAT_CAFE_RUNTIME_BRANCH and CAT_CAFE_RUNTIME_DIR, while their fixtures expected runtime/main-sync. That made main red under this local runtime session and hid the scheduler signal.

## Issue Closure

- None. Patrol baseline gate cleanup discovered during scheduler review.

## Original Requirements

- Source: scheduled patrol mission, 2026-07-12 00:00 Asia/Shanghai.
- Excerpt: inspect Clowder Code / Cat Cafe for imperfect, improvable, competitiveness-relevant areas; verify truth sources and evidence first; close executable findings through lifecycle, implementation, gate, review, and completion records.
- Operator pain: scheduler work should not be blocked by unrelated environment-sensitive baseline tests.
- Reviewer check: this PR should only remove ambient env pollution from test fixtures, not change runtime behavior.

## Plan / ADR

- Plan: patrol finding from scheduler baseline gate attribution.
- ADR: none.
- BACKLOG: none.

## Tips Contribution

- [ ] Added or updated tips
- [ ] Existing tip sourceRef still covers this user-visible change
- [x] tips_exempt: internal test harness stabilization; no user-visible capability change.

## Tradeoff

This does not change runtime-worktree.sh behavior. It confines the fix to test subprocess env setup so production/runtime semantics remain untouched.

## Test Evidence

- Targeted RED before fix: install/runtime worktree suites had 40 pass / 5 fail under inherited runtime env.
- Targeted GREEN after fix: with Node 24 and shared-state preflight disabled, install/runtime worktree suites pass 45/45.
- pnpm check: pass.
- pnpm gate: pass on fix/runtime-worktree-baseline-gate at f5d79970, rebased onto origin/main.
- git diff --check origin/main...HEAD: clean.
- Root artifact guard: no root media/design artifacts.

## Open Questions

- Please verify the env sanitizer is narrow enough: clears runtime fixture pollution without hiding variables each test intentionally sets.

---

**Local Review**: [x] Maine Coon GPT-5.4 reviewed f5d799702d42b3d062406ff05c7cb0578957f72f and gave scoped APPROVE.
**Cloud Review**: [ ] PR comment trigger pending after creation.

<!-- Cat signature, no route handle: Maine Coon/GPT-5.5 codex -->