### PR TITLE
fix(verdict-publisher): update stale repo name default + add contract script

### DIFF
--- a/packages/api/src/config/env-registry.ts
+++ b/packages/api/src/config/env-registry.ts
@@ -317,7 +317,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_REPO_FULL_NAME',
-    defaultValue: 'zts212653/cat-cafe',
+    defaultValue: 'clowder-labs/clowder-ai',
     description: 'F233 Phase C feat trajectory collector 调 gh CLI 用的 owner/repo（GitHub PR 元数据查询）',
     category: 'server',
     sensitive: false,
@@ -325,7 +325,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_VERDICT_REPO_FULL_NAME',
-    defaultValue: 'CAT_CAFE_REPO_FULL_NAME or zts212653/cat-cafe',
+    defaultValue: 'CAT_CAFE_REPO_FULL_NAME or clowder-labs/clowder-ai',
     description:
       'F248 verdict publisher canonical owner/repo; automatic, pre-push, and managed agent-shell publication fail closed on target mismatch',
     category: 'server',

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3105,7 +3105,7 @@ async function main(): Promise<void> {
     './infrastructure/harness-eval/publish-verdict/git-worktree-publisher.js'
   );
   const verdictRepoFullName =
-    process.env.CAT_CAFE_VERDICT_REPO_FULL_NAME ?? process.env.CAT_CAFE_REPO_FULL_NAME ?? 'zts212653/cat-cafe';
+    process.env.CAT_CAFE_VERDICT_REPO_FULL_NAME ?? process.env.CAT_CAFE_REPO_FULL_NAME ?? 'clowder-labs/clowder-ai';
   const { createA2aGeneratorAdapter } = await import(
     './infrastructure/harness-eval/publish-verdict/a2a-generator-adapter.js'
   );
@@ -6597,7 +6597,7 @@ async function main(): Promise<void> {
 
     const trajIntervalMs = Number.parseInt(process.env.F233_FEAT_TRAJECTORY_COLLECTOR_INTERVAL_MS ?? '', 10);
     const repoRoot = process.env.CAT_CAFE_REPO_ROOT || process.cwd();
-    const repoFullName = process.env.CAT_CAFE_REPO_FULL_NAME || 'zts212653/cat-cafe';
+    const repoFullName = process.env.CAT_CAFE_REPO_FULL_NAME || 'clowder-labs/clowder-ai';
 
     const trajProjector = new FeatTrajectoryProjectorCls(featTrajectoryStore);
     const gitRunner = new RealGitRunner(repoRoot);

--- a/packages/api/src/utils/cli-spawn.ts
+++ b/packages/api/src/utils/cli-spawn.ts
@@ -97,7 +97,7 @@ export function withVerdictGhGuardEnv<T extends Record<string, string | null | u
   }
   if (!mutable.CAT_CAFE_VERDICT_REPO_FULL_NAME) {
     mutable.CAT_CAFE_VERDICT_REPO_FULL_NAME =
-      process.env.CAT_CAFE_VERDICT_REPO_FULL_NAME ?? process.env.CAT_CAFE_REPO_FULL_NAME ?? 'zts212653/cat-cafe';
+      process.env.CAT_CAFE_VERDICT_REPO_FULL_NAME ?? process.env.CAT_CAFE_REPO_FULL_NAME ?? 'clowder-labs/clowder-ai';
   }
   return env;
 }

--- a/scripts/check-verdict-publish-contract.mjs
+++ b/scripts/check-verdict-publish-contract.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * check-verdict-publish-contract.mjs
+ *
+ * Pre-publish contract check for the verdict auto-PR pipeline.
+ * Called by git-worktree-publisher.ts before and after `git fetch`.
+ *
+ * Two modes:
+ *   --identity-only true  → verify remote URL matches --expected-repo (fast, no network)
+ *   (default)             → identity check + verify --source-ref is reachable
+ *
+ * Exit 0 = contract satisfied. Non-zero = abort publish.
+ *
+ * CLI args:
+ *   --repo-root <path>        Repository root
+ *   --expected-repo <owner/repo>  Expected GitHub repo (e.g. zts212653/cat-cafe)
+ *   --remote <name>           Remote name (e.g. origin)
+ *   --base-ref <ref>          Base ref for the publish (e.g. origin/main)
+ *   --source-ref <ref>        Source ref to validate corpus against
+ *   --identity-only <bool>    If "true", skip corpus check
+ */
+
+import { execFileSync } from 'node:child_process';
+import { parseArgs } from 'node:util';
+
+const { values } = parseArgs({
+  options: {
+    'repo-root': { type: 'string' },
+    'expected-repo': { type: 'string' },
+    remote: { type: 'string' },
+    'base-ref': { type: 'string' },
+    'source-ref': { type: 'string' },
+    'identity-only': { type: 'string' },
+  },
+  strict: true,
+});
+
+const repoRoot = values['repo-root'];
+const expectedRepo = values['expected-repo'];
+const remote = values['remote'] ?? 'origin';
+const sourceRef = values['source-ref'];
+const identityOnly = values['identity-only'] === 'true';
+
+if (!repoRoot || !expectedRepo) {
+  console.error('Usage: check-verdict-publish-contract.mjs --repo-root <path> --expected-repo <owner/repo>');
+  process.exit(1);
+}
+
+function git(args) {
+  return execFileSync('git', ['-C', repoRoot, ...args], { encoding: 'utf8', timeout: 30_000 }).trim();
+}
+
+// ── Identity check: verify remote URL matches expected repo ──
+let remoteUrl;
+try {
+  remoteUrl = git(['remote', 'get-url', remote]);
+} catch {
+  console.error(`verdict_publish_contract: remote '${remote}' not found`);
+  process.exit(1);
+}
+
+// Normalize: extract owner/repo from HTTPS or SSH URL
+const httpsMatch = remoteUrl.match(/github\.com[/:]([^/]+\/[^/.]+?)(?:\.git)?$/);
+const repoSlug = httpsMatch?.[1];
+if (!repoSlug) {
+  console.error(`verdict_publish_contract: cannot parse GitHub repo from remote URL '${remoteUrl}'`);
+  process.exit(1);
+}
+
+if (repoSlug !== expectedRepo) {
+  console.error(
+    `verdict_publish_contract: remote '${remote}' points to '${repoSlug}', expected '${expectedRepo}'`,
+  );
+  process.exit(1);
+}
+
+if (identityOnly) {
+  process.exit(0);
+}
+
+// ── Corpus check: verify source-ref is reachable ──
+if (!sourceRef) {
+  console.error('verdict_publish_contract: --source-ref is required for full corpus check');
+  process.exit(1);
+}
+
+try {
+  git(['rev-parse', '--verify', sourceRef]);
+} catch {
+  console.error(`verdict_publish_contract: source-ref '${sourceRef}' is not reachable`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- Add missing `scripts/check-verdict-publish-contract.mjs` — referenced by `git-worktree-publisher.ts` (line 99) but never committed after merge `84164cd63`
- Update stale hardcoded fallback `zts212653/cat-cafe` → `clowder-labs/clowder-ai` in three source files (`index.ts`, `cli-spawn.ts`, `env-registry.ts`)
- Unblocks all eval domain verdict publishes (W34 eval:qc and forward)

## Context

The verdict publisher contract check was introduced in merge `84164cd63` but shipped with two defects:
1. The contract script was never committed → `MODULE_NOT_FOUND`
2. The `expectedRepoFullName` fallback chain resolves to the pre-move repo name `zts212653/cat-cafe`, but the remote is `clowder-labs/clowder-ai`

Remaining `zts212653/cat-cafe` in test fixtures (use own remotes) and other subsystems tracked separately.

## Test plan

- [x] `check-verdict-publish-contract.mjs --identity-only true` passes against local origin
- [x] Full contract check (identity + corpus) passes against `origin/develop`
- [x] `check-env-registry.test.mjs` passes
- [x] Existing `git-worktree-publisher-target-contract.test.js` unaffected (uses fixture remote)

Closes #139

🐾 Hotfix — cross-cat review required per §3 hotfix protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)