### PR TITLE
verdict(eval:a2a): 2026-07-31-eval-a2a-grounding-sample-retention-build

### DIFF
--- a/docs/harness-feedback/bundles/2026-07-31-eval-a2a-grounding-sample-retention-build/attribution.json
+++ b/docs/harness-feedback/bundles/2026-07-31-eval-a2a-grounding-sample-retention-build/attribution.json
@@ -1,0 +1,11 @@
+{
+  "verdictId": "2026-07-31-eval-a2a-grounding-sample-retention-build",
+  "featureId": "F167",
+  "evalSnapshotId": "eval-F167-2026-07-31",
+  "generatedAt": "2026-07-31T03:13:26.879Z",
+  "findings": [],
+  "noFindingRecord": {
+    "reason": "No friction signals detected across 5 components",
+    "evidence": "Checked components: L1, C1, C2, route-serial, grounding-phase-o. Friction metrics examined: c1.hold_zombie_count, c1.hold_cancel_count, c2.verdict_without_pass_count, c2.void_hold_hint_emitted, inline_action.shadow_miss, grounding.budget_exhausted_total. All values within threshold."
+  }
+}

--- a/docs/harness-feedback/bundles/2026-07-31-eval-a2a-grounding-sample-retention-build/provenance.json
+++ b/docs/harness-feedback/bundles/2026-07-31-eval-a2a-grounding-sample-retention-build/provenance.json
@@ -1,0 +1,19 @@
+{
+  "verdictId": "2026-07-31-eval-a2a-grounding-sample-retention-build",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/snapshots/2026-07-31-eval-F167-runtime.yaml",
+      "sha256": "0efb38cb0dc529bf23670b0c71bf9a375595ddca01c0f543cd0d03760cb12446"
+    },
+    {
+      "path": "docs/harness-feedback/attributions/2026-07-31-eval-F167-attribution.yaml",
+      "sha256": "5e6a798278a4a24929b06a0cbb39de9c7f3564fba6789a465ad41e485bbe351f"
+    }
+  ],
+  "generatedAt": "2026-07-31T03:13:26.879Z",
+  "generator": {
+    "name": "eval-a2a-live-verdict",
+    "version": "1"
+  },
+  "sanitizeRulesVersion": "f192-e-pilot-v1"
+}

--- a/docs/harness-feedback/bundles/2026-07-31-eval-a2a-grounding-sample-retention-build/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-07-31-eval-a2a-grounding-sample-retention-build/snapshot.json
@@ -1,0 +1,84 @@
+{
+  "verdictId": "2026-07-31-eval-a2a-grounding-sample-retention-build",
+  "evalSnapshotId": "eval-F167-2026-07-31",
+  "featureId": "F167",
+  "generatedAt": "2026-07-31T03:13:26.875Z",
+  "window": {
+    "startMs": 1785392898615,
+    "endMs": 1785467344465,
+    "durationHours": 20.679402777777778
+  },
+  "counterWindow": {
+    "startMs": 1784451435240,
+    "endMs": 1785467606825,
+    "durationHours": 282.26988462628475
+  },
+  "components": [
+    {
+      "id": "L1",
+      "name": "WorklistRegistry (ping-pong breaker)",
+      "confidence": "medium",
+      "activationCounts": {
+        "l1.streak_warn_count": 0,
+        "l1.streak_break_count": 0
+      },
+      "frictionCounts": {}
+    },
+    {
+      "id": "C1",
+      "name": "hold_ball (MCP tool)",
+      "confidence": "medium",
+      "activationCounts": {
+        "hold_ball_calls": 0,
+        "c1.hold_replacement_count": 0
+      },
+      "frictionCounts": {
+        "c1.hold_zombie_count": 0,
+        "c1.hold_cancel_count": 0
+      }
+    },
+    {
+      "id": "C2",
+      "name": "exit-check (forced-pass guard)",
+      "confidence": "medium",
+      "activationCounts": {
+        "hint_emitted (mixed routing+verdict)": null,
+        "c2.verdict_hint_emitted": 0,
+        "c2.checked": 303,
+        "c2.void_hold_checked": 305
+      },
+      "frictionCounts": {
+        "c2.verdict_without_pass_count": 0,
+        "c2.void_hold_hint_emitted": 3
+      }
+    },
+    {
+      "id": "route-serial",
+      "name": "route-serial (A2A handoff routing)",
+      "confidence": "high",
+      "activationCounts": {
+        "line_start.detected": 98,
+        "inline_action.checked": 305
+      },
+      "frictionCounts": {
+        "inline_action.shadow_miss": 1
+      }
+    },
+    {
+      "id": "grounding-phase-o",
+      "name": "claim grounding (Phase O shadow)",
+      "confidence": "medium",
+      "activationCounts": {
+        "grounding.check_total": 12,
+        "grounding.verdict_total": 12,
+        "grounding.resolver_total": 0,
+        "grounding.cache_hit_total": 0,
+        "grounding.sample_count": 5,
+        "grounding.mismatch_sample_count": 0
+      },
+      "frictionCounts": {
+        "grounding.budget_exhausted_total": 0
+      }
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-07-31-eval-a2a-grounding-sample-retention-build.md
+++ b/docs/harness-feedback/verdicts/2026-07-31-eval-a2a-grounding-sample-retention-build.md
@@ -1,0 +1,34 @@
+---
+feature_ids: [F192, F167]
+topics: [harness-eval, eval-a2a, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:a2a
+packet_id: 2026-07-31-eval-a2a-grounding-sample-retention-build
+source_snapshot: "snapshot:bundle/2026-07-31-eval-a2a-grounding-sample-retention-build/snapshot"
+---
+
+# Live Verdict — 2026-07-31-eval-a2a-grounding-sample-retention-build
+
+- Verdict: `build`
+- Phenomenon: A2A routing remains clean, but grounding Phase O retained sample depth fell to 5 after the 14 -> 10 -> 8 -> 6 -> 5 decline, so the zero-mismatch signal is now too shallow to trust as healthy evidence.
+- Harness: F167/grounding-phase-o (claim grounding (Phase O shadow))
+- Owner ask: Build grounding Phase O retention-depth coverage: raise sample retention capacity or TTL, or emit an explicit low-volume/retention diagnostic, so eval:a2a retains at least 10 grounding samples for 3 consecutive daily runs or explains why the sample is intentionally shallow.
+- Re-eval: Within the next 72h, grounding-phase-o keeps mismatch_sample_count at 0 and either retains sample_count >= 10 on each daily eval or reports an explicit low-volume/retention diagnostic that makes the shallow sample interpretable. at 2026-08-01T03:00:00.000Z
+
+Evidence:
+- snapshot:bundle/2026-07-31-eval-a2a-grounding-sample-retention-build/snapshot
+- attribution:bundle/2026-07-31-eval-a2a-grounding-sample-retention-build/eval-F167-2026-07-31:no-finding
+- metric:grounding.sample_count
+- metric:grounding.mismatch_sample_count
+- metric:grounding.check_total
+- metric:c2.verdict_without_pass_count
+- metric:c2.void_hold_hint_emitted
+- metric:counter_window.duration_hours
+- raw:docs/harness-feedback/snapshots/2026-07-31-eval-F167-runtime.yaml:grounding_sample_evidence
+- grounding_sample:register_pr_tracking:pr_url:clowder-labs/clowder-ai#104
+
+Counterarguments:
+- The routing guard itself is healthy: C2 forced-pass is 0/303 and void-hold stayed frozen at 3/305 (0.98%).
+- The grounding checker may simply have low eligible stateful-tool traffic, and no mismatches were retained.
+- The raw attribution report correctly has no friction finding because this is a longitudinal evidence-depth gap, not a threshold breach in frictionCounts.


### PR DESCRIPTION
Verdict published via cat_cafe_publish_verdict MCP tool.

Verdict: build
Domain: eval:a2a
Phenomenon: A2A routing remains clean, but grounding Phase O retained sample depth fell to 5 after the 14 -> 10 -> 8 -> 6 -> 5 decline, so the zero-mismatch signal is now too shallow to trust as healthy evidence.

Reviewed by: opus-47
Action: Build grounding Phase O retention-depth coverage: raise sample retention capacity or TTL, or emit an explicit low-volume/retention diagnostic, so eval:a2a retains at least 10 grounding samples for 3 consecutive daily runs or explains why the sample is intentionally shallow.