### PR TITLE
verdict(eval:qc): 2026-07-26-eval-qc-zero-baseline-w30

### DIFF
--- a/docs/harness-feedback/bundles/2026-07-26-eval-qc-zero-baseline-w30/attribution.json
+++ b/docs/harness-feedback/bundles/2026-07-26-eval-qc-zero-baseline-w30/attribution.json
@@ -1,0 +1,11 @@
+{
+  "verdictId": "2026-07-26-eval-qc-zero-baseline-w30",
+  "featureId": "F253",
+  "evalSnapshotId": "qc-snapshot-2026-07-26-eval-qc-zero-baseline-w30",
+  "generatedAt": "2026-07-26T03:00:49.308Z",
+  "findings": [],
+  "noFindingRecord": {
+    "reason": "Zero-baseline bootstrap (Phase C) — no live QC data sources wired",
+    "evidence": "All QC metrics are zero (prCount=0). Eval:qc data pipeline not yet active."
+  }
+}

--- a/docs/harness-feedback/bundles/2026-07-26-eval-qc-zero-baseline-w30/provenance.json
+++ b/docs/harness-feedback/bundles/2026-07-26-eval-qc-zero-baseline-w30/provenance.json
@@ -1,0 +1,15 @@
+{
+  "verdictId": "2026-07-26-eval-qc-zero-baseline-w30",
+  "rawInputs": [
+    {
+      "path": "bundles/2026-07-26-eval-qc-zero-baseline-w30/snapshot.json",
+      "sha256": "a73977798a870ad0ffcaffb4a05bb4ea33c6a309f7faebe22091af9ed7f61459"
+    }
+  ],
+  "generatedAt": "2026-07-26T03:00:49.308Z",
+  "generator": {
+    "name": "qc-generator-adapter",
+    "version": "1.0.0"
+  },
+  "sanitizeRulesVersion": "1.0.0"
+}

--- a/docs/harness-feedback/bundles/2026-07-26-eval-qc-zero-baseline-w30/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-07-26-eval-qc-zero-baseline-w30/snapshot.json
@@ -1,0 +1,27 @@
+{
+  "verdictId": "2026-07-26-eval-qc-zero-baseline-w30",
+  "evalSnapshotId": "qc-snapshot-2026-07-26-eval-qc-zero-baseline-w30",
+  "featureId": "F253",
+  "generatedAt": "2026-07-26T03:00:49.308Z",
+  "window": {
+    "startMs": 1784419200000,
+    "endMs": 1785024000000,
+    "durationHours": 168
+  },
+  "components": [
+    {
+      "componentId": "qc-pipeline",
+      "componentName": "QC Pipeline",
+      "activationCounts": {
+        "finding_yield": 0,
+        "reviewer_delta": 0,
+        "pr_count": 0
+      },
+      "frictionCounts": {
+        "false_positive_rate": 0,
+        "post_merge_bug_rate": 0
+      },
+      "confidence": "no-data"
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-07-26-eval-qc-zero-baseline-w30.md
+++ b/docs/harness-feedback/verdicts/2026-07-26-eval-qc-zero-baseline-w30.md
@@ -1,0 +1,36 @@
+---
+feature_ids: [F253]
+topics: [harness-eval, eval-qc, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:qc
+packet_id: 2026-07-26-eval-qc-zero-baseline-w30
+source_snapshot: "snapshot:bundle/2026-07-26-eval-qc-zero-baseline-w30/snapshot"
+---
+
+# eval:qc Verdict — 2026-07-26-eval-qc-zero-baseline-w30
+
+- Verdict: `keep_observe`
+- Phenomenon: QC pipeline metrics remain in zero-baseline state for the third consecutive week (Jul 19–26 window). Phase C bootstrap continues: all 4 metrics return 0 — no live review telemetry source wired. Pipeline structural health stable (W28 schema fix, W29 MCP path validation, W30 routine cadence).
+- Harness: F253/qc-pipeline (QC Review Loop)
+- Owner ask: No action required. Continue weekly cadence. Three consecutive stable zero-baseline runs confirm structural readiness for Phase D data wiring.
+- Re-eval: next eval at 2026-08-02T03:00:00.000Z
+
+Evidence:
+- snapshot:bundle/2026-07-26-eval-qc-zero-baseline-w30/snapshot
+- attribution:bundle/2026-07-26-eval-qc-zero-baseline-w30/qc-snapshot-2026-07-26-eval-qc-zero-baseline-w30:no-finding
+
+**Window**: 7 days | **PRs analyzed**: 0
+
+## Metrics
+
+| Metric | Value |
+|--------|-------|
+| Finding Yield (avg/review) | 0 |
+| False Positive Rate | 0 |
+| Reviewer Delta | 0 |
+| Post-Merge Bug Rate | 0 |
+
+## Notes
+
+No PR data available in this window. Zero-baseline snapshot (Phase C bootstrap — live data sources not yet wired).


### PR DESCRIPTION
Verdict published via cat_cafe_publish_verdict MCP tool.

Verdict: keep_observe
Domain: eval:qc
Phenomenon: QC pipeline metrics remain in zero-baseline state for the third consecutive week (Jul 19–26 window). Phase C bootstrap continues: all 4 metrics return 0 — no live review telemetry source wired. Pipeline structural health stable (W28 schema fix, W29 MCP path validation, W30 routine cadence).

Reviewed by: opus
Action: No action required. Continue weekly cadence. Three consecutive stable zero-baseline runs confirm structural readiness for Phase D data wiring.

---
**Cat-owned artifact gate — No operator merge needed.**
(Interim: keep_observe + no actionable findings. Rollup mechanism deferred to future Phase. See docs/SOP.md § artifact-only-pr-merge-gate for cat merge contract.)