### PR TITLE
verdict(eval:anchor-first): 2026-08-02-eval-anchor-first-low-sample-keep-observe

### DIFF
--- a/docs/harness-feedback/bundles/2026-08-02-eval-anchor-first-low-sample-keep-observe/attribution.json
+++ b/docs/harness-feedback/bundles/2026-08-02-eval-anchor-first-low-sample-keep-observe/attribution.json
@@ -1,0 +1,79 @@
+{
+  "verdictId": "2026-08-02-eval-anchor-first-low-sample-keep-observe",
+  "featureId": "F236",
+  "evalSnapshotId": "eval-F236-2026-08-02",
+  "generatedAt": "2026-08-02T03:18:34.097Z",
+  "findings": [
+    {
+      "id": "AF-2026-08-02-list-tasks",
+      "relatedFeature": "F236",
+      "sunsetSignals": {
+        "anchorTax": false,
+        "highOpenRate": false,
+        "netNegative": false
+      },
+      "frictionSignal": {
+        "type": "anchor.open_rate.list-tasks",
+        "severity": "low",
+        "confidence": 0.8,
+        "detectedAt": "2026-08-02T03:18:34.097Z"
+      },
+      "attribution": {
+        "primaryLayer": "needs_investigation",
+        "evidence": [
+          {
+            "type": "counter",
+            "anchor": "anchor-telemetry-rollup/list-tasks_drilled_unique_items",
+            "excerpt": "list-tasks: 0/10 items drilled (0.0% open rate), charsSaved=777, drillChars=0, netBenefit=777"
+          }
+        ]
+      },
+      "proposedAction": [
+        {
+          "action": "keep-observe",
+          "target": "anchor-telemetry-rollup/list-tasks",
+          "rationale": "Open rate 0.0%: 0/10 items drilled, net benefit 777 chars"
+        }
+      ]
+    },
+    {
+      "id": "AF-2026-08-02-thread-context",
+      "relatedFeature": "F236",
+      "sunsetSignals": {
+        "anchorTax": false,
+        "highOpenRate": false,
+        "netNegative": false
+      },
+      "frictionSignal": {
+        "type": "anchor.open_rate.thread-context",
+        "severity": "low",
+        "confidence": 0.8,
+        "detectedAt": "2026-08-02T03:18:34.097Z"
+      },
+      "attribution": {
+        "primaryLayer": "needs_investigation",
+        "evidence": [
+          {
+            "type": "counter",
+            "anchor": "anchor-telemetry-rollup/thread-context_drilled_unique_items",
+            "excerpt": "thread-context: 0/46 items drilled (0.0% open rate), charsSaved=490426, drillChars=0, netBenefit=490426"
+          }
+        ]
+      },
+      "proposedAction": [
+        {
+          "action": "keep-observe",
+          "target": "anchor-telemetry-rollup/thread-context",
+          "rationale": "Open rate 0.0%: 0/46 items drilled, net benefit 490426 chars"
+        }
+      ]
+    }
+  ],
+  "sunsetAssessment": {
+    "toolCount": 2,
+    "toolsWithAnchorTax": 0,
+    "toolsNetNegative": 0,
+    "toolsHighOpenRate": 0,
+    "lowSampleToolCount": 0
+  }
+}

--- a/docs/harness-feedback/bundles/2026-08-02-eval-anchor-first-low-sample-keep-observe/provenance.json
+++ b/docs/harness-feedback/bundles/2026-08-02-eval-anchor-first-low-sample-keep-observe/provenance.json
@@ -1,0 +1,15 @@
+{
+  "verdictId": "2026-08-02-eval-anchor-first-low-sample-keep-observe",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/bundles/2026-08-02-eval-anchor-first-low-sample-keep-observe/raw/rollup.json",
+      "sha256": "ad2348a743afe305b27f2b05a34b4e1f6818e7c9869e14d683226ed48ff8261f"
+    }
+  ],
+  "generatedAt": "2026-08-02T03:18:34.097Z",
+  "generator": {
+    "name": "eval-anchor-first-live-verdict",
+    "version": "1"
+  },
+  "sanitizeRulesVersion": "f236-anchor-telemetry-v1"
+}

--- a/docs/harness-feedback/bundles/2026-08-02-eval-anchor-first-low-sample-keep-observe/raw/rollup.json
+++ b/docs/harness-feedback/bundles/2026-08-02-eval-anchor-first-low-sample-keep-observe/raw/rollup.json
@@ -1,0 +1,67 @@
+{
+  "verdictId": "2026-08-02-eval-anchor-first-low-sample-keep-observe",
+  "selector": {
+    "kind": "anchor-telemetry-snapshot",
+    "windowStartMs": 1785554094487,
+    "windowEndMs": 1785640494487
+  },
+  "rollup": {
+    "perTool": {
+      "list-tasks": {
+        "previewResponses": 2,
+        "previewedItems": 10,
+        "drills": 0,
+        "drilledUniqueItems": 0,
+        "openRateByItem": 0,
+        "returnedChars": 2030,
+        "originalChars": 2807,
+        "charsSaved": 777,
+        "drillChars": 0,
+        "netBenefit": 777
+      },
+      "thread-context": {
+        "previewResponses": 2,
+        "previewedItems": 46,
+        "drills": 0,
+        "drilledUniqueItems": 0,
+        "openRateByItem": 0,
+        "returnedChars": 28336,
+        "originalChars": 518762,
+        "charsSaved": 490426,
+        "drillChars": 0,
+        "netBenefit": 490426
+      }
+    },
+    "orphanDrills": 0,
+    "adoption": {
+      "explicitAnchorCalls": 2,
+      "explicitFullCalls": 0,
+      "defaultAnchorCalls": 0,
+      "defaultFullCalls": 0,
+      "legacyEquivalentAnchorCalls": 2,
+      "legacyEquivalentFullCalls": 0,
+      "unknownModeCalls": 0,
+      "uniqueCatsExplicitAnchor": 1
+    },
+    "track1Snapshot": {
+      "returnedByTool": {
+        "thread-context": 61,
+        "pending-mentions": 13,
+        "list-tasks": 40
+      },
+      "returnedCharsByTool": {
+        "thread-context": 634595,
+        "pending-mentions": 33026,
+        "list-tasks": 622593
+      },
+      "drillByTool": {
+        "get-message": 32,
+        "list-tasks": 9
+      },
+      "drillCharsByTool": {
+        "get-message": 106082,
+        "list-tasks": 6488
+      }
+    }
+  }
+}

--- a/docs/harness-feedback/bundles/2026-08-02-eval-anchor-first-low-sample-keep-observe/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-08-02-eval-anchor-first-low-sample-keep-observe/snapshot.json
@@ -1,0 +1,48 @@
+{
+  "verdictId": "2026-08-02-eval-anchor-first-low-sample-keep-observe",
+  "evalSnapshotId": "eval-F236-2026-08-02",
+  "featureId": "F236",
+  "generatedAt": "2026-08-02T03:18:34.097Z",
+  "window": {
+    "startMs": 1785554094487,
+    "endMs": 1785640494487,
+    "durationHours": 24
+  },
+  "components": [
+    {
+      "id": "anchor-telemetry-rollup",
+      "name": "anchor-first preview/drill open-rate rollup",
+      "confidence": "medium",
+      "activationCounts": {
+        "orphan_drills": 0,
+        "adoption_explicit_anchor_calls": 2,
+        "adoption_explicit_full_calls": 0,
+        "adoption_default_anchor_calls": 0,
+        "adoption_default_full_calls": 0,
+        "adoption_legacy_equivalent_anchor_calls": 2,
+        "adoption_legacy_equivalent_full_calls": 0,
+        "adoption_unique_cats_explicit_anchor": 1,
+        "adoption_unknown_mode_calls": 0,
+        "list-tasks_preview_responses": 2,
+        "list-tasks_previewed_items": 10,
+        "list-tasks_drills": 0,
+        "list-tasks_drilled_unique_items": 0,
+        "list-tasks_returned_chars": 2030,
+        "list-tasks_original_chars": 2807,
+        "list-tasks_chars_saved": 777,
+        "list-tasks_drill_chars": 0,
+        "list-tasks_net_benefit": 777,
+        "thread-context_preview_responses": 2,
+        "thread-context_previewed_items": 46,
+        "thread-context_drills": 0,
+        "thread-context_drilled_unique_items": 0,
+        "thread-context_returned_chars": 28336,
+        "thread-context_original_chars": 518762,
+        "thread-context_chars_saved": 490426,
+        "thread-context_drill_chars": 0,
+        "thread-context_net_benefit": 490426
+      },
+      "frictionCounts": {}
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-08-02-eval-anchor-first-low-sample-keep-observe.md
+++ b/docs/harness-feedback/verdicts/2026-08-02-eval-anchor-first-low-sample-keep-observe.md
@@ -1,0 +1,49 @@
+---
+feature_ids: [F192, F236]
+topics: [harness-eval, eval-anchor-first, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:anchor-first
+packet_id: 2026-08-02-eval-anchor-first-low-sample-keep-observe
+source_snapshot: "snapshot:bundle/2026-08-02-eval-anchor-first-low-sample-keep-observe/snapshot"
+---
+
+# Live Verdict — 2026-08-02-eval-anchor-first-low-sample-keep-observe
+
+- Verdict: `keep_observe`
+- Phenomenon: The selected 24h window shows only four anchored preview responses at the API/log surface: two `list-tasks` overviews on August 1, 2026 and two `thread-context` reads on August 2, 2026, with no observed `pending-mentions`, `get-message`, or drill activity. The task-outcome truth source still has zero post-anchor episode verdict writebacks, so blindness cannot be corroborated or falsified.
+- Harness: F236/anchor-telemetry-rollup (anchor-first preview/drill open-rate rollup)
+- Owner ask: Keep eval:anchor-first on observe. Do not sunset any tool from this window; wait for a future 24h window with organic anchor traffic and task-outcome verdict writebacks before interpreting AC-E3 sunset signals.
+- Re-eval: A future 24h rollup contains organic preview traffic beyond the eval cat's own reads and task-outcome begins writing non-null episode verdicts; if a tool then shows anchorTax plus blindness evidence, escalate from keep_observe. at 2026-08-09T03:00:00.000Z
+
+Sunset Signal Assessment:
+- list-tasks: HEALTHY (openRate=0.0%, netBenefit=777)
+- thread-context: HEALTHY (openRate=0.0%, netBenefit=490426)
+
+Open-Rate Detail:
+- list-tasks: 0.0% open rate (0/10 items), charsSaved=777, drillChars=0, netBenefit=777
+- thread-context: 0.0% open rate (0/46 items), charsSaved=490426, drillChars=0, netBenefit=490426
+- Orphan drills: 0
+
+Adoption Detail:
+- explicitAnchorCalls=2; explicitFullCalls=0; uniqueCatsExplicitAnchor=1
+- defaultAnchorCalls=0; defaultFullCalls=0
+- legacyEquivalentAnchorCalls=2; legacyEquivalentFullCalls=0
+- unknownModeCalls=0
+
+Evidence:
+- snapshot:bundle/2026-08-02-eval-anchor-first-low-sample-keep-observe/snapshot
+- attribution:bundle/2026-08-02-eval-anchor-first-low-sample-keep-observe/AF-2026-08-02-list-tasks
+- attribution:bundle/2026-08-02-eval-anchor-first-low-sample-keep-observe/AF-2026-08-02-thread-context
+- metric:anchor.preview_responses_24h
+- metric:anchor.previewed_items_24h
+- metric:anchor.drill_events_24h
+- metric:task_outcome.verdict_writebacks_since_anchor
+- log:api.2026-08-01.1.log:274-276
+- log:api.2026-08-02.1.log:57348-57352
+- db:task-outcome-episodes.sqlite:post-anchor-verdict-writebacks=0
+
+Counterarguments:
+- The in-memory rollup may include additional preview events that are not visible in the route logs I used to estimate volume.
+- Zero observed drills in this window could be a quiet-period artifact rather than evidence that anchor previews are healthy.
+- Because task-outcome has published no post-anchor episode verdicts, the absence of blindness evidence is a telemetry gap, not proof of safety.


### PR DESCRIPTION
Verdict published via cat_cafe_publish_verdict MCP tool.

Verdict: keep_observe
Domain: eval:anchor-first
Phenomenon: The selected 24h window shows only four anchored preview responses at the API/log surface: two `list-tasks` overviews on August 1, 2026 and two `thread-context` reads on August 2, 2026, with no observed `pending-mentions`, `get-message`, or drill activity. The task-outcome truth source still has zero post-anchor episode verdict writebacks, so blindness cannot be corroborated or falsified.

Reviewed by: opus-47
Action: Keep eval:anchor-first on observe. Do not sunset any tool from this window; wait for a future 24h window with organic anchor traffic and task-outcome verdict writebacks before interpreting AC-E3 sunset signals.

---
**Cat-owned artifact gate — No operator merge needed.**
(Actionable findings present; eval domain owner cat merges per docs/SOP.md § artifact-only-pr-merge-gate.)