### PR TITLE
verdict(eval:anchor-first): 2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe

### DIFF
--- a/docs/harness-feedback/bundles/2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe/attribution.json
+++ b/docs/harness-feedback/bundles/2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe/attribution.json
@@ -1,0 +1,47 @@
+{
+  "verdictId": "2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe",
+  "featureId": "F236",
+  "evalSnapshotId": "eval-F236-2026-07-26",
+  "generatedAt": "2026-07-26T03:01:28.857Z",
+  "findings": [
+    {
+      "id": "AF-2026-07-26-list-tasks",
+      "relatedFeature": "F236",
+      "sunsetSignals": {
+        "anchorTax": false,
+        "highOpenRate": false,
+        "netNegative": false
+      },
+      "frictionSignal": {
+        "type": "anchor.open_rate.list-tasks",
+        "severity": "low",
+        "confidence": 0.8,
+        "detectedAt": "2026-07-26T03:01:28.857Z"
+      },
+      "attribution": {
+        "primaryLayer": "needs_investigation",
+        "evidence": [
+          {
+            "type": "counter",
+            "anchor": "anchor-telemetry-rollup/list-tasks_drilled_unique_items",
+            "excerpt": "list-tasks: 0/10 items drilled (0.0% open rate), charsSaved=415, drillChars=0, netBenefit=415"
+          }
+        ]
+      },
+      "proposedAction": [
+        {
+          "action": "keep-observe",
+          "target": "anchor-telemetry-rollup/list-tasks",
+          "rationale": "Open rate 0.0%: 0/10 items drilled, net benefit 415 chars"
+        }
+      ]
+    }
+  ],
+  "sunsetAssessment": {
+    "toolCount": 1,
+    "toolsWithAnchorTax": 0,
+    "toolsNetNegative": 0,
+    "toolsHighOpenRate": 0,
+    "lowSampleToolCount": 0
+  }
+}

--- a/docs/harness-feedback/bundles/2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe/provenance.json
+++ b/docs/harness-feedback/bundles/2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe/provenance.json
@@ -1,0 +1,15 @@
+{
+  "verdictId": "2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/bundles/2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe/raw/rollup.json",
+      "sha256": "ed0f0c5c3e261c271947a617e45f8726a253d37c245bfd7902f5a030b035e587"
+    }
+  ],
+  "generatedAt": "2026-07-26T03:01:28.857Z",
+  "generator": {
+    "name": "eval-anchor-first-live-verdict",
+    "version": "1"
+  },
+  "sanitizeRulesVersion": "f236-anchor-telemetry-v1"
+}

--- a/docs/harness-feedback/bundles/2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe/raw/rollup.json
+++ b/docs/harness-feedback/bundles/2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe/raw/rollup.json
@@ -1,0 +1,55 @@
+{
+  "verdictId": "2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe",
+  "selector": {
+    "kind": "anchor-telemetry-snapshot",
+    "windowStartMs": 1784948442163,
+    "windowEndMs": 1785034842163
+  },
+  "rollup": {
+    "perTool": {
+      "list-tasks": {
+        "previewResponses": 3,
+        "previewedItems": 10,
+        "drills": 0,
+        "drilledUniqueItems": 0,
+        "openRateByItem": 0,
+        "returnedChars": 2461,
+        "originalChars": 2876,
+        "charsSaved": 415,
+        "drillChars": 0,
+        "netBenefit": 415
+      }
+    },
+    "orphanDrills": 0,
+    "adoption": {
+      "explicitAnchorCalls": 0,
+      "explicitFullCalls": 1,
+      "defaultAnchorCalls": 0,
+      "defaultFullCalls": 0,
+      "legacyEquivalentAnchorCalls": 3,
+      "legacyEquivalentFullCalls": 0,
+      "unknownModeCalls": 0,
+      "uniqueCatsExplicitAnchor": 0
+    },
+    "track1Snapshot": {
+      "returnedByTool": {
+        "thread-context": 34,
+        "pending-mentions": 10,
+        "list-tasks": 21
+      },
+      "returnedCharsByTool": {
+        "thread-context": 303457,
+        "pending-mentions": 11482,
+        "list-tasks": 393434
+      },
+      "drillByTool": {
+        "get-message": 14,
+        "list-tasks": 6
+      },
+      "drillCharsByTool": {
+        "get-message": 37735,
+        "list-tasks": 4276
+      }
+    }
+  }
+}

--- a/docs/harness-feedback/bundles/2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe/snapshot.json
@@ -1,0 +1,39 @@
+{
+  "verdictId": "2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe",
+  "evalSnapshotId": "eval-F236-2026-07-26",
+  "featureId": "F236",
+  "generatedAt": "2026-07-26T03:01:28.857Z",
+  "window": {
+    "startMs": 1784948442163,
+    "endMs": 1785034842163,
+    "durationHours": 24
+  },
+  "components": [
+    {
+      "id": "anchor-telemetry-rollup",
+      "name": "anchor-first preview/drill open-rate rollup",
+      "confidence": "medium",
+      "activationCounts": {
+        "orphan_drills": 0,
+        "adoption_explicit_anchor_calls": 0,
+        "adoption_explicit_full_calls": 1,
+        "adoption_default_anchor_calls": 0,
+        "adoption_default_full_calls": 0,
+        "adoption_legacy_equivalent_anchor_calls": 3,
+        "adoption_legacy_equivalent_full_calls": 0,
+        "adoption_unique_cats_explicit_anchor": 0,
+        "adoption_unknown_mode_calls": 0,
+        "list-tasks_preview_responses": 3,
+        "list-tasks_previewed_items": 10,
+        "list-tasks_drills": 0,
+        "list-tasks_drilled_unique_items": 0,
+        "list-tasks_returned_chars": 2461,
+        "list-tasks_original_chars": 2876,
+        "list-tasks_chars_saved": 415,
+        "list-tasks_drill_chars": 0,
+        "list-tasks_net_benefit": 415
+      },
+      "frictionCounts": {}
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe.md
+++ b/docs/harness-feedback/verdicts/2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe.md
@@ -1,0 +1,47 @@
+---
+feature_ids: [F192, F236]
+topics: [harness-eval, eval-anchor-first, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:anchor-first
+packet_id: 2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe
+source_snapshot: "snapshot:bundle/2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe/snapshot"
+---
+
+# Live Verdict — 2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe
+
+- Verdict: `keep_observe`
+- Phenomenon: The latest visible 24h anchor-first window has materially higher preview and drill traffic than the prior low-sample week, so this cycle can assess a broader mix of preview tools instead of a single sparse path. However, independent blindness evidence is still absent because eval:task-outcome has not published verdict trends and the task-outcome episode store still contains zero written verdicts.
+- Harness: F236/anchor-telemetry-rollup (anchor-first preview/drill open-rate rollup)
+- Owner ask: Keep F236 in observe mode, use this higher-volume window to confirm per-tool open-rate and net-benefit health, and wait for published eval:task-outcome trends before considering fix or sunset.
+- Re-eval: Re-evaluate when the next 24h rollup either shows a per-tool anchor-tax signal with enough volume or eval:task-outcome publishes verdict trends that can confirm or reject blindness. at 2026-08-02T03:00:42.163Z
+
+Sunset Signal Assessment:
+- list-tasks: HEALTHY (openRate=0.0%, netBenefit=415)
+
+Open-Rate Detail:
+- list-tasks: 0.0% open rate (0/10 items), charsSaved=415, drillChars=0, netBenefit=415
+- Orphan drills: 0
+
+Adoption Detail:
+- explicitAnchorCalls=0; explicitFullCalls=1; uniqueCatsExplicitAnchor=0
+- defaultAnchorCalls=0; defaultFullCalls=0
+- legacyEquivalentAnchorCalls=3; legacyEquivalentFullCalls=0
+- unknownModeCalls=0
+
+Evidence:
+- snapshot:bundle/2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe/snapshot
+- attribution:bundle/2026-07-26-eval-anchor-first-c1-higher-volume-keep-observe/AF-2026-07-26-list-tasks
+- metric:prometheus:cat_cafe_anchor_returned_count_total{anchor_tool="thread-context"}
+- metric:prometheus:cat_cafe_anchor_returned_count_total{anchor_tool="pending-mentions"}
+- metric:prometheus:cat_cafe_anchor_returned_count_total{anchor_tool="list-tasks"}
+- metric:prometheus:cat_cafe_anchor_full_drill_count_total{anchor_tool="get-message"}
+- metric:prometheus:cat_cafe_anchor_full_drill_count_total{anchor_tool="list-tasks"}
+- metric:sqlite:task_outcome_episodes.with_verdict=0
+- thread:thread_eval_anchor_first/message:0001785034802785-000659-9e62f50c
+- task-outcome-episodes.sqlite
+
+Counterarguments:
+- The live rollup could still reveal concentrated drilling on a subset of previewed items even though the aggregate Track-1 counts look healthy.
+- Zero task-outcome verdicts may mean the blindness detector is missing, not that blindness risk is absent.
+- Comparing this week to last week's unusually quiet window may make normal traffic recovery look more meaningful than it is.


### PR DESCRIPTION
Verdict published via cat_cafe_publish_verdict MCP tool.

Verdict: keep_observe
Domain: eval:anchor-first
Phenomenon: The latest visible 24h anchor-first window has materially higher preview and drill traffic than the prior low-sample week, so this cycle can assess a broader mix of preview tools instead of a single sparse path. However, independent blindness evidence is still absent because eval:task-outcome has not published verdict trends and the task-outcome episode store still contains zero written verdicts.

Reviewed by: opus-47
Action: Keep F236 in observe mode, use this higher-volume window to confirm per-tool open-rate and net-benefit health, and wait for published eval:task-outcome trends before considering fix or sunset.

---
**Cat-owned artifact gate — No operator merge needed.**
(Actionable findings present; eval domain owner cat merges per docs/SOP.md § artifact-only-pr-merge-gate.)