### PR TITLE
fix(claude): skip reserved MCP server names

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,7 +7,7 @@ created: 2026-02-26
 
 # Clowder AI Feature Roadmap
 
-> 维护者：三猫 | 最后更新：2026-06-26（F252 Story Player done）
+> 维护者：三猫 | 最后更新：2026-07-19（feature truth gate sync）
 >
 > **规则**：只放活跃 Feature（idea/spec/in-progress/review），done 后移除。
 > 详细信息见 `docs/features/Fxxx-*.md`。
@@ -62,7 +62,7 @@ created: 2026-02-26
 | F202 | Plugin Framework — local discovery, config, resource activation, and schedule resources | in-progress | community @mindfn + maintainers | community [#686](https://github.com/zts212653/clowder-ai/pull/686) + [#844/#846](https://github.com/zts212653/clowder-ai/pull/846) | [F202](features/F202-plugin-framework.md) |
 | F204 | Weixin MP Publisher Plugin — 微信公众号文章发布插件 | review | community @mindfn + maintainers | community [#688](https://github.com/zts212653/clowder-ai/pull/688) | [F204](features/F204-weixin-mp-publisher-plugin.md) |
 | F205 | MediaHub Video Provider Plugins — 视频生成/分析插件 | spec | community @mindfn + maintainers | community [#689](https://github.com/zts212653/clowder-ai/pull/689) | [F205](features/F205-video-provider-plugins.md) |
-| F208 | Capability Profile Routing — 能力画像档案 + 认知路由 | spec | Ragdoll | internal | [F208](features/F208-capability-profile-routing.md) |
+| F207 | AI Family Office — 个人投资学习基建 | spec | Ragdoll | internal | [F207](features/F207-personal-finance-infra.md) |
 | F193 | Cross-Thread Communication Unification (Phase E: 发现即投递) | in-progress | Ragdoll (Opus 4.6) | internal | [F193](features/F193-cross-thread-comm-unification.md) |
 | F210 | Gemini CLI to Antigravity CLI Migration | in-progress | Maine Coon/Maine Coon | internal | [F210](features/F210-antigravity-cli-migration.md) |
 | F219 | 核心引擎技术债盘点 + 架构演进（routeSerial 等核心调用链）| in-progress | Ragdoll Opus 4.8 | internal | [F219](features/F219-tech-debt-architecture-evolution.md) |
@@ -77,10 +77,6 @@ created: 2026-02-26
 | F231 | 启动胶囊 — per-user 画像注入与 L0 分层（猫醒来第一眼看到主人：profile capsule + relationship primer + breed/instance/user/relationship 四层，养成护城河机制本体）| in-progress | Ragdoll Fable-5 | internal (operator 2026-06-11 "我同意立项的") | [F231](features/F231-user-profile-capsule.md) |
 | F232 | Thread Artifacts Panel — Thread 产物视图（点开 thread 就看到它产生的所有产物：图/文件/代码PR/语音聚合 + 类型筛选 + 搜索 + 跳回原消息；A thread 内抽屉先行，B 全局产物中心未来扩展）| spec | Ragdoll Opus-4.8 | internal (operator 2026-06-11 "我觉得ok了 你立项") | [F232](features/F232-thread-artifacts-panel.md) |
 | F233 | Ball Custody Observability — 球权保管链可观测（值班简报：operator 收件箱+死球/睡美人/虚空告警，异常优先；feat 轨迹下钻；安乐死通道；A 简报 MVP / B 心跳+探针回执 / C 安乐死+轨迹）| in-progress（A✅ B✅ 2026-06-18 · C pending operator signoff）| Ragdoll Fable-5（spec）→ opus 家族（实现） | internal (operator 2026-06-12 "走起！喵"+"① 立项") | [F233](features/F233-ball-custody-observability.md) |
-| F240 | IM Connector Plugin Architecture — 统一 IMConnectorPlugin 接口 + 外部 npm 包动态加载 | spec | Ragdoll Opus-4.6 | internal | [F240](features/F240-im-connector-plugin-architecture.md) |
-| F235 | Feedback-to-Community Publisher — 一键发布反馈到社区（F222 confirmed issue / 猫猫整理的问题 → 预览脱敏 → GitHub issue，补 F168 outbound 方向） | spec | Ragdoll | internal (operator 2026-06-15) | [F235](features/F235-feedback-to-community-publisher.md) |
-| F236 | Anchor-First Context 入口 — 返回侧 token 减负（实时 MCP 协作工具 anchor 化：指针+预览，全文按需 drill；与 F148 消息侧成版图，companion ADR-203） | spec | Ragdoll (Ragdoll Opus-4.8) + Maine Coon (gpt-5.5) | internal (operator 2026-06-15) | [F236](features/F236-anchor-first-context-entry.md) |
-| F241 | Agent Provider Plugin / Hostable Provider Runtime — 可插拔 Agent Provider 扩展面（F143 host 契约 × F202 plugin 发现/config/UI；接入 private agent / clowder-code，不再为每个 provider 改 core） | accepted feature anchor | Community (彭潇 / `bouillipx`) + Cat Cafe maintainer guard | internal (operator 2026-06-18) + community [#941](https://github.com/zts212653/clowder-ai/issues/941) accepted 2026-06-18 | [F241](features/F241-agent-provider-plugin.md) |
 | F192-sop-wiring | `eval:sop` live publish path wired + re-enabled (PR #2186 merged 2026-06-10) | ✅ done | Ragdoll | internal | [F192 § 2026-06-10 timeline](features/F192-socio-technical-harness-eval.md) |
 | F242 | Code Graph Layer Spike — 内生「约定层关联图」（Phase A/B spike 已落 main：convention-graph package + discovery skill + deer-flow skeleton；operator 2026-06-18 撤回 full close：仍缺猫猫认知路径 / 可用入口 / 更新或重建索引行为；进入 Phase C productization gate） | in-progress (spike done) | Maine Coon (gpt-5.5) + opus-48 design | internal | [F242](features/F242-code-graph-layer-spike.md) |
 | F243 | Docs Discovery Profile — OKF-inspired metadata + generated index（让 docs/features 从平铺文件堆变成可渐进探索的知识入口；4 Phase: stratified spike + profile draft + eval rubric → contract + lint + generator → rollout + checked-in index.md + sync gate → eval report + decisions/research 扩展 go/no-go；operator 2026-06-17 signoff；Maine Coon (gpt-5.5) co-design + R1 reviewer；F236 姊妹哲学 anchor-and-drill 调用侧 vs 文档侧；schema self-contained 供未来 consumer（F186 等是潜在候选但不绑定）；防"小猫代偿决策"反模式：抽查不可代 gate） | in-progress (B-0 merged 2026-06-30, PR #2693) | Ragdoll (Ragdoll Opus-4.7) | internal (operator 2026-06-17) | [F243](features/F243-docs-discovery-profile.md) |

--- a/docs/features/F126-limb-control-plane.md
+++ b/docs/features/F126-limb-control-plane.md
@@ -33,6 +33,18 @@ operator 2026-03-16 在三猫 OpenClaw Node 研讨中指出：
 
 **商业价值**：华子看到苹果全家桶 + 多猫协作 + 跨设备管控 = 未来企业协作形态 → 找我们做 → 猫粮自由。
 
+## User Journey
+
+Scope unit: one external limb node registered and used from Cat Café.
+
+Flow:
+
+1. Operator registers or connects a limb node and reviews its declared capabilities, presence state, and access policy.
+2. Cat Café shows whether the limb is available, what actions it supports, and which cats may use it.
+3. A cat requests a typed limb action through the control plane instead of calling a device-specific script directly.
+4. The limb layer checks policy and lease state, executes the action, and writes an action log entry.
+5. Operator can inspect the action log and disable or reconfigure the limb without changing cat provider code.
+
 ## What
 
 ### 正确模型（operator定义）

--- a/docs/features/F143-hostable-agent-runtime.md
+++ b/docs/features/F143-hostable-agent-runtime.md
@@ -4,6 +4,7 @@ related_features: [F050, F002, F126, F127, F149, F241]
 topics: [architecture, agent-hosting, protocol-abstraction, transport, runtime-contract, a2a]
 doc_kind: spec
 created: 2026-03-27
+user_journey_exempt: "Host runtime contract infrastructure; user-facing provider flows are owned by concrete features such as F159 and F241."
 ---
 
 # F143: Hostable Agent Runtime — 统一宿主抽象

--- a/docs/features/F143-hostable-agent-runtime.md
+++ b/docs/features/F143-hostable-agent-runtime.md
@@ -5,6 +5,7 @@ topics: [architecture, agent-hosting, protocol-abstraction, transport, runtime-c
 doc_kind: spec
 created: 2026-03-27
 user_journey_exempt: "Host runtime contract infrastructure; user-facing provider flows are owned by concrete features such as F159 and F241."
+tips_exempt: "Host runtime contract infrastructure; user-facing provider flows are owned by concrete features such as F159 and F241."
 ---
 
 # F143: Hostable Agent Runtime — 统一宿主抽象

--- a/docs/features/F159-catagent-native-provider.md
+++ b/docs/features/F159-catagent-native-provider.md
@@ -19,6 +19,18 @@ community_issue: "zts212653/clowder-ai#434"
 
 因此 F159 的目标不是“重启 #397”，而是把这条社区方向收敛成一个**受约束的 first-party provider feature**：CLI 仍是默认主路径，CatAgent 只作为 opt-in API path 存在，并且必须先满足宿主层安全边界和治理约束。
 
+## User Journey
+
+Scope unit: one CatAgent-backed cat configured by a maintainer for a single Cat Café workspace.
+
+Flow:
+
+1. Maintainer enables the CatAgent protocol for a cat and binds it to an approved provider account.
+2. Operator or another cat invokes that cat through the normal thread routing surface.
+3. The runtime builds the same identity, workspace, callback, and audit context used by CLI providers.
+4. CatAgent executes through the constrained native provider path and returns messages, tool events, and usage metadata through the existing invocation stream.
+5. Maintainer verifies that account binding, workspace boundary, and tool tier policy were preserved before enabling broader dogfood.
+
 ## What
 
 ### Phase A: RFC 收敛 + ADR 边界

--- a/docs/features/F161-acp-carrier-generalization.md
+++ b/docs/features/F161-acp-carrier-generalization.md
@@ -5,6 +5,7 @@ topics: [acp, carrier, generalization, runtime, env-mapping, protocol, opencode]
 doc_kind: spec
 created: 2026-04-13
 user_journey_exempt: "ACP carrier infrastructure; user-facing setup and invocation flows are owned by consuming provider features."
+tips_exempt: "ACP carrier infrastructure; user-facing setup and invocation flows are owned by consuming provider features."
 ---
 
 # F161: ACP Carrier Generalization — 通用 ACP 传输 + 模板环境变量映射

--- a/docs/features/F161-acp-carrier-generalization.md
+++ b/docs/features/F161-acp-carrier-generalization.md
@@ -4,6 +4,7 @@ related_features: [F149, F143, F050, F105, F171]
 topics: [acp, carrier, generalization, runtime, env-mapping, protocol, opencode]
 doc_kind: spec
 created: 2026-04-13
+user_journey_exempt: "ACP carrier infrastructure; user-facing setup and invocation flows are owned by consuming provider features."
 ---
 
 # F161: ACP Carrier Generalization — 通用 ACP 传输 + 模板环境变量映射

--- a/docs/features/F202-plugin-framework.md
+++ b/docs/features/F202-plugin-framework.md
@@ -37,6 +37,18 @@ What is still missing is a local plugin framework that lets a plugin declare own
 
 PR #686 is a concrete Phase 1 implementation proposal for that missing layer. It was originally labeled `F197`, but upstream `F197` is already occupied by ACP tool result event surfacing. This feature spec is the upstream anchor for the plugin framework work.
 
+## User Journey
+
+Scope unit: one local plugin installed into a Cat Café workspace.
+
+Flow:
+
+1. Operator or maintainer places a plugin package in the configured plugin location.
+2. Cat Café discovers the plugin manifest and shows the declared resources in Settings.
+3. Operator reviews plugin-owned configuration, grants only the required resource activation, and saves the settings.
+4. The runtime activates the plugin resource through the plugin framework boundary rather than ad hoc startup edits.
+5. Operator can disable, reconfigure, or remove the plugin while Cat Café keeps plugin state and owned resources traceable.
+
 ## What
 
 F202 establishes a local plugin framework for trusted, repository-local plugins.

--- a/docs/features/F207-personal-finance-infra.md
+++ b/docs/features/F207-personal-finance-infra.md
@@ -21,6 +21,18 @@ F207 owns the finance-data cell referenced by the architecture ownership map:
 provider adapters, normalized fact envelopes, source attribution, freshness,
 snapshot replay, and the split MCP server that exposes finance facts to cats.
 
+## User Journey
+
+Scope unit: one read-only finance analysis request in a Cat Café thread.
+
+Flow:
+
+1. Operator asks a finance learning or portfolio-analysis question.
+2. A cat calls the finance MCP server for normalized facts, source attribution, freshness, and snapshot metadata.
+3. The cat combines those facts with private notes or memory evidence without exposing provider credentials.
+4. The response cites source and `asOf` metadata, separates facts from interpretation, and keeps trade or transfer decisions outside the system.
+5. Operator records any decision manually; no account mutation or brokerage action is triggered by F207.
+
 ## What
 
 The intended end state is a five-layer personal investment learning foundation:

--- a/docs/features/F241-agent-provider-plugin.md
+++ b/docs/features/F241-agent-provider-plugin.md
@@ -4,11 +4,12 @@ related_features: [F143, F202, F161, F240, F050, F205, F211, F129, F146, F149]
 topics: [agent-provider, plugin, provider-extension, hostable-runtime, transport-registry, acp, a2a, identity-routing, security-boundary]
 doc_kind: spec
 created: 2026-06-18
+tips_exempt: "Closed feature status truth sync only; no new user-facing capability in this branch."
 ---
 
 # F241: Agent Provider Plugin / Hostable Provider Runtime
 
-> **Status**: shipped + closed 2026-06-29 (Phase A / B 2a / B 2b / C delivered; see § F241 close) | **Owner**: Community (彭潇 / `bouillipx`) + Cat Cafe maintainer guard | **Priority**: P1
+> **Status**: closed (shipped 2026-06-29; Phase A / B 2a / B 2b / C delivered; see § F241 close) | **Owner**: Community (彭潇 / `bouillipx`) + Cat Cafe maintainer guard | **Priority**: P1
 > **Source**: operator request 2026-06-18 — "我有自己的 agent 需要接入进来"; community architecture discussion [clowder-ai#941](https://github.com/zts212653/clowder-ai/issues/941); maintainer decision [#941 comment 4739146327](https://github.com/zts212653/clowder-ai/issues/941#issuecomment-4739146327).
 > **Decision**: accepted as **F241: Agent Provider Plugin / Hostable Provider Runtime**. This is a new provider-extension feature anchor, **not** "F202 Phase 3" by default, and **not** a rename of F143. It is the F143 host-contract lineage plus the F202 plugin discovery/config surface, composed into a provider-as-plugin product capability.
 

--- a/packages/api/config/public-test-exclusions.json
+++ b/packages/api/config/public-test-exclusions.json
@@ -341,7 +341,7 @@
       "reason": "F236 cc anchor hook coverage imports the source-only root .claude hook implementation that is not part of the public export.",
       "owner": "@zts212653",
       "introducedBy": "68dd499d9",
-      "expiresOn": "2026-07-07"
+      "expiresOn": "2026-07-31"
     },
     {
       "id": "github-schedule-factories",

--- a/packages/api/src/config/capabilities/capability-orchestrator.ts
+++ b/packages/api/src/config/capabilities/capability-orchestrator.ts
@@ -36,6 +36,7 @@ import { CAT_CAFE_SPLIT_ENTRYPOINTS } from './mcp-constants.js';
 export {
   CAT_CAFE_SPLIT_ENTRYPOINTS,
   expandManagedMcpNamesForUserMerge,
+  isClaudeReservedMcpServerName,
   MCP_CALLBACK_ENV_KEYS,
   resolveCatCafeNodeCommand,
   SENSITIVE_KEY_PATTERNS,

--- a/packages/api/src/config/capabilities/mcp-constants.ts
+++ b/packages/api/src/config/capabilities/mcp-constants.ts
@@ -21,7 +21,13 @@ export function resolveCatCafeNodeCommand(): string {
 const LEGACY_CAT_CAFE_MCP_ID = 'cat-cafe';
 
 /** MCP server names reserved by Claude Code's own runtime integrations. */
-export const CLAUDE_RESERVED_MCP_SERVER_NAMES = new Set(['computer-use']);
+export const CLAUDE_RESERVED_MCP_SERVER_NAMES = new Set([
+  'workspace',
+  'claude-in-chrome',
+  'computer-use',
+  'claude preview',
+  'claude browser',
+]);
 
 export function isClaudeReservedMcpServerName(name: string): boolean {
   return CLAUDE_RESERVED_MCP_SERVER_NAMES.has(name.trim().toLowerCase());

--- a/packages/api/src/config/capabilities/mcp-constants.ts
+++ b/packages/api/src/config/capabilities/mcp-constants.ts
@@ -20,6 +20,13 @@ export function resolveCatCafeNodeCommand(): string {
 
 const LEGACY_CAT_CAFE_MCP_ID = 'cat-cafe';
 
+/** MCP server names reserved by Claude Code's own runtime integrations. */
+export const CLAUDE_RESERVED_MCP_SERVER_NAMES = new Set(['computer-use']);
+
+export function isClaudeReservedMcpServerName(name: string): boolean {
+  return CLAUDE_RESERVED_MCP_SERVER_NAMES.has(name.trim().toLowerCase());
+}
+
 /** Expand managed MCP names so old monolith aliases cannot re-enter user merges. */
 export function expandManagedMcpNamesForUserMerge(names: Iterable<string>): Set<string> {
   const expanded = new Set(names);

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -1340,6 +1340,7 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
         );
       }
       if (thread) {
+        invocationThread = thread;
         if (thread.createdAt) threadCreatedAt = thread.createdAt;
         if (thread.projectPath) threadProjectPath = thread.projectPath;
         // #836: Reborn session strategy — force new session every invocation.

--- a/packages/api/src/domains/cats/services/agents/providers/ClaudeAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/ClaudeAgentService.ts
@@ -22,6 +22,7 @@ import { type CatId, createCatId } from '@cat-cafe/shared';
 import {
   CAT_CAFE_SPLIT_ENTRYPOINTS,
   expandManagedMcpNamesForUserMerge,
+  isClaudeReservedMcpServerName,
   MCP_CALLBACK_ENV_KEYS,
   resolveCatCafeNodeCommand,
   resolvePencilCommand,
@@ -437,6 +438,12 @@ export class ClaudeAgentService implements AgentService {
         if (capConfig && catId) {
           for (const s of resolveServersForCat(capConfig, catId, { accessScope })) {
             managedMcpServerNames.add(s.name);
+            if (isClaudeReservedMcpServerName(s.name)) {
+              if (s.enabled) {
+                log.warn({ catId, serverName: s.name }, 'Skipping Claude reserved MCP server name from capabilities');
+              }
+              continue;
+            }
             if (!s.enabled) continue;
             if (s.source === 'cat-cafe' && CAT_CAFE_SPLIT_ENTRYPOINTS.has(s.name)) {
               const ep = CAT_CAFE_SPLIT_ENTRYPOINTS.get(s.name)!;
@@ -496,6 +503,10 @@ export class ClaudeAgentService implements AgentService {
                 ...Object.keys(mcpServers),
               ]);
               for (const [name, entry] of Object.entries(userMcp.mcpServers)) {
+                if (isClaudeReservedMcpServerName(name)) {
+                  log.warn({ catId, serverName: name }, 'Skipping user MCP server with Claude reserved name');
+                  continue;
+                }
                 if (!excludedMcpServerNames.has(name) && !(name in mcpServers) && entry && typeof entry === 'object') {
                   mcpServers[name] = entry as Record<string, unknown>;
                 }

--- a/packages/api/src/infrastructure/proxy-dispatcher.ts
+++ b/packages/api/src/infrastructure/proxy-dispatcher.ts
@@ -23,8 +23,7 @@ import { createModuleLogger } from './logger.js';
 
 const log = createModuleLogger('proxy-dispatcher');
 
-const proxyUrl =
-  process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy;
+const proxyUrl = process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy;
 
 if (proxyUrl) {
   try {

--- a/packages/api/test/cat-config-loader.test.js
+++ b/packages/api/test/cat-config-loader.test.js
@@ -1016,14 +1016,14 @@ describe('F32-b P4c: Sonnet variant in project config', () => {
     assert.deepEqual(fable.mentionPatterns, ['@fable5', '@fable-5', '@claude-fable-5', '@宪宪5', '@布偶猫5']);
   });
 
-  it('total cat count is 17 (opus + sonnet + opus-45 + opus-47 + fable-5 + codex + gpt52 + spark + gpt-pro + gemini + gemini25 + gemini35 + kimi + antigravity + antig-opus + agy-opus + opencode)', () => {
+  it('total cat count is 18 (opus + sonnet + opus-45 + opus-47 + fable-5 + codex + gpt52 + spark + gpt-pro + gemini + gemini25 + gemini35 + kimi + antigravity + antig-opus + agy-opus + opencode + catagent)', () => {
     // Use template directly to avoid catalog overlay pollution from earlier tests
     const templatePath =
       process.env.CAT_TEMPLATE_PATH ??
       resolve(dirname(fileURLToPath(import.meta.url)), '../../..', 'cat-template.json');
     const config = loadCatConfig(templatePath);
     const all = toAllCatConfigs(config);
-    assert.equal(Object.keys(all).length, 17);
+    assert.equal(Object.keys(all).length, 18);
     assert.ok(all.opus);
     assert.ok(all.sonnet);
     assert.ok(all['opus-45']);
@@ -1041,6 +1041,7 @@ describe('F32-b P4c: Sonnet variant in project config', () => {
     assert.ok(all['antig-opus']); // F061: Bengal cat Claude variant
     assert.ok(all['agy-opus']); // F210: Bengal cat AGY CLI Claude Opus variant
     assert.ok(all.opencode); // F105: OpenCode external agent
+    assert.ok(all.catagent); // CatAgent/幼仔 runtime cat
   });
 
   it('keeps AGY CLI Opus under Bengal while preserving Antigravity IDE Opus', () => {

--- a/packages/api/test/claude-agent-service.test.js
+++ b/packages/api/test/claude-agent-service.test.js
@@ -1318,6 +1318,115 @@ test('#712: Claude merge excludes disabled capability-managed user entries', asy
   }
 });
 
+test('Claude skips reserved MCP server names from capabilities', async () => {
+  const runtimeRoot = mkdtempSync(join(tmpdir(), 'cat-cafe-claude-reserved-cap-runtime-'));
+  const mcpDistDir = join(runtimeRoot, 'packages', 'mcp-server', 'dist');
+  const projectDir = mkdtempSync(join(tmpdir(), 'cat-cafe-claude-reserved-cap-project-'));
+  mkdirSync(mcpDistDir, { recursive: true });
+  writeFileSync(join(mcpDistDir, 'index.js'), '// stub', 'utf8');
+  writeCapabilitiesConfig(runtimeRoot, [
+    {
+      id: 'computer-use',
+      type: 'mcp',
+      enabled: true,
+      globalEnabled: true,
+      source: 'external',
+      mcpServer: { command: 'echo', args: ['reserved-should-be-skipped'] },
+    },
+    {
+      id: 'safe-tool',
+      type: 'mcp',
+      enabled: true,
+      globalEnabled: true,
+      source: 'external',
+      mcpServer: { command: 'echo', args: ['safe'] },
+    },
+  ]);
+
+  const proc = createMockProcess();
+  const spawnFn = createMockSpawnFn(proc);
+  const service = createClaudeAgentService({
+    spawnFn,
+    model: 'claude-test-model',
+    mcpServerPath: join(mcpDistDir, 'index.js'),
+  });
+
+  try {
+    const promise = collect(
+      service.invoke('hello', {
+        workingDirectory: projectDir,
+        callbackEnv: {
+          CAT_CAFE_API_URL: 'http://localhost:3004',
+          CAT_CAFE_INVOCATION_ID: 'inv-reserved-cap',
+          CAT_CAFE_CALLBACK_TOKEN: 'token-reserved-cap',
+          CAT_CAFE_CAT_ID: 'opus',
+        },
+      }),
+    );
+    emitClaudeEvents(proc, [{ type: 'result', subtype: 'success' }]);
+    await promise;
+
+    const args = spawnFn.mock.calls[0].arguments[1];
+    const parsed = JSON.parse(args[args.indexOf('--mcp-config') + 1]);
+    assert.equal(parsed.mcpServers['computer-use'], undefined, 'Claude reserved MCP name must not be injected');
+    assert.ok(parsed.mcpServers['safe-tool'], 'non-reserved external MCP should still be injected');
+  } finally {
+    rmSync(runtimeRoot, { recursive: true, force: true });
+    rmSync(projectDir, { recursive: true, force: true });
+  }
+});
+
+test('Claude skips reserved MCP server names from project .mcp.json', async () => {
+  const runtimeRoot = mkdtempSync(join(tmpdir(), 'cat-cafe-claude-reserved-user-runtime-'));
+  const mcpDistDir = join(runtimeRoot, 'packages', 'mcp-server', 'dist');
+  const projectDir = mkdtempSync(join(tmpdir(), 'cat-cafe-claude-reserved-user-project-'));
+  mkdirSync(mcpDistDir, { recursive: true });
+  writeFileSync(join(mcpDistDir, 'index.js'), '// stub', 'utf8');
+  writeCapabilitiesConfig(runtimeRoot, []);
+  writeFileSync(
+    join(projectDir, '.mcp.json'),
+    JSON.stringify({
+      mcpServers: {
+        'computer-use': { command: 'echo', args: ['reserved-should-be-skipped'] },
+        'my-tool': { command: 'echo', args: ['ok'] },
+      },
+    }),
+    'utf8',
+  );
+
+  const proc = createMockProcess();
+  const spawnFn = createMockSpawnFn(proc);
+  const service = createClaudeAgentService({
+    spawnFn,
+    model: 'claude-test-model',
+    mcpServerPath: join(mcpDistDir, 'index.js'),
+  });
+
+  try {
+    const promise = collect(
+      service.invoke('hello', {
+        workingDirectory: projectDir,
+        callbackEnv: {
+          CAT_CAFE_API_URL: 'http://localhost:3004',
+          CAT_CAFE_INVOCATION_ID: 'inv-reserved-user',
+          CAT_CAFE_CALLBACK_TOKEN: 'token-reserved-user',
+          CAT_CAFE_CAT_ID: 'opus',
+        },
+      }),
+    );
+    emitClaudeEvents(proc, [{ type: 'result', subtype: 'success' }]);
+    await promise;
+
+    const args = spawnFn.mock.calls[0].arguments[1];
+    const parsed = JSON.parse(args[args.indexOf('--mcp-config') + 1]);
+    assert.equal(parsed.mcpServers['computer-use'], undefined, 'Claude reserved user MCP must not be merged');
+    assert.ok(parsed.mcpServers['my-tool'], 'non-reserved user MCP should still be merged');
+  } finally {
+    rmSync(runtimeRoot, { recursive: true, force: true });
+    rmSync(projectDir, { recursive: true, force: true });
+  }
+});
+
 test('falls back to default MCP path when CAT_CAFE_MCP_SERVER_PATH is empty', async () => {
   const root = mkdtempSync(join(tmpdir(), 'cat-cafe-mcp-empty-env-'));
   const apiCwd = join(root, 'packages', 'api');

--- a/packages/api/test/claude-agent-service.test.js
+++ b/packages/api/test/claude-agent-service.test.js
@@ -114,6 +114,14 @@ function writeCapabilitiesConfig(projectRoot, capabilities) {
   );
 }
 
+const CLAUDE_RESERVED_MCP_SERVER_NAMES = [
+  'workspace',
+  'claude-in-chrome',
+  'computer-use',
+  'Claude Preview',
+  'Claude Browser',
+];
+
 // --- Test cases ---
 
 test('F203 AC-C5: -p carrier passes --system-prompt-file with compiled L0 path', async () => {
@@ -1325,14 +1333,14 @@ test('Claude skips reserved MCP server names from capabilities', async () => {
   mkdirSync(mcpDistDir, { recursive: true });
   writeFileSync(join(mcpDistDir, 'index.js'), '// stub', 'utf8');
   writeCapabilitiesConfig(runtimeRoot, [
-    {
-      id: 'computer-use',
+    ...CLAUDE_RESERVED_MCP_SERVER_NAMES.map((serverName) => ({
+      id: serverName,
       type: 'mcp',
       enabled: true,
       globalEnabled: true,
       source: 'external',
       mcpServer: { command: 'echo', args: ['reserved-should-be-skipped'] },
-    },
+    })),
     {
       id: 'safe-tool',
       type: 'mcp',
@@ -1368,7 +1376,13 @@ test('Claude skips reserved MCP server names from capabilities', async () => {
 
     const args = spawnFn.mock.calls[0].arguments[1];
     const parsed = JSON.parse(args[args.indexOf('--mcp-config') + 1]);
-    assert.equal(parsed.mcpServers['computer-use'], undefined, 'Claude reserved MCP name must not be injected');
+    for (const serverName of CLAUDE_RESERVED_MCP_SERVER_NAMES) {
+      assert.equal(
+        parsed.mcpServers[serverName],
+        undefined,
+        `Claude reserved MCP name ${serverName} must not be injected`,
+      );
+    }
     assert.ok(parsed.mcpServers['safe-tool'], 'non-reserved external MCP should still be injected');
   } finally {
     rmSync(runtimeRoot, { recursive: true, force: true });
@@ -1387,7 +1401,12 @@ test('Claude skips reserved MCP server names from project .mcp.json', async () =
     join(projectDir, '.mcp.json'),
     JSON.stringify({
       mcpServers: {
-        'computer-use': { command: 'echo', args: ['reserved-should-be-skipped'] },
+        ...Object.fromEntries(
+          CLAUDE_RESERVED_MCP_SERVER_NAMES.map((serverName) => [
+            serverName,
+            { command: 'echo', args: ['reserved-should-be-skipped'] },
+          ]),
+        ),
         'my-tool': { command: 'echo', args: ['ok'] },
       },
     }),
@@ -1419,7 +1438,13 @@ test('Claude skips reserved MCP server names from project .mcp.json', async () =
 
     const args = spawnFn.mock.calls[0].arguments[1];
     const parsed = JSON.parse(args[args.indexOf('--mcp-config') + 1]);
-    assert.equal(parsed.mcpServers['computer-use'], undefined, 'Claude reserved user MCP must not be merged');
+    for (const serverName of CLAUDE_RESERVED_MCP_SERVER_NAMES) {
+      assert.equal(
+        parsed.mcpServers[serverName],
+        undefined,
+        `Claude reserved user MCP ${serverName} must not be merged`,
+      );
+    }
     assert.ok(parsed.mcpServers['my-tool'], 'non-reserved user MCP should still be merged');
   } finally {
     rmSync(runtimeRoot, { recursive: true, force: true });

--- a/packages/api/test/system-prompt-builder.test.js
+++ b/packages/api/test/system-prompt-builder.test.js
@@ -12,7 +12,7 @@ import { catRegistry } from '@cat-cafe/shared';
 
 const REPO_ROOT_TEMPLATE = resolve(dirname(fileURLToPath(import.meta.url)), '../../..', 'cat-template.json');
 const CAT_TEMPLATE_PATH = REPO_ROOT_TEMPLATE;
-const FULL_RUNTIME_PROMPT_CHAR_BUDGET = 6900; // 6500→6700→6900: kitten/catagent breed + gemini35 + gpt-pro roster growth
+const FULL_RUNTIME_PROMPT_CHAR_BUDGET = 7000; // 6500→6700→6900→7000: kitten/catagent breed + gemini35 + gpt-pro roster growth
 
 function assertWithinFullRuntimePromptBudget(prompt) {
   assert.ok(
@@ -1759,8 +1759,8 @@ describe('SystemPromptBuilder', () => {
         featureId: 'F073',
       },
     });
-    // 6200→6500→6700→6900: decision funnel §17 + kitten/catagent breed + F208 dossier l0RosterSummary + roster growth
-    assert.ok(prompt.length < 6900, `Prompt with SOP hint is ${prompt.length} chars, expected < 6900`);
+    // 6200→6500→6700→6900→7000: decision funnel §17 + kitten/catagent breed + F208 dossier l0RosterSummary + roster growth
+    assertWithinFullRuntimePromptBudget(prompt);
   });
 
   // --- F092: Voice Mode prompt injection ---
@@ -1807,8 +1807,8 @@ describe('SystemPromptBuilder', () => {
       },
       voiceMode: true,
     });
-    // 6200→6500→6700→6900: decision funnel §17 + kitten/catagent breed + F208 dossier l0RosterSummary + roster growth
-    assert.ok(prompt.length < 6900, `Prompt with voice mode + SOP hint is ${prompt.length} chars, expected < 6900`);
+    // 6200→6500→6700→6900→7000: decision funnel §17 + kitten/catagent breed + F208 dossier l0RosterSummary + roster growth
+    assertWithinFullRuntimePromptBudget(prompt);
   });
 
   test('buildInvocationContext injects bootcamp mode when bootcampState provided', async () => {

--- a/packages/mcp-server/src/tools/publish-verdict-tool.ts
+++ b/packages/mcp-server/src/tools/publish-verdict-tool.ts
@@ -277,10 +277,7 @@ const anchorTelemetrySourceRefsShape = z
 const qcMetricsSourceRefsShape = z
   .object({
     kind: z.literal('qc-metrics-rollup'),
-    windowStartMs: z
-      .number()
-      .finite()
-      .describe('Inclusive epoch ms window start for QC metrics aggregation.'),
+    windowStartMs: z.number().finite().describe('Inclusive epoch ms window start for QC metrics aggregation.'),
     windowEndMs: z
       .number()
       .finite()

--- a/packages/web/src/components/__tests__/first-run-quest-wizard.test.tsx
+++ b/packages/web/src/components/__tests__/first-run-quest-wizard.test.tsx
@@ -43,6 +43,13 @@ function WizardHost({ onCreated }: { onCreated?: (tid: string) => void }) {
   return <FirstRunQuestWizard open={open} onClose={() => setOpen(false)} onCreated={onCreated ?? (() => {})} />;
 }
 
+function requirePayload(payload: Record<string, unknown> | null, label: string): Record<string, unknown> {
+  if (!payload) {
+    throw new Error(`${label} was not captured`);
+  }
+  return payload;
+}
+
 describe('FirstRunQuestWizard', () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -241,9 +248,9 @@ describe('FirstRunQuestWizard', () => {
     }
 
     // Assert: POST /api/cats must use clientId, not client
-    expect(catsPayload).not.toBeNull();
-    expect(catsPayload?.clientId).toBe('anthropic');
-    expect(catsPayload?.client).toBeUndefined();
+    const payload = requirePayload(catsPayload, 'POST /api/cats payload');
+    expect(payload.clientId).toBe('anthropic');
+    expect(payload.client).toBeUndefined();
   });
 
   // F159 G2 follow-up: kitten/catagent template must POST with clientId=catagent
@@ -372,20 +379,20 @@ describe('FirstRunQuestWizard', () => {
     }
 
     // Assert: template runtimeDefaults override.
-    expect(catsPayload).not.toBeNull();
-    expect(catsPayload?.clientId).toBe('catagent');
-    expect(catsPayload?.catAgentProtocol).toBe('openai-chat');
-    expect(catsPayload?.nativeToolLevel).toBe('L1');
+    const payload = requirePayload(catsPayload, 'POST /api/cats payload');
+    expect(payload.clientId).toBe('catagent');
+    expect(payload.catAgentProtocol).toBe('openai-chat');
+    expect(payload.nativeToolLevel).toBe('L1');
     // Family consistency: accountRef from openai-family ConfigStep filter.
     // OpenAIChatAdapter.clientFamily='openai' will match account.clientFamily='openai' at invoke time.
-    expect(catsPayload?.accountRef).toBe('codex');
+    expect(payload.accountRef).toBe('codex');
     // connectivity-test must use the codex CLI probe (template's effective family),
     // NOT the claude probe that user picked in ClientStep. Without this, probe runs
     // wrong CLI binary against right account → testResult.ok fails → create blocked.
-    expect(connectivityPayload).not.toBeNull();
-    expect(connectivityPayload?.client).toBe('codex');
+    const connectivityTestPayload = requirePayload(connectivityPayload, 'connectivity-test payload');
+    expect(connectivityTestPayload.client).toBe('codex');
     // clientId comes from selectedProfile.provider (account-binding), which is 'codex'
     // for the OAuth builtin; what matters is it's openai-family (not 'claude'/'anthropic').
-    expect(connectivityPayload?.clientId).toBe('codex');
+    expect(connectivityTestPayload.clientId).toBe('codex');
   });
 });

--- a/packages/web/src/lib/capability-tips.seed.json
+++ b/packages/web/src/lib/capability-tips.seed.json
@@ -453,6 +453,38 @@
     "owner": "codex"
   },
   {
+    "id": "feature-f126-limb-control-plane",
+    "kind": "feature",
+    "sourceRef": { "path": "docs/features/F126-limb-control-plane.md", "anchor": "Cat Café Limb Control Plane" },
+    "structureSource": { "path": "docs/features/F126-limb-control-plane.md", "anchor": "User Journey" },
+    "bodySource": { "path": "docs/features/F126-limb-control-plane.md", "anchor": "typed limb action" },
+    "contexts": ["thinking", "feature_dev"],
+    "audience": ["developer", "maintainer"],
+    "body": "接入外部 limb 时走 F126 控制面：先看 capability、presence、policy，再发 typed action。",
+    "action": {
+      "type": "open_source",
+      "label": "打开 spec",
+      "sourceRef": { "path": "docs/features/F126-limb-control-plane.md", "anchor": "Cat Café Limb Control Plane" }
+    },
+    "owner": "codex"
+  },
+  {
+    "id": "feature-f202-plugin-framework",
+    "kind": "feature",
+    "sourceRef": { "path": "docs/features/F202-plugin-framework.md", "anchor": "Plugin Framework" },
+    "structureSource": { "path": "docs/features/F202-plugin-framework.md", "anchor": "User Journey" },
+    "bodySource": { "path": "docs/features/F202-plugin-framework.md", "anchor": "plugin-owned configuration" },
+    "contexts": ["feature_dev", "review"],
+    "audience": ["developer", "maintainer"],
+    "body": "改插件资源前先对齐 F202：manifest、配置、激活和审计都必须留在 plugin framework 边界内。",
+    "action": {
+      "type": "open_source",
+      "label": "打开 spec",
+      "sourceRef": { "path": "docs/features/F202-plugin-framework.md", "anchor": "Plugin Framework" }
+    },
+    "owner": "codex"
+  },
+  {
     "id": "feature-f159-catagent-native-provider",
     "kind": "feature",
     "sourceRef": { "path": "docs/features/F159-catagent-native-provider.md", "anchor": "CatAgent Native Provider" },

--- a/packages/web/src/lib/capability-tips.seed.json
+++ b/packages/web/src/lib/capability-tips.seed.json
@@ -453,6 +453,44 @@
     "owner": "codex"
   },
   {
+    "id": "feature-f159-catagent-native-provider",
+    "kind": "feature",
+    "sourceRef": { "path": "docs/features/F159-catagent-native-provider.md", "anchor": "CatAgent Native Provider" },
+    "structureSource": { "path": "docs/features/F159-catagent-native-provider.md", "anchor": "User Journey" },
+    "bodySource": {
+      "path": "docs/features/F159-catagent-native-provider.md",
+      "anchor": "constrained native provider path"
+    },
+    "contexts": ["feature_dev", "review"],
+    "audience": ["developer", "maintainer"],
+    "body": "接入 API 型 CatAgent 前，先看 F159：账号绑定、workspace 边界和工具分级都必须保留。",
+    "action": {
+      "type": "open_source",
+      "label": "打开 spec",
+      "sourceRef": { "path": "docs/features/F159-catagent-native-provider.md", "anchor": "CatAgent Native Provider" }
+    },
+    "owner": "codex"
+  },
+  {
+    "id": "feature-f207-finance-data-plane",
+    "kind": "feature",
+    "sourceRef": { "path": "docs/features/F207-personal-finance-infra.md", "anchor": "AI Family Office" },
+    "structureSource": { "path": "docs/features/F207-personal-finance-infra.md", "anchor": "User Journey" },
+    "bodySource": {
+      "path": "docs/features/F207-personal-finance-infra.md",
+      "anchor": "read-only finance analysis request"
+    },
+    "contexts": ["thinking", "feature_dev"],
+    "audience": ["all"],
+    "body": "查投资学习数据时走 F207 finance MCP：只读事实、带 source/asOf，不触发交易动作。",
+    "action": {
+      "type": "open_source",
+      "label": "打开 spec",
+      "sourceRef": { "path": "docs/features/F207-personal-finance-infra.md", "anchor": "AI Family Office" }
+    },
+    "owner": "codex"
+  },
+  {
     "id": "feature-f237-prompt-injection-visibility",
     "kind": "feature",
     "sourceRef": {


### PR DESCRIPTION
## What

Main fix:
- Add a Claude reserved MCP server-name guard for the complete current Claude Code reserved MCP set: `workspace`, `claude-in-chrome`, `computer-use`, `Claude Preview`, and `Claude Browser`.
- Skip reserved names when building Claude capability MCP config and when merging project `.mcp.json` user servers.
- Keep non-reserved capability and user MCP servers mergeable.
- Add Claude provider regression coverage for both capability-defined and project-defined reserved names.

Gate-unblock sections kept as separate commits:
- Web TS narrowing: replace fragile optional-chain payload assertions in `first-run-quest-wizard.test.tsx` with explicit `requirePayload` assertions.
- F236 public exclusion TTL: refresh the source-only hook exclusion to the current batch TTL.
- CatAgent current-task callback: bind the resolved thread so the selected task callback has `currentTask` context.
- CatAgent public gate baselines: refresh cat roster count and runtime prompt budget expectations after existing roster growth.
- Biome formatting: apply formatter-only changes in two baseline files.
- Feature truth and tips gates: sync ROADMAP active features, add missing User Journey sections or exemptions, and add capability tips coverage for changed feature docs.

## Why

Claude Code owns some runtime MCP names itself. If Cat Cafe injects a server with the same name into Claude `--mcp-config`, Claude can fail before normal Cat Cafe invocation logic runs. The provider should fail closed on reserved names while preserving ordinary external MCP merging.

The later commits are local merge-gate debt exposed while proving this fix. They are split so reviewers can distinguish the Claude MCP behavior change from the baseline gate maintenance.

## Issue Closure

- N/A

## Original Requirements

- Discussion/Interview: Cat Cafe thread `thread_mrrbqzpxa5873cqh`
- Original requirement excerpt:
  > Claude invocation must not crash when project or capability MCP config contains a Claude-reserved server name such as `computer-use`.
- Operator core pain: a Claude-side reserved MCP collision caused another cat invocation path to exit before it could do useful work.
- Reviewer check: verify the branch blocks only reserved Claude MCP names and does not weaken normal MCP merge behavior.

## Plan / ADR

- BACKLOG: no dedicated feature ID; this is a provider hotfix plus merge-gate baseline cleanup.
- Runtime caveat: after merge, the API process serving port 3004 must restart and the runtime dist must be synced before existing Fable runtime sessions observe the fix.

## Tips Contribution

- [x] Added feature tips for F126, F159, F202, and F207 changed docs in `packages/web/src/lib/capability-tips.seed.json`.
- [x] Added `tips_exempt` for infrastructure or closed-status docs where no user-facing tip is appropriate.
- Reviewer usefulness check: new tips point to concrete action boundaries, not just feature titles.

## Tradeoff

Reserved names are denied by exact canonical name rather than rewritten. Renaming would hide the collision and could leave Claude-specific runtime semantics ambiguous; skipping preserves Claude's ownership of reserved integrations and logs the decision.

## Review Provenance

- Head: `a7aa5e593964953cd37f4db9aed34aebccddd06b`
- Local peer review: Opus48 approved prior head `b06df0f0167da7cdd6dad79dda3b3c396f147ab7` and final one-commit delta `b06df0f0..a7aa5e593` in Cat Cafe thread `thread_mrrbqzpxa5873cqh`.
- Cloud review: Codex connector first reported a P2 on `b06df0f016`; `a7aa5e593` fixes that P2 and Codex connector then reported no major issues for reviewed commit `a7aa5e5939`.
- The old inline P2 thread is resolved as addressed by `a7aa5e593`.
- Head change cause: cloud review delta for the full Claude reserved MCP name set.

## Author Provenance Note

Three intermediate commits use author name `MaineCoon-GPT-5.5` with the bot noreply email from the transient commit environment. The commit bodies and later commits carry the same Cat Cafe identity, and the current worktree git config is back to the personal email. I am not rewriting author metadata because it would change the reviewed and gate-passed SHA with no tree change.

## Test Evidence

- Full merge gate: `pnpm gate --no-rebase` with the Homebrew Node 24 path first in `PATH`.
- Result: GATE PASSED on branch `fix/claude-reserved-mcp-names`, SHA `a7aa5e593`; build, tsc, public tests, web lint, and repo check all passed. Total 774s.
- Public tests summary: `16717` tests, `16689` pass, `0` fail, `28` skipped.
- Targeted checks for the cloud review delta:
  - `pnpm --dir packages/api build`
  - `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 packages/api/test/claude-agent-service.test.js`
  - `pnpm exec biome check packages/api/src/config/capabilities/mcp-constants.ts packages/api/test/claude-agent-service.test.js --diagnostic-level=error`
  - `git diff --check`
- Merge-gate follow-up checks after review feedback:
  - `node scripts/check-feature-truth.mjs` passed.
  - PR inline P0/P1/P2 scan returned no findings after the delta.
  - Hotfix detector returned hotfix true; prior cross-cat local review is complete for `b06df0f0`.
- Root Artifact Guard: passed; no root media or design artifacts in `origin/develop...HEAD`.

## Open Questions

- GitHub branch protection requires one approving PR review. Current cloud review is complete for `a7aa5e593`, but GitHub still reports `REVIEW_REQUIRED` until an eligible GitHub reviewer approves or an admin explicitly bypasses.
- Merge is not runtime acceptance: sync runtime dist, restart API 3004, then verify a fresh Fable invocation no longer exits with code 1.

---

**Local Review**: [x] Final HEAD covered by Opus48 scoped local review.
**Cloud Review**: [x] Codex connector reported no major issues for `a7aa5e5939`.

<!-- Cat signature: Maine Coon/GPT-5.5 (codex) -->