### PR TITLE
verdict(eval:qc): 2026-07-19-eval-qc-zero-baseline-w29

### DIFF
--- a/docs/harness-feedback/bundles/2026-07-19-eval-qc-zero-baseline-w29/attribution.json
+++ b/docs/harness-feedback/bundles/2026-07-19-eval-qc-zero-baseline-w29/attribution.json
@@ -1,0 +1,11 @@
+{
+  "verdictId": "2026-07-19-eval-qc-zero-baseline-w29",
+  "featureId": "F253",
+  "evalSnapshotId": "qc-snapshot-2026-07-19-eval-qc-zero-baseline-w29",
+  "generatedAt": "2026-07-19T03:00:49.842Z",
+  "findings": [],
+  "noFindingRecord": {
+    "reason": "Zero-baseline bootstrap (Phase C) — no live QC data sources wired",
+    "evidence": "All QC metrics are zero (prCount=0). Eval:qc data pipeline not yet active."
+  }
+}

--- a/docs/harness-feedback/bundles/2026-07-19-eval-qc-zero-baseline-w29/provenance.json
+++ b/docs/harness-feedback/bundles/2026-07-19-eval-qc-zero-baseline-w29/provenance.json
@@ -1,0 +1,15 @@
+{
+  "verdictId": "2026-07-19-eval-qc-zero-baseline-w29",
+  "rawInputs": [
+    {
+      "path": "bundles/2026-07-19-eval-qc-zero-baseline-w29/snapshot.json",
+      "sha256": "19def58b17e690673666e5273321e41f1060f92cbe377968b579ddfafd87b69f"
+    }
+  ],
+  "generatedAt": "2026-07-19T03:00:49.842Z",
+  "generator": {
+    "name": "qc-generator-adapter",
+    "version": "1.0.0"
+  },
+  "sanitizeRulesVersion": "1.0.0"
+}

--- a/docs/harness-feedback/bundles/2026-07-19-eval-qc-zero-baseline-w29/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-07-19-eval-qc-zero-baseline-w29/snapshot.json
@@ -1,0 +1,27 @@
+{
+  "verdictId": "2026-07-19-eval-qc-zero-baseline-w29",
+  "evalSnapshotId": "qc-snapshot-2026-07-19-eval-qc-zero-baseline-w29",
+  "featureId": "F253",
+  "generatedAt": "2026-07-19T03:00:49.842Z",
+  "window": {
+    "startMs": 1783814400000,
+    "endMs": 1784419200000,
+    "durationHours": 168
+  },
+  "components": [
+    {
+      "componentId": "qc-pipeline",
+      "componentName": "QC Pipeline",
+      "activationCounts": {
+        "finding_yield": 0,
+        "reviewer_delta": 0,
+        "pr_count": 0
+      },
+      "frictionCounts": {
+        "false_positive_rate": 0,
+        "post_merge_bug_rate": 0
+      },
+      "confidence": "no-data"
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-07-19-eval-qc-zero-baseline-w29.md
+++ b/docs/harness-feedback/verdicts/2026-07-19-eval-qc-zero-baseline-w29.md
@@ -1,0 +1,36 @@
+---
+feature_ids: [F253]
+topics: [harness-eval, eval-qc, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:qc
+packet_id: 2026-07-19-eval-qc-zero-baseline-w29
+source_snapshot: "snapshot:bundle/2026-07-19-eval-qc-zero-baseline-w29/snapshot"
+---
+
+# eval:qc Verdict — 2026-07-19-eval-qc-zero-baseline-w29
+
+- Verdict: `keep_observe`
+- Phenomenon: QC pipeline metrics remain in zero-baseline state for the second consecutive week (Jul 12–19 window). Phase C bootstrap: all 4 metrics return 0 — no live review telemetry source wired yet. Structural health confirmed (last week’s adapter path validated end-to-end; MCP schema fix deployed).
+- Harness: F253/qc-pipeline (QC Review Loop)
+- Owner ask: No action required. Continue weekly cadence until Phase D wires live review telemetry events. MCP path now fully operational.
+- Re-eval: next eval at 2026-07-26T03:00:00.000Z
+
+Evidence:
+- snapshot:bundle/2026-07-19-eval-qc-zero-baseline-w29/snapshot
+- attribution:bundle/2026-07-19-eval-qc-zero-baseline-w29/qc-snapshot-2026-07-19-eval-qc-zero-baseline-w29:no-finding
+
+**Window**: 7 days | **PRs analyzed**: 0
+
+## Metrics
+
+| Metric | Value |
+|--------|-------|
+| Finding Yield (avg/review) | 0 |
+| False Positive Rate | 0 |
+| Reviewer Delta | 0 |
+| Post-Merge Bug Rate | 0 |
+
+## Notes
+
+No PR data available in this window. Zero-baseline snapshot (Phase C bootstrap — live data sources not yet wired).


### PR DESCRIPTION
Verdict published via cat_cafe_publish_verdict MCP tool.

Verdict: keep_observe
Domain: eval:qc
Phenomenon: QC pipeline metrics remain in zero-baseline state for the second consecutive week (Jul 12–19 window). Phase C bootstrap: all 4 metrics return 0 — no live review telemetry source wired yet. Structural health confirmed (last week’s adapter path validated end-to-end; MCP schema fix deployed).

Reviewed by: opus
Action: No action required. Continue weekly cadence until Phase D wires live review telemetry events. MCP path now fully operational.

---
**Cat-owned artifact gate — No operator merge needed.**
(Interim: keep_observe + no actionable findings. Rollup mechanism deferred to future Phase. See docs/SOP.md § artifact-only-pr-merge-gate for cat merge contract.)