### PR TITLE
verdict(eval:anchor-first): 2026-07-19-eval-anchor-first-c1-low-sample-keep-observe

### DIFF
--- a/docs/harness-feedback/bundles/2026-07-19-eval-anchor-first-c1-low-sample-keep-observe/attribution.json
+++ b/docs/harness-feedback/bundles/2026-07-19-eval-anchor-first-c1-low-sample-keep-observe/attribution.json
@@ -1,0 +1,47 @@
+{
+  "verdictId": "2026-07-19-eval-anchor-first-c1-low-sample-keep-observe",
+  "featureId": "F236",
+  "evalSnapshotId": "eval-F236-2026-07-19",
+  "generatedAt": "2026-07-19T03:01:58.378Z",
+  "findings": [
+    {
+      "id": "AF-2026-07-19-thread-context",
+      "relatedFeature": "F236",
+      "sunsetSignals": {
+        "anchorTax": false,
+        "highOpenRate": false,
+        "netNegative": false
+      },
+      "frictionSignal": {
+        "type": "anchor.open_rate.thread-context",
+        "severity": "low",
+        "confidence": 0.8,
+        "detectedAt": "2026-07-19T03:01:58.378Z"
+      },
+      "attribution": {
+        "primaryLayer": "needs_investigation",
+        "evidence": [
+          {
+            "type": "counter",
+            "anchor": "anchor-telemetry-rollup/thread-context_drilled_unique_items",
+            "excerpt": "thread-context: 0/10 items drilled (0.0% open rate), charsSaved=7009, drillChars=0, netBenefit=7009"
+          }
+        ]
+      },
+      "proposedAction": [
+        {
+          "action": "keep-observe",
+          "target": "anchor-telemetry-rollup/thread-context",
+          "rationale": "Open rate 0.0%: 0/10 items drilled, net benefit 7009 chars"
+        }
+      ]
+    }
+  ],
+  "sunsetAssessment": {
+    "toolCount": 1,
+    "toolsWithAnchorTax": 0,
+    "toolsNetNegative": 0,
+    "toolsHighOpenRate": 0,
+    "lowSampleToolCount": 1
+  }
+}

--- a/docs/harness-feedback/bundles/2026-07-19-eval-anchor-first-c1-low-sample-keep-observe/provenance.json
+++ b/docs/harness-feedback/bundles/2026-07-19-eval-anchor-first-c1-low-sample-keep-observe/provenance.json
@@ -1,0 +1,15 @@
+{
+  "verdictId": "2026-07-19-eval-anchor-first-c1-low-sample-keep-observe",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/bundles/2026-07-19-eval-anchor-first-c1-low-sample-keep-observe/raw/rollup.json",
+      "sha256": "b3b8e4ed939b6e870ae2ec85d92bedcd32de21d93d05ce820d4012867409726d"
+    }
+  ],
+  "generatedAt": "2026-07-19T03:01:58.378Z",
+  "generator": {
+    "name": "eval-anchor-first-live-verdict",
+    "version": "1"
+  },
+  "sanitizeRulesVersion": "f236-anchor-telemetry-v1"
+}

--- a/docs/harness-feedback/bundles/2026-07-19-eval-anchor-first-c1-low-sample-keep-observe/raw/rollup.json
+++ b/docs/harness-feedback/bundles/2026-07-19-eval-anchor-first-c1-low-sample-keep-observe/raw/rollup.json
@@ -1,0 +1,59 @@
+{
+  "verdictId": "2026-07-19-eval-anchor-first-c1-low-sample-keep-observe",
+  "selector": {
+    "kind": "anchor-telemetry-snapshot",
+    "windowStartMs": 1784343656728,
+    "windowEndMs": 1784430056728
+  },
+  "rollup": {
+    "perTool": {
+      "pending-mentions": {
+        "previewResponses": 1,
+        "previewedItems": 0,
+        "drills": 0,
+        "drilledUniqueItems": 0,
+        "openRateByItem": 0,
+        "returnedChars": 0,
+        "originalChars": 0,
+        "charsSaved": 0,
+        "drillChars": 0,
+        "netBenefit": 0
+      },
+      "thread-context": {
+        "previewResponses": 1,
+        "previewedItems": 10,
+        "drills": 0,
+        "drilledUniqueItems": 0,
+        "openRateByItem": 0,
+        "returnedChars": 2050,
+        "originalChars": 9059,
+        "charsSaved": 7009,
+        "drillChars": 0,
+        "netBenefit": 7009
+      }
+    },
+    "orphanDrills": 0,
+    "adoption": {
+      "explicitAnchorCalls": 0,
+      "explicitFullCalls": 0,
+      "defaultAnchorCalls": 2,
+      "defaultFullCalls": 0,
+      "legacyEquivalentAnchorCalls": 0,
+      "legacyEquivalentFullCalls": 0,
+      "unknownModeCalls": 0,
+      "uniqueCatsExplicitAnchor": 0
+    },
+    "track1Snapshot": {
+      "returnedByTool": {
+        "pending-mentions": 1,
+        "thread-context": 1
+      },
+      "returnedCharsByTool": {
+        "pending-mentions": 15,
+        "thread-context": 5094
+      },
+      "drillByTool": {},
+      "drillCharsByTool": {}
+    }
+  }
+}

--- a/docs/harness-feedback/bundles/2026-07-19-eval-anchor-first-c1-low-sample-keep-observe/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-07-19-eval-anchor-first-c1-low-sample-keep-observe/snapshot.json
@@ -1,0 +1,48 @@
+{
+  "verdictId": "2026-07-19-eval-anchor-first-c1-low-sample-keep-observe",
+  "evalSnapshotId": "eval-F236-2026-07-19",
+  "featureId": "F236",
+  "generatedAt": "2026-07-19T03:01:58.378Z",
+  "window": {
+    "startMs": 1784343656728,
+    "endMs": 1784430056728,
+    "durationHours": 24
+  },
+  "components": [
+    {
+      "id": "anchor-telemetry-rollup",
+      "name": "anchor-first preview/drill open-rate rollup",
+      "confidence": "medium",
+      "activationCounts": {
+        "orphan_drills": 0,
+        "adoption_explicit_anchor_calls": 0,
+        "adoption_explicit_full_calls": 0,
+        "adoption_default_anchor_calls": 2,
+        "adoption_default_full_calls": 0,
+        "adoption_legacy_equivalent_anchor_calls": 0,
+        "adoption_legacy_equivalent_full_calls": 0,
+        "adoption_unique_cats_explicit_anchor": 0,
+        "adoption_unknown_mode_calls": 0,
+        "pending-mentions_preview_responses": 1,
+        "pending-mentions_previewed_items": 0,
+        "pending-mentions_drills": 0,
+        "pending-mentions_drilled_unique_items": 0,
+        "pending-mentions_returned_chars": 0,
+        "pending-mentions_original_chars": 0,
+        "pending-mentions_chars_saved": 0,
+        "pending-mentions_drill_chars": 0,
+        "pending-mentions_net_benefit": 0,
+        "thread-context_preview_responses": 1,
+        "thread-context_previewed_items": 10,
+        "thread-context_drills": 0,
+        "thread-context_drilled_unique_items": 0,
+        "thread-context_returned_chars": 2050,
+        "thread-context_original_chars": 9059,
+        "thread-context_chars_saved": 7009,
+        "thread-context_drill_chars": 0,
+        "thread-context_net_benefit": 7009
+      },
+      "frictionCounts": {}
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-07-19-eval-anchor-first-c1-low-sample-keep-observe.md
+++ b/docs/harness-feedback/verdicts/2026-07-19-eval-anchor-first-c1-low-sample-keep-observe.md
@@ -1,0 +1,46 @@
+---
+feature_ids: [F192, F236]
+topics: [harness-eval, eval-anchor-first, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:anchor-first
+packet_id: 2026-07-19-eval-anchor-first-c1-low-sample-keep-observe
+source_snapshot: "snapshot:bundle/2026-07-19-eval-anchor-first-c1-low-sample-keep-observe/snapshot"
+---
+
+# Live Verdict — 2026-07-19-eval-anchor-first-c1-low-sample-keep-observe
+
+- Verdict: `keep_observe`
+- Phenomenon: The latest visible 24h anchor-first activity is far below last week's window and shows only sparse preview traffic, so this cycle is primarily a low-sample observation pass rather than a meaningful sunset decision point. Independent blindness evidence is still absent because eval:task-outcome has not published verdict trends and the task-outcome episode store still has zero written verdicts.
+- Harness: F236/anchor-telemetry-rollup (anchor-first preview/drill open-rate rollup)
+- Owner ask: Keep F236 in observe mode and gather another 24h anchor-telemetry window with more preview volume or a published eval:task-outcome trend before considering fix or sunset.
+- Re-eval: Re-evaluate when a fresh 24h rollup has enough previewed items per tool to assess sunset signals confidently or when eval:task-outcome publishes verdict trends that can confirm or reject blindness. at 2026-07-26T03:00:56.728Z
+
+Sunset Signal Assessment:
+- pending-mentions: LOW_SAMPLE (openRate=0.0%, netBenefit=0)
+- thread-context: HEALTHY (openRate=0.0%, netBenefit=7009)
+
+Open-Rate Detail:
+- pending-mentions: 0.0% open rate (0/0 items), charsSaved=0, drillChars=0, netBenefit=0
+- thread-context: 0.0% open rate (0/10 items), charsSaved=7009, drillChars=0, netBenefit=7009
+- Orphan drills: 0
+
+Adoption Detail:
+- explicitAnchorCalls=0; explicitFullCalls=0; uniqueCatsExplicitAnchor=0
+- defaultAnchorCalls=2; defaultFullCalls=0
+- legacyEquivalentAnchorCalls=0; legacyEquivalentFullCalls=0
+- unknownModeCalls=0
+
+Evidence:
+- snapshot:bundle/2026-07-19-eval-anchor-first-c1-low-sample-keep-observe/snapshot
+- attribution:bundle/2026-07-19-eval-anchor-first-c1-low-sample-keep-observe/AF-2026-07-19-thread-context
+- metric:prometheus:cat_cafe_anchor_returned_count_total{anchor_tool="pending-mentions"}
+- metric:prometheus:cat_cafe_anchor_returned_count_total{anchor_tool="thread-context"}
+- metric:sqlite:task_outcome_episodes.with_verdict=0
+- thread:thread_eval_anchor_first/message:0001784430000252-000111-00306bac
+- task-outcome-episodes.sqlite
+
+Counterarguments:
+- The live rollup could still uncover a concentrated drill pattern on a tool that is invisible in the sparse Track-1 aggregate sample.
+- A low-volume week can mask a real preview-quality problem because dissatisfied cats may avoid the tool entirely rather than drilling through it.
+- Using last week's 24h window as the baseline may overstate regression if workload mix changed materially this week.


### PR DESCRIPTION
Verdict published via cat_cafe_publish_verdict MCP tool.

Verdict: keep_observe
Domain: eval:anchor-first
Phenomenon: The latest visible 24h anchor-first activity is far below last week's window and shows only sparse preview traffic, so this cycle is primarily a low-sample observation pass rather than a meaningful sunset decision point. Independent blindness evidence is still absent because eval:task-outcome has not published verdict trends and the task-outcome episode store still has zero written verdicts.

Reviewed by: opus-47
Action: Keep F236 in observe mode and gather another 24h anchor-telemetry window with more preview volume or a published eval:task-outcome trend before considering fix or sunset.

---
**Cat-owned artifact gate — No operator merge needed.**
(Actionable findings present; eval domain owner cat merges per docs/SOP.md § artifact-only-pr-merge-gate.)