### PR TITLE
verdict(eval:anchor-first): 2026-08-16-eval-anchor-first-low-drill-keep-observe

### DIFF
--- a/docs/harness-feedback/bundles/2026-08-16-eval-anchor-first-low-drill-keep-observe/attribution.json
+++ b/docs/harness-feedback/bundles/2026-08-16-eval-anchor-first-low-drill-keep-observe/attribution.json
@@ -1,0 +1,79 @@
+{
+  "verdictId": "2026-08-16-eval-anchor-first-low-drill-keep-observe",
+  "featureId": "F236",
+  "evalSnapshotId": "eval-F236-2026-08-16",
+  "generatedAt": "2026-08-16T03:02:38.871Z",
+  "findings": [
+    {
+      "id": "AF-2026-08-16-pending-mentions",
+      "relatedFeature": "F236",
+      "sunsetSignals": {
+        "anchorTax": false,
+        "highOpenRate": false,
+        "netNegative": false
+      },
+      "frictionSignal": {
+        "type": "anchor.open_rate.pending-mentions",
+        "severity": "low",
+        "confidence": 0.8,
+        "detectedAt": "2026-08-16T03:02:38.871Z"
+      },
+      "attribution": {
+        "primaryLayer": "needs_investigation",
+        "evidence": [
+          {
+            "type": "counter",
+            "anchor": "anchor-telemetry-rollup/pending-mentions_drilled_unique_items",
+            "excerpt": "pending-mentions: 0/15 items drilled (0.0% open rate), charsSaved=14852, drillChars=0, netBenefit=14852"
+          }
+        ]
+      },
+      "proposedAction": [
+        {
+          "action": "keep-observe",
+          "target": "anchor-telemetry-rollup/pending-mentions",
+          "rationale": "Open rate 0.0%: 0/15 items drilled, net benefit 14852 chars"
+        }
+      ]
+    },
+    {
+      "id": "AF-2026-08-16-thread-context",
+      "relatedFeature": "F236",
+      "sunsetSignals": {
+        "anchorTax": false,
+        "highOpenRate": false,
+        "netNegative": false
+      },
+      "frictionSignal": {
+        "type": "anchor.open_rate.thread-context",
+        "severity": "low",
+        "confidence": 0.8,
+        "detectedAt": "2026-08-16T03:02:38.871Z"
+      },
+      "attribution": {
+        "primaryLayer": "needs_investigation",
+        "evidence": [
+          {
+            "type": "counter",
+            "anchor": "anchor-telemetry-rollup/thread-context_drilled_unique_items",
+            "excerpt": "thread-context: 2/31 items drilled (6.5% open rate), charsSaved=31986, drillChars=2614, netBenefit=29372"
+          }
+        ]
+      },
+      "proposedAction": [
+        {
+          "action": "keep-observe",
+          "target": "anchor-telemetry-rollup/thread-context",
+          "rationale": "Open rate 6.5%: 2/31 items drilled, net benefit 29372 chars"
+        }
+      ]
+    }
+  ],
+  "sunsetAssessment": {
+    "toolCount": 2,
+    "toolsWithAnchorTax": 0,
+    "toolsNetNegative": 0,
+    "toolsHighOpenRate": 0,
+    "lowSampleToolCount": 0
+  }
+}

--- a/docs/harness-feedback/bundles/2026-08-16-eval-anchor-first-low-drill-keep-observe/provenance.json
+++ b/docs/harness-feedback/bundles/2026-08-16-eval-anchor-first-low-drill-keep-observe/provenance.json
@@ -1,0 +1,15 @@
+{
+  "verdictId": "2026-08-16-eval-anchor-first-low-drill-keep-observe",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/bundles/2026-08-16-eval-anchor-first-low-drill-keep-observe/raw/rollup.json",
+      "sha256": "34c183b915b3708d03c8f6d4947789da04cf3d7b852f9cf4826a6049bee357ef"
+    }
+  ],
+  "generatedAt": "2026-08-16T03:02:38.871Z",
+  "generator": {
+    "name": "eval-anchor-first-live-verdict",
+    "version": "1"
+  },
+  "sanitizeRulesVersion": "f236-anchor-telemetry-v1"
+}

--- a/docs/harness-feedback/bundles/2026-08-16-eval-anchor-first-low-drill-keep-observe/raw/rollup.json
+++ b/docs/harness-feedback/bundles/2026-08-16-eval-anchor-first-low-drill-keep-observe/raw/rollup.json
@@ -1,0 +1,67 @@
+{
+  "verdictId": "2026-08-16-eval-anchor-first-low-drill-keep-observe",
+  "selector": {
+    "kind": "anchor-telemetry-snapshot",
+    "windowStartMs": 1786762864737,
+    "windowEndMs": 1786849264737
+  },
+  "rollup": {
+    "perTool": {
+      "pending-mentions": {
+        "previewResponses": 7,
+        "previewedItems": 15,
+        "drills": 0,
+        "drilledUniqueItems": 0,
+        "openRateByItem": 0,
+        "returnedChars": 4006,
+        "originalChars": 18858,
+        "charsSaved": 14852,
+        "drillChars": 0,
+        "netBenefit": 14852
+      },
+      "thread-context": {
+        "previewResponses": 4,
+        "previewedItems": 31,
+        "drills": 2,
+        "drilledUniqueItems": 2,
+        "openRateByItem": 0.06451612903225806,
+        "returnedChars": 7182,
+        "originalChars": 39168,
+        "charsSaved": 31986,
+        "drillChars": 2614,
+        "netBenefit": 29372
+      }
+    },
+    "orphanDrills": 0,
+    "adoption": {
+      "explicitAnchorCalls": 0,
+      "explicitFullCalls": 0,
+      "defaultAnchorCalls": 11,
+      "defaultFullCalls": 0,
+      "legacyEquivalentAnchorCalls": 0,
+      "legacyEquivalentFullCalls": 2,
+      "unknownModeCalls": 0,
+      "uniqueCatsExplicitAnchor": 0
+    },
+    "track1Snapshot": {
+      "returnedByTool": {
+        "thread-context": 225,
+        "pending-mentions": 66,
+        "list-tasks": 60
+      },
+      "returnedCharsByTool": {
+        "thread-context": 2071740,
+        "pending-mentions": 168664,
+        "list-tasks": 821900
+      },
+      "drillByTool": {
+        "get-message": 125,
+        "list-tasks": 15
+      },
+      "drillCharsByTool": {
+        "get-message": 378580,
+        "list-tasks": 11493
+      }
+    }
+  }
+}

--- a/docs/harness-feedback/bundles/2026-08-16-eval-anchor-first-low-drill-keep-observe/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-08-16-eval-anchor-first-low-drill-keep-observe/snapshot.json
@@ -1,0 +1,48 @@
+{
+  "verdictId": "2026-08-16-eval-anchor-first-low-drill-keep-observe",
+  "evalSnapshotId": "eval-F236-2026-08-16",
+  "featureId": "F236",
+  "generatedAt": "2026-08-16T03:02:38.871Z",
+  "window": {
+    "startMs": 1786762864737,
+    "endMs": 1786849264737,
+    "durationHours": 24
+  },
+  "components": [
+    {
+      "id": "anchor-telemetry-rollup",
+      "name": "anchor-first preview/drill open-rate rollup",
+      "confidence": "medium",
+      "activationCounts": {
+        "orphan_drills": 0,
+        "adoption_explicit_anchor_calls": 0,
+        "adoption_explicit_full_calls": 0,
+        "adoption_default_anchor_calls": 11,
+        "adoption_default_full_calls": 0,
+        "adoption_legacy_equivalent_anchor_calls": 0,
+        "adoption_legacy_equivalent_full_calls": 2,
+        "adoption_unique_cats_explicit_anchor": 0,
+        "adoption_unknown_mode_calls": 0,
+        "pending-mentions_preview_responses": 7,
+        "pending-mentions_previewed_items": 15,
+        "pending-mentions_drills": 0,
+        "pending-mentions_drilled_unique_items": 0,
+        "pending-mentions_returned_chars": 4006,
+        "pending-mentions_original_chars": 18858,
+        "pending-mentions_chars_saved": 14852,
+        "pending-mentions_drill_chars": 0,
+        "pending-mentions_net_benefit": 14852,
+        "thread-context_preview_responses": 4,
+        "thread-context_previewed_items": 31,
+        "thread-context_drills": 2,
+        "thread-context_drilled_unique_items": 2,
+        "thread-context_returned_chars": 7182,
+        "thread-context_original_chars": 39168,
+        "thread-context_chars_saved": 31986,
+        "thread-context_drill_chars": 2614,
+        "thread-context_net_benefit": 29372
+      },
+      "frictionCounts": {}
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-08-16-eval-anchor-first-low-drill-keep-observe.md
+++ b/docs/harness-feedback/verdicts/2026-08-16-eval-anchor-first-low-drill-keep-observe.md
@@ -1,0 +1,48 @@
+---
+feature_ids: [F192, F236]
+topics: [harness-eval, eval-anchor-first, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:anchor-first
+packet_id: 2026-08-16-eval-anchor-first-low-drill-keep-observe
+source_snapshot: "snapshot:bundle/2026-08-16-eval-anchor-first-low-drill-keep-observe/snapshot"
+---
+
+# Live Verdict — 2026-08-16-eval-anchor-first-low-drill-keep-observe
+
+- Verdict: `keep_observe`
+- Phenomenon: The latest 24h anchor-first window recovered visible preview traffic on pending-mentions and thread-context, with only two visible get-message drills against that traffic. Task-outcome still has zero post-anchor verdict writebacks, so blindness cannot be tested and no anchor-tax signal is currently evidenced.
+- Harness: F236/anchor-telemetry-rollup (anchor-first preview/drill open-rate rollup)
+- Owner ask: No action required; keep observing the next scheduled eval, especially whether task-outcome starts writing verdicts and whether list-tasks or get-message preview traffic enters the 24h window.
+- Re-eval: Re-evaluate after another 24h window with non-empty preview traffic, or sooner if task-outcome begins emitting verdict writebacks so blindness can be cross-checked. at 2026-08-23T03:00:00.000Z
+
+Sunset Signal Assessment:
+- pending-mentions: HEALTHY (openRate=0.0%, netBenefit=14852)
+- thread-context: HEALTHY (openRate=6.5%, netBenefit=29372)
+
+Open-Rate Detail:
+- pending-mentions: 0.0% open rate (0/15 items), charsSaved=14852, drillChars=0, netBenefit=14852
+- thread-context: 6.5% open rate (2/31 items), charsSaved=31986, drillChars=2614, netBenefit=29372
+- Orphan drills: 0
+
+Adoption Detail:
+- explicitAnchorCalls=0; explicitFullCalls=0; uniqueCatsExplicitAnchor=0
+- defaultAnchorCalls=11; defaultFullCalls=0
+- legacyEquivalentAnchorCalls=0; legacyEquivalentFullCalls=2
+- unknownModeCalls=0
+
+Evidence:
+- snapshot:bundle/2026-08-16-eval-anchor-first-low-drill-keep-observe/snapshot
+- attribution:bundle/2026-08-16-eval-anchor-first-low-drill-keep-observe/AF-2026-08-16-pending-mentions
+- attribution:bundle/2026-08-16-eval-anchor-first-low-drill-keep-observe/AF-2026-08-16-thread-context
+- metric:anchor.preview_responses_24h
+- metric:anchor.previewed_items_24h
+- metric:anchor.drill_events_24h
+- metric:task_outcome.verdict_writebacks_since_anchor
+- trace:f236-anchor-2026-08-15T10:07Z
+- trace:f236-drill-2026-08-15T10:07:56Z
+- trace:f236-anchor-2026-08-15T16:51Z
+
+Counterarguments:
+- The visible callback log is not the authoritative rollup; the live bundle may still classify fewer joined previews or attribute the two drills to a narrower tool slice.
+- A single-day sample can hide intermittent anchor-tax behavior, especially on preview tools that did not appear in this window.


### PR DESCRIPTION
Verdict published via cat_cafe_publish_verdict MCP tool.

Verdict: keep_observe
Domain: eval:anchor-first
Phenomenon: The latest 24h anchor-first window recovered visible preview traffic on pending-mentions and thread-context, with only two visible get-message drills against that traffic. Task-outcome still has zero post-anchor verdict writebacks, so blindness cannot be tested and no anchor-tax signal is currently evidenced.

Reviewed by: opus-47
Action: No action required; keep observing the next scheduled eval, especially whether task-outcome starts writing verdicts and whether list-tasks or get-message preview traffic enters the 24h window.

---
**Cat-owned artifact gate — No operator merge needed.**
(Actionable findings present; eval domain owner cat merges per docs/SOP.md § artifact-only-pr-merge-gate.)