### PR TITLE
fix(web): suppress session_policy_execution raw JSON bubble (#141)

### DIFF
--- a/packages/web/src/hooks/__tests__/useAgentMessages-telemetry-suppression.test.ts
+++ b/packages/web/src/hooks/__tests__/useAgentMessages-telemetry-suppression.test.ts
@@ -152,4 +152,37 @@ describe('useAgentMessages telemetry suppression', () => {
 
     expect(mockAddMessage).not.toHaveBeenCalled();
   });
+
+  // clowder-ai#141 session_policy_execution: F033 (#1334) added this API-side event
+  // (invoke-single-cat.ts) but no web dispatch branch ever consumed it, so it fell
+  // through to `sysContent = msg.content` and surfaced as a raw JSON bubble.
+  // It is pure telemetry (policy execution status transitions) — silently consume.
+  // Real observed bubble: {"type":"session_policy_execution","invocationId":"51e484e6-...",...}
+  it('suppresses session_policy_execution — no system bubble (#141)', () => {
+    act(() => {
+      root.render(React.createElement(Harness));
+    });
+
+    act(() => {
+      captured?.handleAgentMessage({
+        type: 'system_info',
+        catId: 'opus46',
+        content: JSON.stringify({
+          type: 'session_policy_execution',
+          invocationId: '51e484e6-4cef-406d-90eb-ea56a4caf0be',
+          previousExecution: {
+            status: 'unavailable',
+            missingCapabilities: ['effective_input_ceiling', 'carrier_binding', 'authoritative_usage'],
+          },
+          effectiveStrategy: {
+            config: { strategy: 'handoff', thresholds: { warn: 0.8, action: 0.9 }, turnBudget: 12000 },
+            source: 'provider_default',
+            execution: { status: 'active', missingCapabilities: [] },
+          },
+        }),
+      });
+    });
+
+    expect(mockAddMessage).not.toHaveBeenCalled();
+  });
 });

--- a/packages/web/src/hooks/system-info-visible.ts
+++ b/packages/web/src/hooks/system-info-visible.ts
@@ -15,6 +15,11 @@ const INTERNAL_SYSTEM_INFO_TELEMETRY_TYPES = new Set([
   'strategy_allow_compress',
   'tool_activity',
   'turn_duration', // F230 P2: PTY carrier terminal event — silently consumed, never shown as bubble
+  // clowder-ai#141: F033 (#1334) emits session_policy_execution from the API whenever policy
+  // execution status / missingCapabilities change. No dispatch branch ever consumed it, so it
+  // fell through to `sysContent = msg.content` and surfaced as a raw JSON bubble. It is pure
+  // telemetry (the same snapshot already drives the Hub session-strategy UI) — suppress it.
+  'session_policy_execution',
 ]);
 
 export function isInternalSystemInfoTelemetry(parsed: Record<string, unknown>): boolean {


### PR DESCRIPTION
Closes #141

## 问题

猫猫回复下方出现一整坨裸 JSON 气泡：

```
{"type":"session_policy_execution","invocationId":"51e484e6-...","previousExecution":{"status":"unavailable","missingCapabilities":["effective_input_ceiling","carrier_binding","authoritative_usage"]},"effectiveStrategy":{...}}
```

## 根因

F033 (#1334) 在 API 侧加了 `session_policy_execution` 事件（`invoke-single-cat.ts:3083`），在 policy execution 的 status / missingCapabilities 发生迁移时用 `system_info` 包 JSON 发出。

web 侧从未接过这个类型——`git log --all -S session_policy_execution -- packages/web` 零命中。两条 `system_info` 分发链（后台 `useAgentMessages.ts:1788`、活跃 `:6067`）的 else-if 都不认识它，末尾兜底白名单 `INTERNAL_SYSTEM_INFO_TELEMETRY_TYPES` 里也没有 → `consumed` 保持 false → `sysContent = msg.content` → 整坨 payload 上屏。

即 F033 落地时的半个功能：后端加了事件类型，前端消费白名单没同步加。

## 排除 merge 回归

用户怀疑是最近合并弄坏的，查下来不是：

- main 既不发也不处理这个事件，所以 main 看不到
- main 与 develop 的分发链**结构一字未改**（`isInternalSystemInfoTelemetry` 兜底在 main 是 :1338/:5469，develop 是 :1788/:6067，仅行号位移，逻辑与注释相同）
- `fix(merge-84164cd63)` 批次**未碰过** `useAgentMessages.ts` / `system-info-visible.ts`
- F033 PR 动了 15 个 web 文件（HubSessionStrategyEditor / SessionChainPanel 等配置面板），但没动消息分发链

## 改动

`INTERNAL_SYSTEM_INFO_TELEMETRY_TYPES` 加一条，与 `strategy_allow_compress` / `turn_duration` 同类静默消费。两条链共用 `isInternalSystemInfoTelemetry`，一处即覆盖。

不需要处理历史消息：该事件**服务端不持久化**（`persist-system-info-warnings.ts` 只持久化 `warning` / `cloud_bridge_status`），是瞬态 socket 遥测，刷新页面旧气泡本就消失。

## 验证

TDD，先 RED 后 GREEN：

- 新增测试用真实观测到的 payload，改前 `mockAddMessage` 被调用 1 次（复现裸气泡），改后 4 tests passed
- `pnpm exec biome check` 改动文件：clean
- `pnpm lint`：exit 0
- `vitest run src/hooks/__tests__/`：1009 passed，唯一 failure 是 `f232-artifact-content.test.tsx`，已确认在**未改动的 develop 上同样失败**（既有基线）
- `pnpm check` 全仓 34 errors 同样是 develop 既有基线（全在 packages/api 未触及文件）

## Pre-flight

在飞 PR 查了两刀：#41 碰 `useAgentMessages.ts`，但改的是 `governance_blocked` 分支，与遥测白名单不重叠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)