### PR TITLE
verdict(eval:friction): 2026-07-15-eval-friction-empty-window-after-singleton-recovery

### DIFF
--- a/docs/harness-feedback/bundles/2026-07-15-eval-friction-empty-window-after-singleton-recovery/attribution.json
+++ b/docs/harness-feedback/bundles/2026-07-15-eval-friction-empty-window-after-singleton-recovery/attribution.json
@@ -1,0 +1,11 @@
+{
+  "verdictId": "2026-07-15-eval-friction-empty-window-after-singleton-recovery",
+  "featureId": "F245",
+  "evalSnapshotId": "eval-F245-2026-07-15",
+  "generatedAt": "2026-07-15T03:01:28.912Z",
+  "findings": [],
+  "noFindingRecord": {
+    "reason": "no friction cluster surfaced in the selected window",
+    "evidence": "friction-rollup/cluster_count"
+  }
+}

--- a/docs/harness-feedback/bundles/2026-07-15-eval-friction-empty-window-after-singleton-recovery/provenance.json
+++ b/docs/harness-feedback/bundles/2026-07-15-eval-friction-empty-window-after-singleton-recovery/provenance.json
@@ -1,0 +1,15 @@
+{
+  "verdictId": "2026-07-15-eval-friction-empty-window-after-singleton-recovery",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/bundles/2026-07-15-eval-friction-empty-window-after-singleton-recovery/raw/rollup-report.json",
+      "sha256": "329b4f77122ad1f64847c97a6de07c1fc550368fdab05c72c317c456ab5d64b4"
+    }
+  ],
+  "generatedAt": "2026-07-15T03:01:28.912Z",
+  "generator": {
+    "name": "eval-friction-live-verdict",
+    "version": "1"
+  },
+  "sanitizeRulesVersion": "f245-friction-rollup-v1"
+}

--- a/docs/harness-feedback/bundles/2026-07-15-eval-friction-empty-window-after-singleton-recovery/raw/rollup-report.json
+++ b/docs/harness-feedback/bundles/2026-07-15-eval-friction-empty-window-after-singleton-recovery/raw/rollup-report.json
@@ -1,0 +1,39 @@
+{
+  "verdictId": "2026-07-15-eval-friction-empty-window-after-singleton-recovery",
+  "selector": {
+    "kind": "friction-rollup-snapshot",
+    "windowStartMs": 1783825200000,
+    "windowEndMs": 1784084400000,
+    "topN": 10,
+    "tokenCap": 4000
+  },
+  "window": {
+    "sinceMs": 1783825200000,
+    "untilMs": 1784084400000
+  },
+  "signalCount": 0,
+  "clusterCount": 0,
+  "degraded": false,
+  "droppedChannels": [],
+  "report": {
+    "window": {
+      "sinceMs": 1783825200000,
+      "untilMs": 1784084400000
+    },
+    "generatedAt": "2026-07-15T03:01:28.912Z",
+    "topClusters": [],
+    "actionableCandidates": [],
+    "referenceOnly": [],
+    "tailSummary": {
+      "clusterCount": 0,
+      "signalCount": 0,
+      "byChannel": {}
+    },
+    "degraded": false,
+    "droppedChannels": [],
+    "tokenBudget": {
+      "cap": 4000,
+      "estimated": 78
+    }
+  }
+}

--- a/docs/harness-feedback/bundles/2026-07-15-eval-friction-empty-window-after-singleton-recovery/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-07-15-eval-friction-empty-window-after-singleton-recovery/snapshot.json
@@ -1,0 +1,25 @@
+{
+  "verdictId": "2026-07-15-eval-friction-empty-window-after-singleton-recovery",
+  "evalSnapshotId": "eval-F245-2026-07-15",
+  "featureId": "F245",
+  "generatedAt": "2026-07-15T03:01:28.912Z",
+  "window": {
+    "startMs": 1783825200000,
+    "endMs": 1784084400000,
+    "durationHours": 72
+  },
+  "components": [
+    {
+      "id": "friction-rollup",
+      "name": "friction rollup (Top-N + sensorForm)",
+      "confidence": "low",
+      "activationCounts": {},
+      "frictionCounts": {
+        "cluster_count": 0,
+        "top_cluster_count": 0,
+        "tail_cluster_count": 0,
+        "tail_signal_count": 0
+      }
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-07-15-eval-friction-empty-window-after-singleton-recovery.md
+++ b/docs/harness-feedback/verdicts/2026-07-15-eval-friction-empty-window-after-singleton-recovery.md
@@ -1,0 +1,30 @@
+---
+feature_ids: [F245]
+topics: [harness-eval, eval-friction, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:friction
+packet_id: 2026-07-15-eval-friction-empty-window-after-singleton-recovery
+source_snapshot: "snapshot:bundle/2026-07-15-eval-friction-empty-window-after-singleton-recovery/snapshot"
+---
+
+# Live Verdict — 2026-07-15-eval-friction-empty-window-after-singleton-recovery
+
+- Verdict: `keep_observe`
+- Phenomenon: The every-3d friction window from 2026-07-12 03:00 UTC to 2026-07-15 03:00 UTC produced no friction signals, no actionableCandidates, and no referenceOnly clusters. This is a further improvement from the prior 72h window, which had one medium-severity `text_frustration` singleton and no recurrence afterward.
+- Harness: F245/friction-rollup (friction rollup (Top-N + sensorForm))
+- Root cause: No active root cause is observable in the current window. The prior `text_frustration` incident most plausibly reflected a transient `execution_gap` or `translation_gap` in one thread, but that pattern did not recur in this 72h cycle. (confidence low)
+- Owner ask: Keep the every-3d friction rollup running and only escalate if the prior singleton reappears, a new actionableCandidate appears, or a referenceOnly eval-domain cluster returns.
+- Re-eval: next eval at 2026-07-18T03:00:00.000Z
+
+Evidence:
+- snapshot:bundle/2026-07-15-eval-friction-empty-window-after-singleton-recovery/snapshot
+- attribution:bundle/2026-07-15-eval-friction-empty-window-after-singleton-recovery/eval-F245-2026-07-15:no-finding
+- metric:friction-rollup.cluster_count
+- metric:friction-rollup.top_cluster_count
+- metric:friction-rollup.tail_signal_count
+
+Counterarguments:
+- One empty window after a singleton is not enough to prove the underlying behavior is fixed.
+- A no-signal window under degraded rollup conditions can understate real friction rather than demonstrate recovery.
+- If the prior incident came from a narrow thread/topic, its disappearance may reflect topic completion rather than a real harness improvement.


### PR DESCRIPTION
Verdict published via cat_cafe_publish_verdict MCP tool.

Verdict: keep_observe
Domain: eval:friction
Phenomenon: The every-3d friction window from 2026-07-12 03:00 UTC to 2026-07-15 03:00 UTC produced no friction signals, no actionableCandidates, and no referenceOnly clusters. This is a further improvement from the prior 72h window, which had one medium-severity `text_frustration` singleton and no recurrence afterward.

Reviewed by: gpt52
Action: Keep the every-3d friction rollup running and only escalate if the prior singleton reappears, a new actionableCandidate appears, or a referenceOnly eval-domain cluster returns.

---
**Cat-owned artifact gate — No operator merge needed.**
(Interim: keep_observe + no actionable findings. Rollup mechanism deferred to future Phase. See docs/SOP.md § artifact-only-pr-merge-gate for cat merge contract.)