### PR TITLE
verdict(eval:anchor-first): 2026-08-09-eval-anchor-first-empty-window-keep-observe

### DIFF
--- a/docs/harness-feedback/bundles/2026-08-09-eval-anchor-first-empty-window-keep-observe/attribution.json
+++ b/docs/harness-feedback/bundles/2026-08-09-eval-anchor-first-empty-window-keep-observe/attribution.json
@@ -1,0 +1,18 @@
+{
+  "verdictId": "2026-08-09-eval-anchor-first-empty-window-keep-observe",
+  "featureId": "F236",
+  "evalSnapshotId": "eval-F236-2026-08-09",
+  "generatedAt": "2026-08-09T03:05:48.106Z",
+  "findings": [],
+  "sunsetAssessment": {
+    "toolCount": 0,
+    "toolsWithAnchorTax": 0,
+    "toolsNetNegative": 0,
+    "toolsHighOpenRate": 0,
+    "lowSampleToolCount": 0
+  },
+  "noFindingRecord": {
+    "reason": "no_preview_events",
+    "evidence": "No anchor-first preview events in the rollup window."
+  }
+}

--- a/docs/harness-feedback/bundles/2026-08-09-eval-anchor-first-empty-window-keep-observe/provenance.json
+++ b/docs/harness-feedback/bundles/2026-08-09-eval-anchor-first-empty-window-keep-observe/provenance.json
@@ -1,0 +1,15 @@
+{
+  "verdictId": "2026-08-09-eval-anchor-first-empty-window-keep-observe",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/bundles/2026-08-09-eval-anchor-first-empty-window-keep-observe/raw/rollup.json",
+      "sha256": "32192560f13fed000de475b9e85d5e398ffd44d577b5586eaa19edf193cff65f"
+    }
+  ],
+  "generatedAt": "2026-08-09T03:05:48.106Z",
+  "generator": {
+    "name": "eval-anchor-first-live-verdict",
+    "version": "1"
+  },
+  "sanitizeRulesVersion": "f236-anchor-telemetry-v1"
+}

--- a/docs/harness-feedback/bundles/2026-08-09-eval-anchor-first-empty-window-keep-observe/raw/rollup.json
+++ b/docs/harness-feedback/bundles/2026-08-09-eval-anchor-first-empty-window-keep-observe/raw/rollup.json
@@ -1,0 +1,42 @@
+{
+  "verdictId": "2026-08-09-eval-anchor-first-empty-window-keep-observe",
+  "selector": {
+    "kind": "anchor-telemetry-snapshot",
+    "windowStartMs": 1786158245282,
+    "windowEndMs": 1786244645282
+  },
+  "rollup": {
+    "perTool": {},
+    "orphanDrills": 0,
+    "adoption": {
+      "explicitAnchorCalls": 0,
+      "explicitFullCalls": 0,
+      "defaultAnchorCalls": 0,
+      "defaultFullCalls": 0,
+      "legacyEquivalentAnchorCalls": 0,
+      "legacyEquivalentFullCalls": 0,
+      "unknownModeCalls": 0,
+      "uniqueCatsExplicitAnchor": 0
+    },
+    "track1Snapshot": {
+      "returnedByTool": {
+        "thread-context": 103,
+        "pending-mentions": 25,
+        "list-tasks": 44
+      },
+      "returnedCharsByTool": {
+        "thread-context": 984651,
+        "pending-mentions": 52609,
+        "list-tasks": 784685
+      },
+      "drillByTool": {
+        "get-message": 65,
+        "list-tasks": 15
+      },
+      "drillCharsByTool": {
+        "get-message": 231218,
+        "list-tasks": 11493
+      }
+    }
+  }
+}

--- a/docs/harness-feedback/bundles/2026-08-09-eval-anchor-first-empty-window-keep-observe/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-08-09-eval-anchor-first-empty-window-keep-observe/snapshot.json
@@ -1,0 +1,30 @@
+{
+  "verdictId": "2026-08-09-eval-anchor-first-empty-window-keep-observe",
+  "evalSnapshotId": "eval-F236-2026-08-09",
+  "featureId": "F236",
+  "generatedAt": "2026-08-09T03:05:48.106Z",
+  "window": {
+    "startMs": 1786158245282,
+    "endMs": 1786244645282,
+    "durationHours": 24
+  },
+  "components": [
+    {
+      "id": "anchor-telemetry-rollup",
+      "name": "anchor-first preview/drill open-rate rollup",
+      "confidence": "low",
+      "activationCounts": {
+        "orphan_drills": 0,
+        "adoption_explicit_anchor_calls": 0,
+        "adoption_explicit_full_calls": 0,
+        "adoption_default_anchor_calls": 0,
+        "adoption_default_full_calls": 0,
+        "adoption_legacy_equivalent_anchor_calls": 0,
+        "adoption_legacy_equivalent_full_calls": 0,
+        "adoption_unique_cats_explicit_anchor": 0,
+        "adoption_unknown_mode_calls": 0
+      },
+      "frictionCounts": {}
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-08-09-eval-anchor-first-empty-window-keep-observe.md
+++ b/docs/harness-feedback/verdicts/2026-08-09-eval-anchor-first-empty-window-keep-observe.md
@@ -1,0 +1,42 @@
+---
+feature_ids: [F192, F236]
+topics: [harness-eval, eval-anchor-first, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:anchor-first
+packet_id: 2026-08-09-eval-anchor-first-empty-window-keep-observe
+source_snapshot: "snapshot:bundle/2026-08-09-eval-anchor-first-empty-window-keep-observe/snapshot"
+---
+
+# Live Verdict — 2026-08-09-eval-anchor-first-empty-window-keep-observe
+
+- Verdict: `keep_observe`
+- Phenomenon: The latest 24h anchor-first window appears empty on the visible preview↔drill callback surfaces, and task-outcome still has zero post-anchor verdict writebacks. This round cannot confirm anchor tax or blindness, so it stays in keep-observe as an insufficient-data observation.
+- Harness: F236/anchor-telemetry-rollup (anchor-first preview/drill open-rate rollup)
+- Owner ask: No action required; keep observing the next scheduled eval and confirm whether a non-empty 24h preview/drill window returns.
+- Re-eval: Re-evaluate after a future 24h window shows at least 10 preview responses or any drill activity, or once task-outcome starts writing verdicts so blindness can be tested. at 2026-08-16T03:00:00.000Z
+
+Sunset Signal Assessment:
+
+Open-Rate Detail:
+- Orphan drills: 0
+
+Adoption Detail:
+- explicitAnchorCalls=0; explicitFullCalls=0; uniqueCatsExplicitAnchor=0
+- defaultAnchorCalls=0; defaultFullCalls=0
+- legacyEquivalentAnchorCalls=0; legacyEquivalentFullCalls=0
+- unknownModeCalls=0
+
+Evidence:
+- snapshot:bundle/2026-08-09-eval-anchor-first-empty-window-keep-observe/snapshot
+- attribution:bundle/2026-08-09-eval-anchor-first-empty-window-keep-observe/eval-F236-2026-08-09:no-finding
+- metric:anchor.preview_responses_24h
+- metric:anchor.previewed_items_24h
+- metric:anchor.drill_events_24h
+- metric:task_outcome.verdict_writebacks_since_anchor
+- trace:anchor-empty-window-2026-08-09
+- trace:task-outcome-no-writebacks-2026-08-09
+
+Counterarguments:
+- Traffic may have genuinely dropped for one day, so an empty window does not imply a harness problem.
+- Visible logs and short metrics history are weaker than the generator bundle; if the bundle shows joined events, this verdict should be revised before merge.


### PR DESCRIPTION
Verdict published via cat_cafe_publish_verdict MCP tool.

Verdict: keep_observe
Domain: eval:anchor-first
Phenomenon: The latest 24h anchor-first window appears empty on the visible preview↔drill callback surfaces, and task-outcome still has zero post-anchor verdict writebacks. This round cannot confirm anchor tax or blindness, so it stays in keep-observe as an insufficient-data observation.

Reviewed by: opus-47
Action: No action required; keep observing the next scheduled eval and confirm whether a non-empty 24h preview/drill window returns.

---
**Cat-owned artifact gate — No operator merge needed.**
(Interim: keep_observe + no actionable findings. Rollup mechanism deferred to future Phase. See docs/SOP.md § artifact-only-pr-merge-gate for cat merge contract.)