### PR TITLE
verdict(eval:friction): 2026-07-18-eval-friction-second-empty-window-stable-recovery-watch

### DIFF
--- a/docs/harness-feedback/bundles/2026-07-18-eval-friction-second-empty-window-stable-recovery-watch/attribution.json
+++ b/docs/harness-feedback/bundles/2026-07-18-eval-friction-second-empty-window-stable-recovery-watch/attribution.json
@@ -1,0 +1,11 @@
+{
+  "verdictId": "2026-07-18-eval-friction-second-empty-window-stable-recovery-watch",
+  "featureId": "F245",
+  "evalSnapshotId": "eval-F245-2026-07-18",
+  "generatedAt": "2026-07-18T03:01:47.175Z",
+  "findings": [],
+  "noFindingRecord": {
+    "reason": "no friction cluster surfaced in the selected window",
+    "evidence": "friction-rollup/cluster_count"
+  }
+}

--- a/docs/harness-feedback/bundles/2026-07-18-eval-friction-second-empty-window-stable-recovery-watch/provenance.json
+++ b/docs/harness-feedback/bundles/2026-07-18-eval-friction-second-empty-window-stable-recovery-watch/provenance.json
@@ -1,0 +1,15 @@
+{
+  "verdictId": "2026-07-18-eval-friction-second-empty-window-stable-recovery-watch",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/bundles/2026-07-18-eval-friction-second-empty-window-stable-recovery-watch/raw/rollup-report.json",
+      "sha256": "f5f393ce722c08ae25980d6f9f2fddec432066d83fef0073513e5eff93e072fc"
+    }
+  ],
+  "generatedAt": "2026-07-18T03:01:47.175Z",
+  "generator": {
+    "name": "eval-friction-live-verdict",
+    "version": "1"
+  },
+  "sanitizeRulesVersion": "f245-friction-rollup-v1"
+}

--- a/docs/harness-feedback/bundles/2026-07-18-eval-friction-second-empty-window-stable-recovery-watch/raw/rollup-report.json
+++ b/docs/harness-feedback/bundles/2026-07-18-eval-friction-second-empty-window-stable-recovery-watch/raw/rollup-report.json
@@ -1,0 +1,39 @@
+{
+  "verdictId": "2026-07-18-eval-friction-second-empty-window-stable-recovery-watch",
+  "selector": {
+    "kind": "friction-rollup-snapshot",
+    "windowStartMs": 1784084400000,
+    "windowEndMs": 1784343600000,
+    "topN": 10,
+    "tokenCap": 4000
+  },
+  "window": {
+    "sinceMs": 1784084400000,
+    "untilMs": 1784343600000
+  },
+  "signalCount": 0,
+  "clusterCount": 0,
+  "degraded": false,
+  "droppedChannels": [],
+  "report": {
+    "window": {
+      "sinceMs": 1784084400000,
+      "untilMs": 1784343600000
+    },
+    "generatedAt": "2026-07-18T03:01:47.175Z",
+    "topClusters": [],
+    "actionableCandidates": [],
+    "referenceOnly": [],
+    "tailSummary": {
+      "clusterCount": 0,
+      "signalCount": 0,
+      "byChannel": {}
+    },
+    "degraded": false,
+    "droppedChannels": [],
+    "tokenBudget": {
+      "cap": 4000,
+      "estimated": 78
+    }
+  }
+}

--- a/docs/harness-feedback/bundles/2026-07-18-eval-friction-second-empty-window-stable-recovery-watch/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-07-18-eval-friction-second-empty-window-stable-recovery-watch/snapshot.json
@@ -1,0 +1,25 @@
+{
+  "verdictId": "2026-07-18-eval-friction-second-empty-window-stable-recovery-watch",
+  "evalSnapshotId": "eval-F245-2026-07-18",
+  "featureId": "F245",
+  "generatedAt": "2026-07-18T03:01:47.175Z",
+  "window": {
+    "startMs": 1784084400000,
+    "endMs": 1784343600000,
+    "durationHours": 72
+  },
+  "components": [
+    {
+      "id": "friction-rollup",
+      "name": "friction rollup (Top-N + sensorForm)",
+      "confidence": "low",
+      "activationCounts": {},
+      "frictionCounts": {
+        "cluster_count": 0,
+        "top_cluster_count": 0,
+        "tail_cluster_count": 0,
+        "tail_signal_count": 0
+      }
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-07-18-eval-friction-second-empty-window-stable-recovery-watch.md
+++ b/docs/harness-feedback/verdicts/2026-07-18-eval-friction-second-empty-window-stable-recovery-watch.md
@@ -1,0 +1,30 @@
+---
+feature_ids: [F245]
+topics: [harness-eval, eval-friction, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:friction
+packet_id: 2026-07-18-eval-friction-second-empty-window-stable-recovery-watch
+source_snapshot: "snapshot:bundle/2026-07-18-eval-friction-second-empty-window-stable-recovery-watch/snapshot"
+---
+
+# Live Verdict — 2026-07-18-eval-friction-second-empty-window-stable-recovery-watch
+
+- Verdict: `keep_observe`
+- Phenomenon: The every-3d friction window from 2026-07-15 03:00 UTC to 2026-07-18 03:00 UTC produced no friction signals, no actionableCandidates, and no referenceOnly clusters. This matches the immediately preceding 72h window, so friction is now quiet for two consecutive cycles after the earlier `text_frustration` singleton on 2026-07-09 to 2026-07-12.
+- Harness: F245/friction-rollup (friction rollup (Top-N + sensorForm))
+- Root cause: No active root cause is observable in the current window. The earlier `text_frustration` signal now looks most plausibly like a transient `execution_gap` or `translation_gap` in one thread, but the current evidence supports only a stable quiet watch, not a stronger causal claim. (confidence low)
+- Owner ask: Keep the every-3d friction rollup running and only escalate if a new actionableCandidate appears or a referenceOnly eval-domain recurrence returns.
+- Re-eval: next eval at 2026-07-21T03:00:00.000Z
+
+Evidence:
+- snapshot:bundle/2026-07-18-eval-friction-second-empty-window-stable-recovery-watch/snapshot
+- attribution:bundle/2026-07-18-eval-friction-second-empty-window-stable-recovery-watch/eval-F245-2026-07-18:no-finding
+- metric:friction-rollup.cluster_count
+- metric:friction-rollup.top_cluster_count
+- metric:friction-rollup.tail_signal_count
+
+Counterarguments:
+- Two quiet windows are encouraging but still may not justify confidence that the underlying behavior has truly improved.
+- A zero-signal window under degraded rollup conditions can hide weak signals rather than prove absence of friction.
+- If the earlier singleton was tied to a narrow thread or short-lived topic, its disappearance may say more about workload mix than about harness quality.


### PR DESCRIPTION
Verdict published via cat_cafe_publish_verdict MCP tool.

Verdict: keep_observe
Domain: eval:friction
Phenomenon: The every-3d friction window from 2026-07-15 03:00 UTC to 2026-07-18 03:00 UTC produced no friction signals, no actionableCandidates, and no referenceOnly clusters. This matches the immediately preceding 72h window, so friction is now quiet for two consecutive cycles after the earlier `text_frustration` singleton on 2026-07-09 to 2026-07-12.

Reviewed by: gpt52
Action: Keep the every-3d friction rollup running and only escalate if a new actionableCandidate appears or a referenceOnly eval-domain recurrence returns.

---
**Cat-owned artifact gate — No operator merge needed.**
(Interim: keep_observe + no actionable findings. Rollup mechanism deferred to future Phase. See docs/SOP.md § artifact-only-pr-merge-gate for cat merge contract.)