### PR TITLE
fix(codex): correlate app-server turn notifications

### DIFF
--- a/packages/api/src/domains/cats/services/agents/providers/CodexAppServerClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAppServerClient.ts
@@ -8,6 +8,7 @@ import {
   asCodexAppServerRecord,
   type CodexAppServerJsonObject,
   codexAppServerErrorMessage,
+  isCodexAppServerNotificationForActiveTurn,
   mapCodexAppServerNotification,
   mapCodexAppServerTokenUsage,
   respondToCodexAppServerRequest,
@@ -187,9 +188,10 @@ export class CodexAppServerClient {
         const next = await this.notifications.next();
         if (next.done) throw new Error('Codex app-server stream ended before turn completion');
         const envelope = next.value;
-        this.lifecycle.touch(timeoutMs, timeoutHandler);
         const record = asCodexAppServerRecord(envelope);
         const params = asCodexAppServerRecord(record?.params);
+        if (!isCodexAppServerNotificationForActiveTurn(envelope, threadId, activeTurnId)) continue;
+        this.lifecycle.touch(timeoutMs, timeoutHandler);
         const itemObserved = record?.method === 'item/started' || record?.method === 'item/completed';
         const exactCompletedItem =
           record?.method === 'item/completed' && params?.threadId === threadId && params?.turnId === activeTurnId;

--- a/packages/api/src/domains/cats/services/agents/providers/CodexAppServerEventMapper.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAppServerEventMapper.ts
@@ -4,6 +4,31 @@ export function asCodexAppServerRecord(value: unknown): CodexAppServerJsonObject
   return typeof value === 'object' && value !== null ? (value as CodexAppServerJsonObject) : null;
 }
 
+export function isCodexAppServerNotificationForActiveTurn(
+  envelopeValue: unknown,
+  threadId: string,
+  turnId: string,
+): boolean {
+  const envelope = asCodexAppServerRecord(envelopeValue);
+  if (!envelope || typeof envelope.method !== 'string') return false;
+  const requiresExactTurn =
+    envelope.method.startsWith('turn/') ||
+    envelope.method.startsWith('item/') ||
+    envelope.method === 'thread/tokenUsage/updated';
+  const params = asCodexAppServerRecord(envelope.params);
+  if (!params) return !requiresExactTurn;
+
+  const turn = asCodexAppServerRecord(params.turn);
+  const notificationThreadId = typeof params.threadId === 'string' ? params.threadId : null;
+  const notificationTurnId =
+    typeof params.turnId === 'string' ? params.turnId : typeof turn?.id === 'string' ? turn.id : null;
+  if (requiresExactTurn) return notificationThreadId === threadId && notificationTurnId === turnId;
+
+  if (notificationThreadId !== null && notificationThreadId !== threadId) return false;
+  if (notificationTurnId !== null && notificationTurnId !== turnId) return false;
+  return true;
+}
+
 export function codexAppServerErrorMessage(value: unknown): string {
   const record = asCodexAppServerRecord(value);
   return typeof record?.message === 'string' ? record.message : 'Codex app-server request failed';

--- a/packages/api/src/domains/cats/services/agents/providers/CodexAppServerEventMapper.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAppServerEventMapper.ts
@@ -18,8 +18,10 @@ export function isCodexAppServerNotificationForActiveTurn(
   const params = asCodexAppServerRecord(envelope.params);
   if (!params) return !requiresExactTurn;
 
+  const thread = asCodexAppServerRecord(params.thread);
   const turn = asCodexAppServerRecord(params.turn);
-  const notificationThreadId = typeof params.threadId === 'string' ? params.threadId : null;
+  const notificationThreadId =
+    typeof params.threadId === 'string' ? params.threadId : typeof thread?.id === 'string' ? thread.id : null;
   const notificationTurnId =
     typeof params.turnId === 'string' ? params.turnId : typeof turn?.id === 'string' ? turn.id : null;
   if (requiresExactTurn) return notificationThreadId === threadId && notificationTurnId === turnId;

--- a/packages/api/test/codex-app-server-transport.test.js
+++ b/packages/api/test/codex-app-server-transport.test.js
@@ -66,12 +66,13 @@ class AsyncInbox {
 }
 
 class ProtocolWire {
-  constructor() {
+  constructor(turnId = 'turn-1') {
     this.inbox = new AsyncInbox();
     this.writes = [];
     this.terminateCalls = 0;
     this.closeCalls = 0;
     this.experimentalApiEnabled = false;
+    this.turnId = turnId;
   }
 
   read() {
@@ -100,7 +101,7 @@ class ProtocolWire {
           },
         });
       } else {
-        this.inbox.push({ id: message.id, result: { turn: { id: 'turn-1', status: 'inProgress' } } });
+        this.inbox.push({ id: message.id, result: { turn: { id: this.turnId, status: 'inProgress' } } });
       }
     }
     if (message.method === 'turn/interrupt') this.inbox.push({ id: message.id, result: {} });
@@ -268,6 +269,82 @@ test('active-turn cancel evicts the host after authoritative interrupted termina
     output.some((event) => event.type === 'turn.completed' && event.status === 'interrupted'),
     true,
   );
+});
+
+test('foreign subagent notifications cannot publish or terminate the active parent turn', async () => {
+  const wire = new ProtocolWire();
+  const client = new CodexAppServerClient({ wire });
+  const run = collect(client.run({ prompt: 'review with a panel', thread: { kind: 'start' } }));
+
+  await waitFor(() => wire.writes.some((message) => message.method === 'turn/start'));
+  wire.inbox.push({
+    method: 'item/completed',
+    params: {
+      threadId: 'thread-subagent',
+      turnId: 'turn-subagent',
+      item: { id: 'agent-subagent', type: 'agentMessage', text: '{"packet_type":"A_INITIAL"}' },
+    },
+  });
+  wire.inbox.push({
+    method: 'thread/tokenUsage/updated',
+    params: {
+      threadId: 'thread-subagent',
+      turnId: 'turn-subagent',
+      tokenUsage: { last: { inputTokens: 999, outputTokens: 999, cachedInputTokens: 0 } },
+    },
+  });
+  wire.inbox.push({
+    method: 'turn/completed',
+    params: { threadId: 'thread-subagent', turn: { id: 'turn-subagent', status: 'completed' } },
+  });
+  wire.inbox.push({
+    method: 'item/completed',
+    params: {
+      threadId: 'thread-1',
+      turnId: 'turn-other',
+      item: { id: 'agent-other-turn', type: 'agentMessage', text: '{"packet_type":"B_VERIFICATION"}' },
+    },
+  });
+  wire.inbox.push({
+    method: 'turn/completed',
+    params: { threadId: 'thread-1', turn: { id: 'turn-other', status: 'completed' } },
+  });
+  wire.inbox.push({
+    method: 'turn/completed',
+    params: { turn: { status: 'completed' } },
+  });
+
+  const earlyOutcome = await Promise.race([run.then(() => 'settled'), delay(25, 'pending')]);
+  assert.equal(earlyOutcome, 'pending', 'a foreign subagent terminal must not settle the parent transport');
+
+  wire.inbox.push({
+    method: 'item/completed',
+    params: {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      item: { id: 'agent-parent', type: 'agentMessage', text: 'leader verdict' },
+    },
+  });
+  wire.inbox.push({
+    method: 'thread/tokenUsage/updated',
+    params: {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      tokenUsage: { last: { inputTokens: 10, outputTokens: 2, cachedInputTokens: 3 } },
+    },
+  });
+  wire.inbox.push({
+    method: 'turn/completed',
+    params: { threadId: 'thread-1', turn: { id: 'turn-1', status: 'completed' } },
+  });
+
+  const output = await run;
+  const agentMessages = output
+    .filter((event) => event.type === 'item.completed' && event.item?.type === 'agent_message')
+    .map((event) => event.item.text);
+  assert.deepEqual(agentMessages, ['leader verdict']);
+  const terminal = output.find((event) => event.type === 'turn.completed');
+  assert.equal(terminal?.usage?.input_tokens, 10, 'foreign subagent usage must not contaminate the parent turn');
 });
 
 test('interrupt grace expiry escalates to the carrier terminate fallback', async () => {
@@ -580,7 +657,7 @@ test('active-writer diagnostics classify a reused healthy affinity host as a loc
     }
     return firstWrite(message);
   };
-  const second = new ProtocolWire();
+  const second = new ProtocolWire('turn-new');
   const wires = [first, second];
   let factoryCalls = 0;
   const run = collect(
@@ -627,7 +704,7 @@ test('active-writer diagnostics remain external-or-unknown when thread/read has 
     }
     return firstWrite(message);
   };
-  const second = new ProtocolWire();
+  const second = new ProtocolWire('turn-new');
   const wires = [first, second];
   let factoryCalls = 0;
   const run = collect(
@@ -881,7 +958,7 @@ test('model-capacity failure without exact Clowder AI task coordinates blocks in
 
 test('model-capacity recovery after completed tools resumes the exact invocation checkpoint', async () => {
   const first = new ProtocolWire();
-  const second = new ProtocolWire();
+  const second = new ProtocolWire('turn-2');
   const wires = [first, second];
   let factoryCalls = 0;
   const run = collect(
@@ -968,8 +1045,8 @@ test('model-capacity recovery after completed tools resumes the exact invocation
 
 test('repeated model-capacity attempts reuse one hidden recovery context without adding user messages', async () => {
   const first = new ProtocolWire();
-  const second = new ProtocolWire();
-  const third = new ProtocolWire();
+  const second = new ProtocolWire('turn-2');
+  const third = new ProtocolWire('turn-3');
   const wires = [first, second, third];
   let factoryCalls = 0;
   const run = collect(

--- a/packages/api/test/codex-app-server-transport.test.js
+++ b/packages/api/test/codex-app-server-transport.test.js
@@ -273,10 +273,15 @@ test('active-turn cancel evicts the host after authoritative interrupted termina
 
 test('foreign subagent notifications cannot publish or terminate the active parent turn', async () => {
   const wire = new ProtocolWire();
-  const client = new CodexAppServerClient({ wire });
+  const lifecycle = [];
+  const client = new CodexAppServerClient({ wire, onLifecycle: (snapshot) => lifecycle.push(snapshot) });
   const run = collect(client.run({ prompt: 'review with a panel', thread: { kind: 'start' } }));
 
   await waitFor(() => wire.writes.some((message) => message.method === 'turn/start'));
+  wire.inbox.push({
+    method: 'thread/started',
+    params: { thread: { id: 'thread-subagent' } },
+  });
   wire.inbox.push({
     method: 'item/completed',
     params: {
@@ -345,6 +350,11 @@ test('foreign subagent notifications cannot publish or terminate the active pare
   assert.deepEqual(agentMessages, ['leader verdict']);
   const terminal = output.find((event) => event.type === 'turn.completed');
   assert.equal(terminal?.usage?.input_tokens, 10, 'foreign subagent usage must not contaminate the parent turn');
+  assert.equal(
+    lifecycle.filter((snapshot) => snapshot.stage === 'turn_accepted').length,
+    2,
+    'a foreign thread-start must not touch the parent lifecycle',
+  );
 });
 
 test('interrupt grace expiry escalates to the carrier terminate fallback', async () => {


### PR DESCRIPTION
## What

Filter Codex app-server notifications against the invocation active threadId and turnId before lifecycle, output, usage, freshness, or terminal handling. Turn/item/usage events without exact coordinates now fail closed; transport-global notifications remain available.

The regression also makes ProtocolWire return the turn ID each scenario later completes, so recovery tests preserve protocol truth under exact correlation.

## Root cause

The pooled app-server stream can carry child-agent events created by review-pr-with-panel. CodexAppServerClient consumed every turn/completed notification as the parent terminal. In thread_mshpuvnuow3hfsg4 this persisted Agent A packet JSON, ended the invocation early, and raised a2a_dispatch_disposition_missing even though the parent Leader later completed A2A custody correctly.

## Original requirements

- Operator: 「为什么这个 thread thread_mshpuvnuow3hfsg4 总是调用失败」 followed by 「诊断决定：直接修复（推荐）」.
- F254 requires provider-native lifecycle and freshness work to stay correlated to the exact active parent/turn.

## Risk

- behavior: medium — changes which multiplexed provider events can advance or terminate one invocation
- data: none — no persistence schema or user data mutation
- security: none
- contract: medium — enforces existing Codex app-server thread/turn coordinates
- irreversible: none

Architecture cell: transport
Map delta: none
Why: this tightens the existing Codex app-server adapter boundary; it adds no owner, queue, store, router, or binding.

## Verification

- TDD RED: foreign child terminal settled the parent immediately; malformed unscoped terminal did the same.
- TDD GREEN: exact regression passed after correlation.
- Cloud P2 RED: foreign nested thread-start produced a third turn-accepted lifecycle projection; GREEN after extracting params.thread.id.
- cat-cafe API build: PASS, protocol census 18 variants.
- Related suites: codex transport, pooling, host pool, agent service, event transform, and F254 freshness suites: PASS together.
- cat-cafe API lint: PASS.
- Biome on all 3 changed files: PASS.
- check:capability-tips: PASS; F254 has tips_exempt: true.
- git diff --check and root artifact scan: PASS.
- fallback audit against origin/develop: one required unknown-envelope guard; no layered fallback added.

Known develop baseline gates, unrelated to this 3-file patch:
- pnpm check: FAIL before reaching project checks due 34 existing Biome/parse errors in files including cicd-router.test.js and conflict-check-spec.test.js.
- check:features: FAIL with 28 existing ROADMAP/status drift findings.

## Dogfood boundary

The original live failure trace supplies real before-state evidence. The patched exact event sequence is exercised through the transport integration boundary. Re-running the actual panel journey requires this patch to be merged and loaded by an operator-authorized runtime restart, so live dogfood remains a post-merge activation check rather than a pre-review claim.

## Review ask

Please verify the exact-turn filter neither admits child, nested-thread, or malformed terminals nor blocks legitimate recovery turns, and return APPROVE or REQUEST_CHANGES for the current exact HEAD.
