### PR TITLE
verdict(eval:a2a): 2026-08-02-eval-a2a-grounding-sample-retention-build

### DIFF
--- a/docs/harness-feedback/bundles/2026-08-02-eval-a2a-grounding-sample-retention-build/attribution.json
+++ b/docs/harness-feedback/bundles/2026-08-02-eval-a2a-grounding-sample-retention-build/attribution.json
@@ -1,0 +1,11 @@
+{
+  "verdictId": "2026-08-02-eval-a2a-grounding-sample-retention-build",
+  "featureId": "F167",
+  "evalSnapshotId": "eval-F167-2026-08-02",
+  "generatedAt": "2026-08-02T03:06:10.933Z",
+  "findings": [],
+  "noFindingRecord": {
+    "reason": "No friction signals detected across 5 components",
+    "evidence": "Checked components: L1, C1, C2, route-serial, grounding-phase-o. Friction metrics examined: c1.hold_zombie_count, c1.hold_cancel_count, c2.verdict_without_pass_count, c2.void_hold_hint_emitted, inline_action.shadow_miss, grounding.budget_exhausted_total. All values within threshold."
+  }
+}

--- a/docs/harness-feedback/bundles/2026-08-02-eval-a2a-grounding-sample-retention-build/provenance.json
+++ b/docs/harness-feedback/bundles/2026-08-02-eval-a2a-grounding-sample-retention-build/provenance.json
@@ -1,0 +1,19 @@
+{
+  "verdictId": "2026-08-02-eval-a2a-grounding-sample-retention-build",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/snapshots/2026-08-02-eval-F167-runtime.yaml",
+      "sha256": "459e08c4df6bcf4d9dbad323a3469050b566a38e06a166656daf2bde0dc891e4"
+    },
+    {
+      "path": "docs/harness-feedback/attributions/2026-08-02-eval-F167-attribution.yaml",
+      "sha256": "7e26ae3f598187efe3e4124254894051d089cc362e851476068fcf43087f6ef1"
+    }
+  ],
+  "generatedAt": "2026-08-02T03:06:10.933Z",
+  "generator": {
+    "name": "eval-a2a-live-verdict",
+    "version": "1"
+  },
+  "sanitizeRulesVersion": "f192-e-pilot-v1"
+}

--- a/docs/harness-feedback/bundles/2026-08-02-eval-a2a-grounding-sample-retention-build/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-08-02-eval-a2a-grounding-sample-retention-build/snapshot.json
@@ -1,0 +1,84 @@
+{
+  "verdictId": "2026-08-02-eval-a2a-grounding-sample-retention-build",
+  "evalSnapshotId": "eval-F167-2026-08-02",
+  "featureId": "F167",
+  "generatedAt": "2026-08-02T03:06:10.931Z",
+  "window": {
+    "startMs": 1785553553854,
+    "endMs": 1785639877569,
+    "durationHours": 23.978809722222223
+  },
+  "counterWindow": {
+    "startMs": 1784451436102,
+    "endMs": 1785639894881,
+    "durationHours": 330.12743860417834
+  },
+  "components": [
+    {
+      "id": "L1",
+      "name": "WorklistRegistry (ping-pong breaker)",
+      "confidence": "medium",
+      "activationCounts": {
+        "l1.streak_warn_count": 0,
+        "l1.streak_break_count": 0
+      },
+      "frictionCounts": {}
+    },
+    {
+      "id": "C1",
+      "name": "hold_ball (MCP tool)",
+      "confidence": "medium",
+      "activationCounts": {
+        "hold_ball_calls": 0,
+        "c1.hold_replacement_count": 0
+      },
+      "frictionCounts": {
+        "c1.hold_zombie_count": 0,
+        "c1.hold_cancel_count": 0
+      }
+    },
+    {
+      "id": "C2",
+      "name": "exit-check (forced-pass guard)",
+      "confidence": "medium",
+      "activationCounts": {
+        "hint_emitted (mixed routing+verdict)": null,
+        "c2.verdict_hint_emitted": 0,
+        "c2.checked": 311,
+        "c2.void_hold_checked": 313
+      },
+      "frictionCounts": {
+        "c2.verdict_without_pass_count": 0,
+        "c2.void_hold_hint_emitted": 3
+      }
+    },
+    {
+      "id": "route-serial",
+      "name": "route-serial (A2A handoff routing)",
+      "confidence": "high",
+      "activationCounts": {
+        "line_start.detected": 99,
+        "inline_action.checked": 313
+      },
+      "frictionCounts": {
+        "inline_action.shadow_miss": 1
+      }
+    },
+    {
+      "id": "grounding-phase-o",
+      "name": "claim grounding (Phase O shadow)",
+      "confidence": "medium",
+      "activationCounts": {
+        "grounding.check_total": 13,
+        "grounding.verdict_total": 13,
+        "grounding.resolver_total": 0,
+        "grounding.cache_hit_total": 0,
+        "grounding.sample_count": 4,
+        "grounding.mismatch_sample_count": 0
+      },
+      "frictionCounts": {
+        "grounding.budget_exhausted_total": 0
+      }
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-08-02-eval-a2a-grounding-sample-retention-build.md
+++ b/docs/harness-feedback/verdicts/2026-08-02-eval-a2a-grounding-sample-retention-build.md
@@ -1,0 +1,34 @@
+---
+feature_ids: [F192, F167]
+topics: [harness-eval, eval-a2a, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:a2a
+packet_id: 2026-08-02-eval-a2a-grounding-sample-retention-build
+source_snapshot: "snapshot:bundle/2026-08-02-eval-a2a-grounding-sample-retention-build/snapshot"
+---
+
+# Live Verdict — 2026-08-02-eval-a2a-grounding-sample-retention-build
+
+- Verdict: `build`
+- Phenomenon: The grounding Phase O retention-depth build finding persists for a third daily eval: retained grounding samples stayed at 4 while mismatch remains 0 and A2A routing counters stay clean.
+- Harness: F167/grounding-phase-o (claim grounding (Phase O shadow))
+- Owner ask: Continue the grounding Phase O retention-depth build: raise sample retention capacity or TTL, or emit an explicit low-volume/retention diagnostic, so eval:a2a retains at least 10 grounding samples for 3 consecutive daily runs or explains intentional shallow sampling before the 2026-08-03 72h SLA boundary.
+- Re-eval: The build finding closes only after grounding-phase-o keeps mismatch_sample_count at 0 and either retains sample_count >= 10 for 3 consecutive daily evals or reports an explicit low-volume/retention diagnostic that makes shallow sample depth interpretable. at 2026-08-03T03:00:00.000Z
+
+Evidence:
+- snapshot:bundle/2026-08-02-eval-a2a-grounding-sample-retention-build/snapshot
+- attribution:bundle/2026-08-02-eval-a2a-grounding-sample-retention-build/eval-F167-2026-08-02:no-finding
+- metric:grounding.sample_count
+- metric:grounding.mismatch_sample_count
+- metric:grounding.check_total
+- metric:c2.verdict_without_pass_count
+- metric:c2.void_hold_hint_emitted
+- metric:counter_window.duration_hours
+- raw:docs/harness-feedback/snapshots/2026-08-02-eval-F167-runtime.yaml:grounding_sample_evidence
+- grounding_sample:register_pr_tracking:pr_url:clowder-labs/clowder-ai#108
+
+Counterarguments:
+- A2A routing quality remains healthy: C2 forced-pass is 0/311 and void-hold stayed frozen at 3/313 (0.96%).
+- Grounding mismatch count is still 0, so there is no evidence today for fail-closed escalation.
+- The sample depth did not worsen from 8/1; this is a persistent build gap rather than a new regression.


### PR DESCRIPTION
Verdict published via cat_cafe_publish_verdict MCP tool.

Verdict: build
Domain: eval:a2a
Phenomenon: The grounding Phase O retention-depth build finding persists for a third daily eval: retained grounding samples stayed at 4 while mismatch remains 0 and A2A routing counters stay clean.

Reviewed by: opus-47
Action: Continue the grounding Phase O retention-depth build: raise sample retention capacity or TTL, or emit an explicit low-volume/retention diagnostic, so eval:a2a retains at least 10 grounding samples for 3 consecutive daily runs or explains intentional shallow sampling before the 2026-08-03 72h SLA boundary.